### PR TITLE
feat(retrieval): gate negative-query results below rerank.min_score

### DIFF
--- a/mulder.config.example.yaml
+++ b/mulder.config.example.yaml
@@ -146,6 +146,7 @@ retrieval:
     enabled: true
     model: "gemini-2.5-flash"
     candidates: 20                    # Top N from RRF sent to reranker
+    min_score: 0.0                    # Drop results when top rerank score is below this AND the query is degraded — set to e.g. 0.3 to filter off-corpus queries
   strategies:
     vector:
       weight: 0.5

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -193,6 +193,17 @@ const rerankSchema = z.object({
 	enabled: z.boolean().default(true),
 	model: z.string().default('gemini-2.5-flash'),
 	candidates: z.number().positive().int().default(20),
+	/**
+	 * Minimum reranker score (after Gemini Flash re-ranks the fused list)
+	 * required for the orchestrator to surface a result. When the top
+	 * reranker score is below this AND the confidence object reports the
+	 * query as degraded, the orchestrator returns an empty result list with
+	 * `confidence.message = 'no_meaningful_matches'` instead of the top-k
+	 * fallback. Defaults to 0.0 — set to 0.3 or higher to filter
+	 * off-corpus queries (e.g. "Rezept für Apfelstrudel" against a UFO
+	 * archive).
+	 */
+	min_score: z.number().min(0).max(1).default(0.0),
 });
 
 const vectorStrategySchema = z.object({

--- a/packages/retrieval/src/orchestrator.ts
+++ b/packages/retrieval/src/orchestrator.ts
@@ -246,6 +246,30 @@ export async function hybridRetrieve(
 	const graphHitCount = strategyResults.get('graph')?.length ?? 0;
 	const confidence = await computeQueryConfidence(pool, config, { graphHitCount });
 
+	// 12a. Negative-query gate: when the top reranker score is below the
+	// configured floor AND the query is already flagged as degraded, drop
+	// the result list and surface the gating reason via confidence.message.
+	// Default min_score is 0.0 so existing pipelines see no behavior change
+	// until they explicitly opt in.
+	const minRerankScore = config.retrieval.rerank.min_score;
+	if (
+		minRerankScore > 0 &&
+		confidence.degraded &&
+		reranked.length > 0 &&
+		(reranked[0]?.rerankScore ?? 0) < minRerankScore
+	) {
+		logger.info(
+			{
+				query: trimmedQuery,
+				topRerankScore: reranked[0]?.rerankScore,
+				minRerankScore,
+			},
+			'hybridRetrieve: gating result list below rerank min_score on degraded query',
+		);
+		reranked = [];
+		confidence.message = 'no_meaningful_matches';
+	}
+
 	// 13. Build counts map for explain.
 	const counts: Partial<Record<RetrievalStrategy, number>> = {};
 	for (const [name, results] of strategyResults) {

--- a/packages/retrieval/src/types.ts
+++ b/packages/retrieval/src/types.ts
@@ -263,6 +263,13 @@ export interface QueryConfidence {
 	corroboration_reliability: 'insufficient' | 'low' | 'moderate' | 'high';
 	graph_density: number;
 	degraded: boolean;
+	/**
+	 * Optional explanatory message attached when the orchestrator gates the
+	 * result list. Set to `'no_meaningful_matches'` when the top reranker
+	 * score falls below `config.retrieval.rerank.min_score` AND the query is
+	 * already flagged as `degraded`.
+	 */
+	message?: string;
 }
 
 /**

--- a/tests/specs/42_hybrid_retrieval_orchestrator.test.ts
+++ b/tests/specs/42_hybrid_retrieval_orchestrator.test.ts
@@ -699,6 +699,84 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 		expect(parsed.topK).toBe(3);
 		expect(parsed.results.length).toBeLessThanOrEqual(3);
 	});
+
+	// ─── QA-23: rerank.min_score = 0 (default) preserves the existing return contract ───
+
+	it('QA-23: default min_score=0 returns the full result list (no gating)', async () => {
+		if (!pgAvailable || !pool || !corpusSourceId) return;
+		const config = makeConfig();
+		expect(config.retrieval.rerank.min_score).toBe(0);
+
+		const llm = new StubLlmService();
+		llm.setResponse({ rankings: [] });
+		const embed = new FakeEmbeddingService();
+
+		const result = await hybridRetrieve(pool, embed, llm, config, 'test', {
+			strategy: 'fulltext',
+		});
+
+		expect(result.confidence.message).toBeUndefined();
+	});
+
+	// ─── QA-24: gate triggers on degraded query with low top rerank score ───
+
+	it('QA-24: degraded query with top rerank score below min_score returns empty results + message', async () => {
+		if (!pgAvailable || !pool || !corpusSourceId) return;
+
+		// Inject a deterministic chunk we can control. Using a unique
+		// queryWord ensures the fulltext hit is exactly what we expect,
+		// independent of whatever else lives in the test corpus.
+		const queryWord = `qa24token${Date.now()}`;
+		const sourceId = '24242424-2424-2424-2424-242424242424';
+		const storyId = '24242424-2424-2424-2424-242424240001';
+		const chunkId = '24242424-2424-2424-2424-242424240002';
+
+		runSql(
+			`INSERT INTO sources (id, filename, file_hash, storage_path, page_count, status) VALUES ` +
+				`('${sourceId}', 'qa24-gating.pdf', 'qa24-${Date.now()}', 'raw/qa24.pdf', 1, 'graphed');`,
+		);
+		runSql(
+			`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) VALUES ` +
+				`('${storyId}', '${sourceId}', 'qa24-story', 's/qa24.md', 's/qa24.meta.json', 'graphed');`,
+		);
+		// Generate a deterministic 768-dim embedding (all zeros + first dim 0.5).
+		const vec = `[0.5${',0'.repeat(767)}]`;
+		runSql(
+			`INSERT INTO chunks (id, story_id, content, chunk_index, embedding) VALUES ` +
+				`('${chunkId}', '${storyId}', 'A passage containing the unique token ${queryWord}.', 0, '${vec}');`,
+		);
+
+		try {
+			// Force the query to be degraded by setting taxonomy_bootstrap above
+			// any plausible corpus_size. Set min_score to 0.5 so the stub's 0.1
+			// relevance scores fall below the floor.
+			const config = makeConfig((c) => {
+				c.thresholds.taxonomy_bootstrap = 999_999;
+				c.retrieval.rerank.min_score = 0.5;
+			});
+
+			const llm = new StubLlmService();
+			const embed = new FakeEmbeddingService();
+
+			llm.setResponse({
+				rankings: [{ passage_id: chunkId, relevance_score: 0.1 }],
+			});
+
+			const result = await hybridRetrieve(pool, embed, llm, config, queryWord, {
+				strategy: 'fulltext',
+			});
+
+			expect(result.confidence.degraded).toBe(true);
+			expect(result.results).toEqual([]);
+			expect(result.confidence.message).toBe('no_meaningful_matches');
+		} finally {
+			runSql(
+				`DELETE FROM chunks WHERE id = '${chunkId}';` +
+					` DELETE FROM stories WHERE id = '${storyId}';` +
+					` DELETE FROM sources WHERE id = '${sourceId}';`,
+			);
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves #95 (M4-DIV-008 + P4-RETRIEVAL-NEGATIVE-QUERY-01): Phase 4 confirmed on live data that queries like `"quantum computing benchmark performance results"` and `"Rezept für Apfelstrudel mit Vanillesauce"` against a UFO corpus still return 10 hits each — the orchestrator computed `confidence.degraded: true` correctly but never gated the result list, so users saw 10 confident-looking unrelated results.

This PR adopts the architect-recommended **Option 1** from the issue review: an opt-in result-list gate at the orchestrator's response-assembly path. **Zero behavior change for existing pipelines** (default `min_score: 0.0`) until they explicitly opt in.

## What changed

### Commit 1: `feat(retrieval): gate negative-query results below rerank.min_score`

- **`packages/core/src/config/schema.ts`**: new `min_score` field on `rerankSchema`, typed as `z.number().min(0).max(1).default(0.0)`. JSDoc recommends `0.3` as a starting point for off-corpus filtering.
- **`packages/retrieval/src/types.ts`**: extend `QueryConfidence` with an optional `message?: string` field. Additive change — existing consumers reading the confidence object are unaffected.
- **`packages/retrieval/src/orchestrator.ts`**: insert a gating block (step 12a) between confidence computation and final-result assembly. The condition is precise:
  - `minRerankScore > 0` — only gates when explicitly opted in
  - `confidence.degraded` — never gates a healthy query
  - `reranked.length > 0` — never short-circuits an already-empty result
  - `reranked[0].rerankScore < minRerankScore` — only when the top hit is below the floor
  
  When all four conditions are met, the orchestrator clears `reranked = []`, sets `confidence.message = 'no_meaningful_matches'`, and emits an info-level log line so operators can see why a query returned no results.
- **`mulder.config.example.yaml`**: document the new `min_score` field with the no-op default.

### Commit 2: `test(retrieval): cover rerank.min_score gating in spec 42`

- **QA-23**: default `min_score=0` returns the full result list. Pinpoints the no-op default contract.
- **QA-24**: degraded query with top rerank score below `min_score` returns empty results + `confidence.message = 'no_meaningful_matches'`. Uses a deterministic SQL-injected fixture chunk with a unique token query (`qa24token{timestamp}`) so the test is isolated from whatever else lives in the test corpus. Stub LlmService returns rerank score `0.1` for the injected chunk; the test config sets `min_score: 0.5` and `taxonomy_bootstrap: 999_999` to force `degraded=true` regardless of corpus state.

## What's NOT in this PR (architect's Option 2 deferred)

The architect noted that the spec letter calls for **Option 2**: store `corroboration_score = NULL` at write time when below `thresholds.corroboration_meaningful`. That's the right long-term fix but requires:
- Threading `MulderConfig.thresholds` through `DeduplicationConfig` into `corroboration.ts`
- Auditing every consumer of `entities.corroboration_score` for nullable handling
- A migration / `COALESCE` audit before shipping

Tracked as a follow-up. Option 1 alone closes the user-visible quality gap.

## Test plan

- [x] `pnpm build` — 9/9 packages green
- [x] `pnpm typecheck` — 17/17 green
- [x] `pnpm lint` — 226 files, 0 findings
- [x] `npx vitest run tests/specs/42_hybrid_retrieval_orchestrator.test.ts` — **33/33 passing** (was 31)
- [x] Full suite — **53 files, 871 passing + 4 skipped = 875 total** (+2 vs the previous baseline)
- [x] Spec 42 logs the gating event when triggered (verified in the test output)

## Architecture alignment

- ✅ Default behavior preserved (`min_score: 0.0` is a no-op)
- ✅ Gate is at the orchestrator's response boundary, not buried in a strategy implementation — single-point-of-control matches the orchestrator's existing architecture
- ✅ `QueryConfidence.message` is optional, so existing API consumers see no breaking change
- ✅ `pino` info log when gating triggers; no `console.log`
- ✅ ESM `.js` imports, strict TypeScript, no `any`/`as`
- ✅ Comment style: current intent only, no historical narration, no issue numbers in code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)