### PR TITLE
docs(spec): align §2.7 contradiction edge encoding with self-loop reality

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -460,7 +460,7 @@ interface StepResult<T> {
    - Update `entities.corroboration_score`
 6. **Contradiction flagging** (attribute diff, no LLM):
    - For each entity with multiple source mentions, compare key attributes (date, location, description)
-   - If attributes conflict (e.g., different dates for the same event): create `POTENTIAL_CONTRADICTION` edge between the two claims
+   - If attributes conflict (e.g., different dates for the same event): create a `POTENTIAL_CONTRADICTION` edge attached to the canonical entity (a self-loop on `entities.id`). The two conflicting claims are encoded in `attributes`: `storyIdA` / `storyIdB` identify the source stories, and `attribute` / `valueA` / `valueB` describe the conflict. A claim is the tuple `(entity_id, story_id)` — claims are not first-class rows, so the edge sits on the entity and the story IDs live in JSONB. M6 G3 Analyze loads these edges by `edge_type` and reads the conflict fields directly from `attributes` to build the contradiction-resolution prompt.
    - Fast pass — no LLM, only string/date comparison
 7. Update story status to `graphed`
 

--- a/packages/pipeline/src/graph/index.ts
+++ b/packages/pipeline/src/graph/index.ts
@@ -294,7 +294,13 @@ export async function execute(
 		const contradictions = await detectContradictions(pool, input.storyId);
 
 		for (const contradiction of contradictions) {
-			// Create POTENTIAL_CONTRADICTION edge between the entity instances
+			// Self-loop on the canonical entity. A "claim" here is the tuple
+			// (entity_id, story_id) — claims are not first-class rows, so the
+			// edge sits on the entity and the two conflicting claim story IDs
+			// are encoded in attributes.storyIdA / attributes.storyIdB
+			// alongside attribute / valueA / valueB. M6 G3 Analyze loads
+			// these edges and reads the conflict directly from JSONB.
+			// See docs/functional-spec.md §2.7 step 6.
 			await upsertEdge(pool, {
 				sourceEntityId: contradiction.entityId,
 				targetEntityId: contradiction.entityId,

--- a/tests/specs/25_edge_repository.test.ts
+++ b/tests/specs/25_edge_repository.test.ts
@@ -386,7 +386,13 @@ describe('Spec 25: Edge Repository', () => {
 	it('QA-10: findEdgesByType returns 2 POTENTIAL_CONTRADICTION edges', async () => {
 		if (!pgAvailable) return;
 
-		// Create 2 POTENTIAL_CONTRADICTION edges
+		// This test exercises the edge repository's ability to round-trip any
+		// edge with edge_type=POTENTIAL_CONTRADICTION through createEdge +
+		// findEdgesByType. It uses distinct entity endpoints because the
+		// repository accepts any (source, target) pair — it does not enforce
+		// the self-loop encoding that the graph step happens to use for real
+		// contradiction edges. The graph-step encoding contract is locked in
+		// by tests/specs/35_graph_step.test.ts QA-10.
 		await createEdge(pool, {
 			sourceEntityId: entityIds[0],
 			targetEntityId: entityIds[1],

--- a/tests/specs/35_graph_step.test.ts
+++ b/tests/specs/35_graph_step.test.ts
@@ -585,6 +585,19 @@ describe('Spec 35 — Graph Step', () => {
 				`SELECT attributes::text FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION' LIMIT 1;`,
 			);
 			expect(contradictionAttrs).toMatch(/date/i);
+
+			// Self-loop encoding: contradiction edges are attached to the
+			// canonical entity. Both conflicting claim story IDs live in
+			// attributes.storyIdA / storyIdB. Lock this in so the encoding
+			// cannot drift without flagging the test.
+			const selfLoopRows = runSql(
+				`SELECT source_entity_id = target_entity_id FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION';`,
+			);
+			for (const row of selfLoopRows.split('\n').filter(Boolean)) {
+				expect(row).toBe('t');
+			}
+			expect(contradictionAttrs).toMatch(/storyIdA/);
+			expect(contradictionAttrs).toMatch(/storyIdB/);
 		}
 
 		// Restore state


### PR DESCRIPTION
## Summary

Resolves #97 (M4-DIV-004): the graph step writes `POTENTIAL_CONTRADICTION` edges as self-loops on the canonical entity, with the two conflicting claim story IDs encoded in `attributes.storyIdA` / `storyIdB`. The functional spec said *"edge between the two claims"*, which is ambiguous at the data-model level — claims are not first-class rows. This PR aligns the spec wording with the actual encoding so M6 G3 Analyze has an unambiguous contract to consume.

Adopts the architect-recommended Option 1 from the issue review: align the spec to the code, no schema migration. The current encoding is workable for M6 G3 (the corroboration step already follows the same JSONB-attribute read pattern for `DUPLICATE_OF` edges, so the precedent exists).

## What changed

- **`docs/functional-spec.md` §2.7 step 6**: rewrite the contradiction flagging step to describe the self-loop encoding, the JSONB attribute layout (`storyIdA` / `storyIdB` / `attribute` / `valueA` / `valueB`), and the `(entity_id, story_id)` tuple as the claim identity.
- **`packages/pipeline/src/graph/index.ts`**: add an inline comment at the `POTENTIAL_CONTRADICTION` edge insertion site explaining the encoding intent. The comment describes *what* the code does and *why*, with no historical narration.
- **`tests/specs/35_graph_step.test.ts` QA-10**: lock the encoding in with three new assertions:
  - Every `POTENTIAL_CONTRADICTION` edge satisfies `source_entity_id = target_entity_id` (the self-loop)
  - JSONB attributes contain `storyIdA`
  - JSONB attributes contain `storyIdB`
  
  This is SF-04 from the sprint plan: prevent the encoding from drifting without flagging the test.
- **`tests/specs/25_edge_repository.test.ts` QA-10**: add a comment clarifying that this test exercises the edge repository's general round-trip ability for any `POTENTIAL_CONTRADICTION` shape — distinct entity endpoints, not self-loops — because the repository doesn't enforce graph-step semantics. The graph-step encoding contract is locked in by spec 35 QA-10.

`contradiction.ts` already references `§2.7` by section number — the link target is unchanged and the new spec body is consistent with what the module does. No JSDoc edit needed.

## Test plan

- [x] `pnpm build` — 9/9 packages green
- [x] `pnpm typecheck` — 17/17 green
- [x] `pnpm lint` — 225 files, 0 findings
- [x] `npx vitest run tests/specs/35_graph_step.test.ts tests/specs/25_edge_repository.test.ts` — 49/49 passing (29 + 20). QA-10 in spec 35 now exercises the new self-loop assertions and passes.
- [x] Full suite — **52 files, 864/864 tests** passing (the new baseline post-M5 merge; my changes net +0)

## Notes

- The fix is intentionally minimal per the architect review's recommendation: spec wording + intent comment + test lock-in. No schema migration, no code-behavior change. The Option 2 design (`claim_id` first-class abstraction) is reserved for a future schema-evolution story if M6 G3 actually needs query flexibility — JSONB attributes already deliver everything M6 needs.
- This PR is built on top of the recently-merged M5 taxonomy bootstrap (PR #110, commit `83d13c7`).
- This PR was developed in a `git worktree` at `/Users/franz/Workspace/mulder-qa-fix/` so the parallel M5 work in the main worktree was never disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)