### PR TITLE
docs: mark roadmap step M4-D7 complete

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ First version worth showing to anyone.
 | 🟢 | D4 | Embed step — `mulder embed <id>` | §2.6, §1 (embed cmd) |
 | 🟢 | D5 | Graph step — dedup + corroboration + contradiction flagging | §2.7, §1 (graph cmd) |
 | 🟢 | D6 | Pipeline orchestrator — cursor-based | §3.1, §3.2, §3.3, §3.4, §3.5, §1 (pipeline cmd) |
-| ⚪ | D7 | Full-text search — generated tsvector on chunks | §4.3 (chunks.fts_vector), §5.1 |
+| 🟢 | D7 | Full-text search — generated tsvector on chunks | §4.3 (chunks.fts_vector), §5.1 |
 | ⚪ | E1 | Vector search — HNSW, pgvector cosine similarity | §5.1 (vector search), §4.3 (HNSW index) |
 | ⚪ | E2 | Full-text search wrapper — BM25 queries | §5.1 (full-text search) |
 | ⚪ | E3 | Graph traversal — recursive CTE, cycle detection | §5.1 (graph traversal SQL) |


### PR DESCRIPTION
## Summary

Pure roadmap reconciliation — D7's deliverable was implicitly completed across earlier work and never marked. No code change.

D7 = *"Full-text search — generated tsvector on chunks"* (refs §4.3 chunks.fts_vector + §5.1).

| Element | Where it landed |
|---|---|
| \`chunks.fts_vector\` generated tsvector column | M1-A7 — \`packages/core/src/database/migrations/006_chunks.sql:9\` |
| \`idx_chunks_fts\` GIN index | M1-A7 — \`packages/core/src/database/migrations/008_indexes.sql:20\` |
| \`searchByFts()\` data-layer query function | M4-D1-D3 (spec 32) — \`packages/core/src/database/repositories/chunk.repository.ts:465\` |
| QA-06: column auto-generates on insert | spec 32 tests, line 442 |
| QA-10: BM25 ranking returns matching chunks | spec 32 tests, line 622 |

The \`AND c.is_question = false\` filter shown in the §5.1 example query belongs to the FTS **strategy wrapper** (E2 — \`packages/retrieval/src/fulltext.ts\`), not to the data-layer function. Spec 32 explicitly excluded the wrapper module from its scope (out of scope: *"Full-text search wrapper module (D7/E2)"*), so the wrapper-side filter is correctly deferred to E2.

## Test plan

- [ ] Visual diff: only \`docs/roadmap.md\` line for D7 changes (⚪ → 🟢)
- [ ] No code or test changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)