### PR TITLE
chore: clean up @reserved tags + minor docs/config drift

### DIFF
--- a/docs/architecture-core-vs-domain.md
+++ b/docs/architecture-core-vs-domain.md
@@ -2,7 +2,7 @@
 
 This document defines architectural constraints that apply to **all** Mulder code. It establishes the boundary between the domain-agnostic core and the domain-specific configuration layer. Every data structure, pipeline step, and feature must respect this boundary.
 
-Referenced by both the functional spec (`docs/functional-spec.md`) and the feature spec addendum (`docs/feature-spec-addendum.md`). All sections use the **§D** prefix to avoid collisions with other spec documents.
+Referenced by both the functional spec (`docs/functional-spec.md`) and the functional spec addendum (`docs/functional-spec-addendum.md`). All sections use the **§D** prefix to avoid collisions with other spec documents.
 
 ---
 

--- a/mulder.config.example.yaml
+++ b/mulder.config.example.yaml
@@ -150,6 +150,7 @@ retrieval:
   strategies:
     vector:
       weight: 0.5
+      ef_search: 40                   # HNSW search-time exploration; higher = better recall, slower queries
     fulltext:
       weight: 0.3
     graph:

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -23,11 +23,11 @@ export type ConfigErrorCode = (typeof CONFIG_ERROR_CODES)[keyof typeof CONFIG_ER
 
 /** Pipeline domain error codes. */
 export const PIPELINE_ERROR_CODES = {
-	/** @reserved D6 pipeline orchestrator */
+	/** Source row not found in DB during pipeline run. */
 	PIPELINE_SOURCE_NOT_FOUND: 'PIPELINE_SOURCE_NOT_FOUND',
-	/** @reserved D6 pipeline orchestrator status checks */
+	/** Source status does not match the expected step entry condition. */
 	PIPELINE_WRONG_STATUS: 'PIPELINE_WRONG_STATUS',
-	/** @reserved D6 pipeline orchestrator step failure wrapping */
+	/** A pipeline step threw — wraps the underlying step error code. */
 	PIPELINE_STEP_FAILED: 'PIPELINE_STEP_FAILED',
 	/** @reserved D6 pipeline orchestrator retry exhaustion */
 	PIPELINE_RATE_LIMITED: 'PIPELINE_RATE_LIMITED',
@@ -118,16 +118,11 @@ export type EnrichErrorCode = (typeof ENRICH_ERROR_CODES)[keyof typeof ENRICH_ER
 
 /** Embed step error codes. */
 export const EMBED_ERROR_CODES = {
-	/** @reserved D4 embed step execute() */
 	EMBED_STORY_NOT_FOUND: 'EMBED_STORY_NOT_FOUND',
-	/** @reserved D4 embed step execute() */
 	EMBED_INVALID_STATUS: 'EMBED_INVALID_STATUS',
-	/** @reserved D4 embed step execute() */
 	EMBED_MARKDOWN_NOT_FOUND: 'EMBED_MARKDOWN_NOT_FOUND',
 	EMBED_EMBEDDING_FAILED: 'EMBED_EMBEDDING_FAILED',
-	/** @reserved D4 embed step execute() */
 	EMBED_QUESTION_GENERATION_FAILED: 'EMBED_QUESTION_GENERATION_FAILED',
-	/** @reserved D4 embed step execute() */
 	EMBED_CHUNK_WRITE_FAILED: 'EMBED_CHUNK_WRITE_FAILED',
 } as const;
 
@@ -135,17 +130,11 @@ export type EmbedErrorCode = (typeof EMBED_ERROR_CODES)[keyof typeof EMBED_ERROR
 
 /** Graph step error codes. */
 export const GRAPH_ERROR_CODES = {
-	/** @reserved D5 graph step execute() */
 	GRAPH_STORY_NOT_FOUND: 'GRAPH_STORY_NOT_FOUND',
-	/** @reserved D5 graph step execute() */
 	GRAPH_INVALID_STATUS: 'GRAPH_INVALID_STATUS',
-	/** @reserved D5 graph step execute() */
 	GRAPH_EDGE_WRITE_FAILED: 'GRAPH_EDGE_WRITE_FAILED',
-	/** @reserved D5 graph step execute() */
 	GRAPH_DEDUP_FAILED: 'GRAPH_DEDUP_FAILED',
-	/** @reserved D5 graph step execute() */
 	GRAPH_CORROBORATION_FAILED: 'GRAPH_CORROBORATION_FAILED',
-	/** @reserved D5 graph step execute() */
 	GRAPH_CONTRADICTION_FAILED: 'GRAPH_CONTRADICTION_FAILED',
 } as const;
 


### PR DESCRIPTION
## Summary

P2 hygiene pass for the post-MVP QA gate. Closes the @reserved-tag drift findings (P6-DOCS-CLAUDE-02), the docs/architecture-core-vs-domain.md filename typo (P6-DOCS-CLAUDE-03), and the missing ef_search field in the example config (P6-DOCS-CONFIG-01).

## What changed

- **errors.ts** — drop `@reserved D6/D4/D5` tags from 14 error codes that are actively thrown:
  - PIPELINE_SOURCE_NOT_FOUND, PIPELINE_WRONG_STATUS, PIPELINE_STEP_FAILED (3) — thrown by `packages/pipeline/src/pipeline/index.ts`
  - All 5 EMBED_* codes — thrown by `packages/pipeline/src/embed/index.ts`
  - All 6 GRAPH_* codes — thrown by `packages/pipeline/src/graph/index.ts`
  - PIPELINE_RATE_LIMITED **kept @reserved** because it is genuinely unused (no thrower)
- **architecture-core-vs-domain.md** — `feature-spec-addendum.md` → `functional-spec-addendum.md` (the file is functional, not feature)
- **mulder.config.example.yaml** — add missing `ef_search: 40` field to retrieval.strategies.vector with inline rationale

## Test plan

- [x] `pnpm build` 9/9 green
- [x] `pnpm typecheck` 17/17 green
- [x] `pnpm lint` 226 files, 0 findings
- [x] No code-behavior changes (annotation + docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)