### PR TITLE
feat: taxonomy export/curate/merge (F2)

### DIFF
--- a/apps/cli/src/commands/taxonomy.ts
+++ b/apps/cli/src/commands/taxonomy.ts
@@ -5,17 +5,25 @@
  * - `bootstrap` — Generate taxonomy from extracted entities via Gemini clustering
  * - `re-bootstrap` — Regenerate taxonomy (replaces auto entries, keeps confirmed)
  * - `show` — Display current taxonomy tree
+ * - `export` — Export taxonomy to curated YAML
+ * - `curate` — Open curated YAML in $EDITOR
+ * - `merge` — Merge curated YAML into active taxonomy
  *
  * Thin wrapper: parses arguments, loads config, creates registry,
  * calls taxonomy functions, formats output. No business logic here.
  *
  * @see docs/specs/46_taxonomy_bootstrap.spec.md §4.1
- * @see docs/functional-spec.md §1 (taxonomy cmd), §6.1
+ * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.2
+ * @see docs/functional-spec.md §1 (taxonomy cmd), §6.1, §6.3
  */
 
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
 import { closeAllPools, createLogger, createServiceRegistry, getWorkerPool, loadConfig } from '@mulder/core';
-import type { BootstrapResult } from '@mulder/taxonomy';
-import { bootstrapTaxonomy, rebootstrapTaxonomy, showTaxonomy } from '@mulder/taxonomy';
+import type { BootstrapResult, MergeChange, MergeResult } from '@mulder/taxonomy';
+import { bootstrapTaxonomy, exportTaxonomy, mergeTaxonomy, rebootstrapTaxonomy, showTaxonomy } from '@mulder/taxonomy';
 import type { Command } from 'commander';
 import { withErrorHandler } from '../lib/errors.js';
 import { printError, printJson, printSuccess } from '../lib/output.js';
@@ -32,6 +40,16 @@ interface BootstrapCommandOptions {
 interface ShowCommandOptions {
 	type?: string;
 	json?: boolean;
+}
+
+interface ExportCommandOptions {
+	output?: string;
+	type?: string;
+}
+
+interface MergeCommandOptions {
+	input?: string;
+	dryRun?: boolean;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -58,6 +76,58 @@ function printBootstrapResult(result: BootstrapResult, json?: boolean): void {
 	for (const line of lines) {
 		process.stdout.write(`${line}\n`);
 	}
+}
+
+function printMergeResult(result: MergeResult): void {
+	// Summary table
+	process.stderr.write('\nSummary:\n');
+	process.stderr.write(`  Created:   ${result.created}\n`);
+	process.stderr.write(`  Updated:   ${result.updated}\n`);
+	process.stderr.write(`  Deleted:   ${result.deleted}\n`);
+	process.stderr.write(`  Unchanged: ${result.unchanged}\n`);
+
+	// Detailed change log (non-unchanged entries)
+	const nonTrivial = result.changes.filter((c: MergeChange) => c.action !== 'unchanged');
+	if (nonTrivial.length > 0) {
+		process.stderr.write('\nChanges:\n');
+		for (const change of nonTrivial) {
+			const action = change.action.toUpperCase().padEnd(7);
+			const details = change.details ? ` — ${change.details}` : '';
+			process.stderr.write(`  [${action}] ${change.entityType}/${change.canonicalName}${details}\n`);
+		}
+	}
+
+	// Errors/warnings
+	if (result.errors.length > 0) {
+		process.stderr.write('\nWarnings:\n');
+		for (const err of result.errors) {
+			process.stderr.write(`  ! ${err}\n`);
+		}
+	}
+
+	process.stderr.write('\n');
+}
+
+/**
+ * Resolves the curated YAML file path relative to the config file location.
+ * Default filename: taxonomy.curated.yaml
+ */
+function resolveCuratedPath(): string {
+	const configPath = resolve(process.env.MULDER_CONFIG ?? 'mulder.config.yaml');
+	return resolve(dirname(configPath), 'taxonomy.curated.yaml');
+}
+
+/**
+ * Prompts the user with a yes/no question. Returns true if the user answers 'y' or 'yes'.
+ */
+function promptYesNo(question: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = createInterface({ input: process.stdin, output: process.stderr });
+		rl.question(`${question} `, (answer) => {
+			rl.close();
+			resolve(answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes');
+		});
+	});
 }
 
 // ────────────────────────────────────────────────────────────
@@ -210,6 +280,173 @@ export function registerTaxonomyCommands(program: Command): void {
 						json: options.json,
 						logger,
 					});
+				} finally {
+					await closeAllPools();
+				}
+			}),
+		);
+
+	// ── export ────────────────────────────────────────────────
+
+	taxonomy
+		.command('export')
+		.description('Export taxonomy to curated YAML')
+		.option('--output <path>', 'write to file instead of stdout')
+		.option('--type <type>', 'filter to a single entity type')
+		.action(
+			withErrorHandler(async (options: ExportCommandOptions) => {
+				const config = loadConfig();
+				const logger = createLogger();
+
+				if (!config.gcp) {
+					printError('GCP configuration with cloud_sql is required for taxonomy export');
+					process.exit(1);
+					return;
+				}
+
+				const pool = getWorkerPool(config.gcp.cloud_sql);
+
+				try {
+					const result = await exportTaxonomy({
+						pool,
+						typeFilter: options.type,
+						logger,
+					});
+
+					if (options.output) {
+						const outputPath = resolve(options.output);
+						writeFileSync(outputPath, result.yaml, 'utf-8');
+						printSuccess(`Exported ${result.totalEntries} taxonomy entries to ${outputPath}`);
+					} else {
+						process.stdout.write(result.yaml);
+					}
+				} finally {
+					await closeAllPools();
+				}
+			}),
+		);
+
+	// ── curate ────────────────────────────────────────────────
+
+	taxonomy
+		.command('curate')
+		.description('Open taxonomy.curated.yaml in $EDITOR for curation')
+		.action(
+			withErrorHandler(async () => {
+				const config = loadConfig();
+				const logger = createLogger();
+
+				if (!config.gcp) {
+					printError('GCP configuration with cloud_sql is required for taxonomy curate');
+					process.exit(1);
+					return;
+				}
+
+				const curatedPath = resolveCuratedPath();
+
+				// If the curated file doesn't exist, create it via export
+				if (!existsSync(curatedPath)) {
+					const pool = getWorkerPool(config.gcp.cloud_sql);
+
+					try {
+						const result = await exportTaxonomy({ pool, logger });
+						writeFileSync(curatedPath, result.yaml, 'utf-8');
+						printSuccess(`Created ${curatedPath} with ${result.totalEntries} entries`);
+					} finally {
+						await closeAllPools();
+					}
+				}
+
+				// Open in editor
+				const editor = process.env.EDITOR ?? 'vi';
+				try {
+					execFileSync(editor, [curatedPath], { stdio: 'inherit' });
+				} catch {
+					printError(`Editor "${editor}" exited with an error`);
+					process.exit(1);
+					return;
+				}
+
+				// Prompt to run merge
+				const shouldMerge = await promptYesNo('Run merge now? [y/N]');
+				if (shouldMerge) {
+					const pool = getWorkerPool(config.gcp.cloud_sql);
+
+					try {
+						const yamlContent = readFileSync(curatedPath, 'utf-8');
+
+						// Dry-run preview first
+						const preview = await mergeTaxonomy({ pool, yamlContent, dryRun: true, logger });
+						printMergeResult(preview);
+
+						if (preview.created === 0 && preview.updated === 0 && preview.deleted === 0) {
+							printSuccess('No changes to apply');
+						} else {
+							const confirm = await promptYesNo('Apply these changes? [y/N]');
+							if (confirm) {
+								const result = await mergeTaxonomy({ pool, yamlContent, logger });
+								printMergeResult(result);
+								printSuccess(
+									`Merge complete: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+								);
+							} else {
+								printSuccess('Merge cancelled');
+							}
+						}
+					} finally {
+						await closeAllPools();
+					}
+				}
+			}),
+		);
+
+	// ── merge ─────────────────────────────────────────────────
+
+	taxonomy
+		.command('merge')
+		.description('Merge curated taxonomy YAML into the active taxonomy')
+		.option('--input <path>', 'read from specified path (default: taxonomy.curated.yaml)')
+		.option('--dry-run', 'preview changes without applying')
+		.action(
+			withErrorHandler(async (options: MergeCommandOptions) => {
+				const config = loadConfig();
+				const logger = createLogger();
+
+				if (!config.gcp) {
+					printError('GCP configuration with cloud_sql is required for taxonomy merge');
+					process.exit(1);
+					return;
+				}
+
+				const inputPath = options.input ? resolve(options.input) : resolveCuratedPath();
+
+				if (!existsSync(inputPath)) {
+					printError(`Curated taxonomy file not found: ${inputPath}`);
+					printError('Run `mulder taxonomy export --output taxonomy.curated.yaml` first');
+					process.exit(1);
+					return;
+				}
+
+				const yamlContent = readFileSync(inputPath, 'utf-8');
+				const pool = getWorkerPool(config.gcp.cloud_sql);
+
+				try {
+					const result = await mergeTaxonomy({
+						pool,
+						yamlContent,
+						dryRun: options.dryRun,
+						logger,
+					});
+
+					printMergeResult(result);
+
+					if (options.dryRun) {
+						printSuccess('Dry-run complete — no changes applied');
+					} else {
+						printSuccess(
+							`Merge complete: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+						);
+					}
 				} finally {
 					await closeAllPools();
 				}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -146,7 +146,7 @@ Human-in-the-loop taxonomy curation. Entity management for production use.
 | Status | Step | What | Spec |
 |--------|------|------|------|
 | 🟢 | F1 | Taxonomy bootstrap — `mulder taxonomy bootstrap` | §6.1, §1 (taxonomy cmd) |
-| 🟡 | F2 | Taxonomy export/curate/merge | §6.3, §1 (taxonomy cmd) |
+| 🟢 | F2 | Taxonomy export/curate/merge | §6.3, §1 (taxonomy cmd) |
 | ⚪ | F3 | Entity management CLI — list/show/merge/aliases | §1 (entity cmd) |
 | ⚪ | F4 | Status overview — `mulder status` | §1 (status cmd) |
 | ⚪ | F5 | Export commands — graph/stories/evidence | §1 (export cmd) |

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -164,13 +164,16 @@ export {
 	linkStoryEntity,
 	unlinkStoryEntity,
 } from './story-entity.repository.js';
+export type { ApplyTaxonomyChangesInput } from './taxonomy.repository.js';
 export {
+	applyTaxonomyChanges,
 	countProcessedSources,
 	countTaxonomyEntries,
 	createTaxonomyEntry,
 	deleteAutoTaxonomyEntries,
 	deleteTaxonomyEntry,
 	findAllTaxonomyEntries,
+	findAllTaxonomyEntriesUnpaginated,
 	findTaxonomyEntryById,
 	findTaxonomyEntryByName,
 	searchTaxonomyBySimilarity,

--- a/packages/core/src/database/repositories/taxonomy.repository.ts
+++ b/packages/core/src/database/repositories/taxonomy.repository.ts
@@ -24,6 +24,13 @@ import type {
 	UpdateTaxonomyEntryInput,
 } from './taxonomy.types.js';
 
+/** Input for a batch of taxonomy changes applied in a single transaction. */
+export interface ApplyTaxonomyChangesInput {
+	creates: CreateTaxonomyEntryInput[];
+	updates: Array<{ id: string; input: UpdateTaxonomyEntryInput }>;
+	deletes: string[];
+}
+
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'taxonomy-repository' });
 
@@ -423,5 +430,117 @@ export async function searchTaxonomyBySimilarity(
 			cause: error,
 			context: { name, entityType, threshold },
 		});
+	}
+}
+
+// ────────────────────────────────────────────────────────────
+// Unpaginated full export + batch apply
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Returns all taxonomy entries ordered by entity_type ASC, canonical_name ASC.
+ * No pagination — intended for export operations that need the full set.
+ */
+export async function findAllTaxonomyEntriesUnpaginated(pool: pg.Pool): Promise<TaxonomyEntry[]> {
+	const sql = 'SELECT * FROM taxonomy ORDER BY entity_type ASC, canonical_name ASC';
+
+	try {
+		const result = await pool.query<TaxonomyRow>(sql);
+		return result.rows.map(mapTaxonomyRow);
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to load all taxonomy entries', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+		});
+	}
+}
+
+/**
+ * Applies a batch of taxonomy creates, updates, and deletes in a single transaction.
+ * Throws `DatabaseError` on failure (auto-rollback via transaction).
+ */
+export async function applyTaxonomyChanges(pool: pg.Pool, changes: ApplyTaxonomyChangesInput): Promise<void> {
+	const client = await pool.connect();
+
+	try {
+		await client.query('BEGIN');
+
+		// Creates — use INSERT ON CONFLICT to handle duplicates gracefully
+		for (const input of changes.creates) {
+			const sql = `
+				INSERT INTO taxonomy (canonical_name, entity_type, category, status, aliases)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (canonical_name, entity_type) DO UPDATE SET
+					category = EXCLUDED.category,
+					status = EXCLUDED.status,
+					aliases = EXCLUDED.aliases,
+					updated_at = now()
+			`;
+			await client.query(sql, [
+				input.canonicalName,
+				input.entityType,
+				input.category ?? null,
+				input.status ?? 'confirmed',
+				input.aliases ?? [],
+			]);
+		}
+
+		// Updates — dynamic SET clauses
+		for (const { id, input } of changes.updates) {
+			const setClauses: string[] = [];
+			const params: unknown[] = [];
+			let paramIndex = 1;
+
+			if (input.canonicalName !== undefined) {
+				setClauses.push(`canonical_name = $${paramIndex}`);
+				params.push(input.canonicalName);
+				paramIndex++;
+			}
+			if (input.category !== undefined) {
+				setClauses.push(`category = $${paramIndex}`);
+				params.push(input.category);
+				paramIndex++;
+			}
+			if (input.status !== undefined) {
+				setClauses.push(`status = $${paramIndex}`);
+				params.push(input.status);
+				paramIndex++;
+			}
+			if (input.aliases !== undefined) {
+				setClauses.push(`aliases = $${paramIndex}`);
+				params.push(input.aliases);
+				paramIndex++;
+			}
+
+			setClauses.push('updated_at = now()');
+			params.push(id);
+
+			const sql = `UPDATE taxonomy SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`;
+			await client.query(sql, params);
+		}
+
+		// Deletes
+		for (const id of changes.deletes) {
+			await client.query('DELETE FROM taxonomy WHERE id = $1', [id]);
+		}
+
+		await client.query('COMMIT');
+
+		const totalOps = changes.creates.length + changes.updates.length + changes.deletes.length;
+		repoLogger.debug(
+			{ creates: changes.creates.length, updates: changes.updates.length, deletes: changes.deletes.length },
+			`Applied ${totalOps} taxonomy changes in transaction`,
+		);
+	} catch (error: unknown) {
+		await client.query('ROLLBACK');
+		throw new DatabaseError('Failed to apply taxonomy changes', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: {
+				creates: changes.creates.length,
+				updates: changes.updates.length,
+				deletes: changes.deletes.length,
+			},
+		});
+	} finally {
+		client.release();
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export {
 	mulderConfigSchema,
 } from './config/index.js';
 export type {
+	ApplyTaxonomyChangesInput,
 	AttributeCandidate,
 	Chunk,
 	ChunkFilter,
@@ -87,6 +88,7 @@ export type {
 } from './database/index.js';
 // ── Database ─────────────────────────────────────────────────
 export {
+	applyTaxonomyChanges,
 	closeAllPools,
 	countChunks,
 	countEdges,
@@ -125,6 +127,7 @@ export {
 	findAllSources,
 	findAllStories,
 	findAllTaxonomyEntries,
+	findAllTaxonomyEntriesUnpaginated,
 	findCandidatesByAttributes,
 	findCandidatesByEmbedding,
 	findChunkById,

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -64,7 +64,7 @@ export const TAXONOMY_ERROR_CODES = {
 	TAXONOMY_VALIDATION_FAILED: 'TAXONOMY_VALIDATION_FAILED',
 	/** F2 taxonomy merge — duplicate entries in curated YAML */
 	TAXONOMY_DUPLICATE_ENTRY: 'TAXONOMY_DUPLICATE_ENTRY',
-	/** F2 taxonomy merge — referenced ID not found in database */
+	/** @reserved F2 taxonomy merge — referenced ID not found in database (graceful skip, not thrown) */
 	TAXONOMY_ID_NOT_FOUND: 'TAXONOMY_ID_NOT_FOUND',
 	/** F2 taxonomy merge — transaction failed */
 	TAXONOMY_MERGE_FAILED: 'TAXONOMY_MERGE_FAILED',

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -60,6 +60,14 @@ export const TAXONOMY_ERROR_CODES = {
 	TAXONOMY_BOOTSTRAP_TOO_FEW: 'TAXONOMY_BOOTSTRAP_TOO_FEW',
 	/** F1 taxonomy bootstrap — corpus below threshold */
 	TAXONOMY_BELOW_THRESHOLD: 'TAXONOMY_BELOW_THRESHOLD',
+	/** F2 taxonomy merge — curated YAML validation failed */
+	TAXONOMY_VALIDATION_FAILED: 'TAXONOMY_VALIDATION_FAILED',
+	/** F2 taxonomy merge — duplicate entries in curated YAML */
+	TAXONOMY_DUPLICATE_ENTRY: 'TAXONOMY_DUPLICATE_ENTRY',
+	/** F2 taxonomy merge — referenced ID not found in database */
+	TAXONOMY_ID_NOT_FOUND: 'TAXONOMY_ID_NOT_FOUND',
+	/** F2 taxonomy merge — transaction failed */
+	TAXONOMY_MERGE_FAILED: 'TAXONOMY_MERGE_FAILED',
 } as const;
 
 export type TaxonomyErrorCode = (typeof TAXONOMY_ERROR_CODES)[keyof typeof TAXONOMY_ERROR_CODES];

--- a/packages/taxonomy/package.json
+++ b/packages/taxonomy/package.json
@@ -13,6 +13,7 @@
 	"dependencies": {
 		"@mulder/core": "workspace:*",
 		"pg": "^8.20.0",
+		"yaml": "^2.8.3",
 		"zod": "^4.3.6",
 		"zod-to-json-schema": "^3.24.5"
 	}

--- a/packages/taxonomy/src/curated-schema.ts
+++ b/packages/taxonomy/src/curated-schema.ts
@@ -1,0 +1,37 @@
+/**
+ * Zod schema for the curated taxonomy YAML format.
+ *
+ * Validates the structure that `mulder taxonomy export` produces and
+ * that `mulder taxonomy merge` consumes. The format is a mapping of
+ * entity type names to arrays of taxonomy entries.
+ *
+ * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.1
+ * @see docs/functional-spec.md §6.3
+ */
+
+import { z } from 'zod';
+
+// ────────────────────────────────────────────────────────────
+// Entry schema
+// ────────────────────────────────────────────────────────────
+
+const CuratedEntrySchema = z.object({
+	id: z.string().uuid().optional(),
+	canonical: z.string().min(1),
+	status: z.enum(['confirmed', 'auto', 'rejected']).default('confirmed'),
+	category: z.string().optional(),
+	aliases: z.array(z.string()).default([]),
+});
+
+// ────────────────────────────────────────────────────────────
+// Top-level schema (entity type -> entries)
+// ────────────────────────────────────────────────────────────
+
+export const CuratedTaxonomySchema = z.record(z.string(), z.array(CuratedEntrySchema));
+
+// ────────────────────────────────────────────────────────────
+// Inferred types
+// ────────────────────────────────────────────────────────────
+
+export type CuratedEntry = z.infer<typeof CuratedEntrySchema>;
+export type CuratedTaxonomy = z.infer<typeof CuratedTaxonomySchema>;

--- a/packages/taxonomy/src/export.ts
+++ b/packages/taxonomy/src/export.ts
@@ -1,0 +1,178 @@
+/**
+ * Taxonomy export -- dumps the current taxonomy to a curated YAML format.
+ *
+ * Loads all taxonomy entries from the database, groups by entity type,
+ * sorts within each group (confirmed first, then auto, then rejected;
+ * alphabetical within each status), and renders as YAML.
+ *
+ * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.1
+ * @see docs/functional-spec.md §6.3
+ */
+
+import type { Logger, TaxonomyEntry } from '@mulder/core';
+import { createChildLogger, findAllTaxonomyEntriesUnpaginated } from '@mulder/core';
+import type pg from 'pg';
+import { stringify as yamlStringify } from 'yaml';
+
+// ────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────
+
+export interface ExportOptions {
+	pool: pg.Pool;
+	typeFilter?: string;
+	logger: Logger;
+}
+
+export interface ExportResult {
+	/** The rendered YAML content. */
+	yaml: string;
+	totalEntries: number;
+	typeBreakdown: Record<string, number>;
+}
+
+// ────────────────────────────────────────────────────────────
+// Status sort order (confirmed first, auto, rejected last)
+// ────────────────────────────────────────────────────────────
+
+const STATUS_ORDER: Record<string, number> = {
+	confirmed: 0,
+	auto: 1,
+	rejected: 2,
+};
+
+function statusSortKey(status: string): number {
+	return STATUS_ORDER[status] ?? 3;
+}
+
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Groups taxonomy entries by entityType.
+ */
+function groupByType(entries: TaxonomyEntry[]): Map<string, TaxonomyEntry[]> {
+	const groups = new Map<string, TaxonomyEntry[]>();
+
+	for (const entry of entries) {
+		const existing = groups.get(entry.entityType);
+		if (existing) {
+			existing.push(entry);
+		} else {
+			groups.set(entry.entityType, [entry]);
+		}
+	}
+
+	return groups;
+}
+
+/**
+ * Sorts entries: confirmed first, then auto, then rejected.
+ * Within each status, alphabetical by canonicalName.
+ */
+function sortEntries(entries: TaxonomyEntry[]): TaxonomyEntry[] {
+	return [...entries].sort((a, b) => {
+		const statusDiff = statusSortKey(a.status) - statusSortKey(b.status);
+		if (statusDiff !== 0) return statusDiff;
+		return a.canonicalName.localeCompare(b.canonicalName);
+	});
+}
+
+/**
+ * Converts a TaxonomyEntry to the curated YAML entry format.
+ */
+function toCuratedEntry(entry: TaxonomyEntry): Record<string, unknown> {
+	const result: Record<string, unknown> = {
+		id: entry.id,
+		canonical: entry.canonicalName,
+		status: entry.status,
+	};
+
+	// Only include category when non-null (keeps YAML clean)
+	if (entry.category !== null) {
+		result.category = entry.category;
+	}
+
+	result.aliases = entry.aliases;
+
+	return result;
+}
+
+/**
+ * Generates the YAML comment header with timestamp and instructions.
+ */
+function generateHeader(): string {
+	const timestamp = new Date().toISOString();
+	return [
+		`# Mulder Taxonomy — exported ${timestamp}`,
+		'# Edit entries: change status, rename canonicals, add/remove aliases.',
+		'# Then run `mulder taxonomy merge` to apply changes.',
+		'#',
+		'# Status values: confirmed | auto | rejected',
+		"# - confirmed: human-verified, bootstrap won't touch these",
+		'# - auto: machine-generated, may be replaced by re-bootstrap',
+		'# - rejected: hidden from normalization, preserved for reference',
+		'',
+	].join('\n');
+}
+
+// ────────────────────────────────────────────────────────────
+// Export
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Exports taxonomy entries to the curated YAML format.
+ *
+ * 1. Loads all taxonomy entries via findAllTaxonomyEntriesUnpaginated()
+ * 2. Optionally filters by entity type
+ * 3. Groups entries by entityType
+ * 4. Sorts within each group (confirmed > auto > rejected, then alphabetical)
+ * 5. Renders as YAML with comment header
+ * 6. Returns the YAML string and stats
+ */
+export async function exportTaxonomy(options: ExportOptions): Promise<ExportResult> {
+	const { pool, typeFilter, logger } = options;
+	const exportLogger = createChildLogger(logger, { module: 'taxonomy-export' });
+
+	// Step 1: Load all entries
+	let entries = await findAllTaxonomyEntriesUnpaginated(pool);
+	exportLogger.debug({ entryCount: entries.length }, 'Loaded taxonomy entries for export');
+
+	// Step 2: Filter by type if specified
+	if (typeFilter) {
+		entries = entries.filter((e) => e.entityType === typeFilter);
+		exportLogger.debug({ typeFilter, filteredCount: entries.length }, 'Filtered by entity type');
+	}
+
+	// Step 3: Group by type
+	const grouped = groupByType(entries);
+
+	// Step 4: Build the YAML data structure (sorted types, sorted entries)
+	const yamlData: Record<string, Array<Record<string, unknown>>> = {};
+	const typeBreakdown: Record<string, number> = {};
+
+	const sortedTypes = [...grouped.keys()].sort();
+
+	for (const entityType of sortedTypes) {
+		const typeEntries = grouped.get(entityType);
+		if (!typeEntries) continue;
+
+		const sorted = sortEntries(typeEntries);
+		yamlData[entityType] = sorted.map(toCuratedEntry);
+		typeBreakdown[entityType] = sorted.length;
+	}
+
+	// Step 5: Render YAML with header
+	const header = generateHeader();
+	const yamlBody = entries.length > 0 ? yamlStringify(yamlData, { lineWidth: 0 }) : '';
+	const yaml = header + yamlBody;
+
+	exportLogger.info({ totalEntries: entries.length, typeCount: sortedTypes.length }, 'Taxonomy export complete');
+
+	return {
+		yaml,
+		totalEntries: entries.length,
+		typeBreakdown,
+	};
+}

--- a/packages/taxonomy/src/index.ts
+++ b/packages/taxonomy/src/index.ts
@@ -1,11 +1,12 @@
 /**
  * Taxonomy package barrel export.
  *
- * Provides taxonomy bootstrap, show, and normalization (trigram similarity matching).
+ * Provides taxonomy bootstrap, show, normalization, export, and merge.
  * Re-exports taxonomy types from @mulder/core.
  *
  * @see docs/specs/46_taxonomy_bootstrap.spec.md §4.2
  * @see docs/specs/27_taxonomy_normalization.spec.md §4.5
+ * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.2
  * @see docs/functional-spec.md §6
  */
 
@@ -20,6 +21,12 @@ export type {
 } from '@mulder/core';
 export type { BootstrapOptions, BootstrapResult } from './bootstrap.js';
 export { bootstrapTaxonomy, rebootstrapTaxonomy } from './bootstrap.js';
+export type { CuratedEntry, CuratedTaxonomy } from './curated-schema.js';
+export { CuratedTaxonomySchema } from './curated-schema.js';
+export type { ExportOptions, ExportResult } from './export.js';
+export { exportTaxonomy } from './export.js';
+export type { MergeChange, MergeOptions, MergeResult } from './merge.js';
+export { mergeTaxonomy } from './merge.js';
 export { normalizeTaxonomy } from './normalize.js';
 export type { ShowOptions } from './show.js';
 export { showTaxonomy } from './show.js';

--- a/packages/taxonomy/src/merge.ts
+++ b/packages/taxonomy/src/merge.ts
@@ -1,0 +1,364 @@
+/**
+ * Taxonomy merge -- applies curated YAML changes back into the taxonomy table.
+ *
+ * Parses and validates the curated YAML, diffs against current database state,
+ * and applies creates/updates/deletes in a single transaction.
+ *
+ * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.1
+ * @see docs/functional-spec.md §6.3
+ */
+
+import type {
+	ApplyTaxonomyChangesInput,
+	CreateTaxonomyEntryInput,
+	Logger,
+	TaxonomyEntry,
+	UpdateTaxonomyEntryInput,
+} from '@mulder/core';
+import {
+	applyTaxonomyChanges,
+	createChildLogger,
+	findAllTaxonomyEntriesUnpaginated,
+	TAXONOMY_ERROR_CODES,
+	TaxonomyError,
+} from '@mulder/core';
+import type pg from 'pg';
+import { parse as yamlParse } from 'yaml';
+import { ZodError } from 'zod';
+import type { CuratedEntry } from './curated-schema.js';
+import { CuratedTaxonomySchema } from './curated-schema.js';
+
+// ────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────
+
+export interface MergeOptions {
+	pool: pg.Pool;
+	/** Raw YAML string to merge. */
+	yamlContent: string;
+	dryRun?: boolean;
+	logger: Logger;
+}
+
+export interface MergeChange {
+	action: 'created' | 'updated' | 'deleted' | 'unchanged';
+	entityType: string;
+	canonicalName: string;
+	id?: string;
+	details?: string;
+}
+
+export interface MergeResult {
+	created: number;
+	updated: number;
+	deleted: number;
+	unchanged: number;
+	changes: MergeChange[];
+	errors: string[];
+}
+
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Builds a composite key for duplicate detection within the YAML file.
+ */
+function entryKey(canonical: string, entityType: string): string {
+	return `${entityType}::${canonical}`;
+}
+
+/**
+ * Checks if two string arrays have the same elements (order-insensitive).
+ */
+function aliasesEqual(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const sorted1 = [...a].sort();
+	const sorted2 = [...b].sort();
+	return sorted1.every((val, idx) => val === sorted2[idx]);
+}
+
+/**
+ * Computes the diff details between a curated YAML entry and a database entry.
+ * Returns null if unchanged.
+ */
+function computeDiff(
+	curatedEntry: CuratedEntry,
+	dbEntry: TaxonomyEntry,
+): { input: UpdateTaxonomyEntryInput; details: string } | null {
+	const diffs: string[] = [];
+	const input: UpdateTaxonomyEntryInput = {};
+
+	// Canonical name change (rename)
+	if (curatedEntry.canonical !== dbEntry.canonicalName) {
+		input.canonicalName = curatedEntry.canonical;
+		diffs.push(`canonical: "${dbEntry.canonicalName}" -> "${curatedEntry.canonical}"`);
+	}
+
+	// Status change
+	if (curatedEntry.status !== dbEntry.status) {
+		input.status = curatedEntry.status;
+		diffs.push(`status: ${dbEntry.status} -> ${curatedEntry.status}`);
+	}
+
+	// Category change
+	const curatedCategory = curatedEntry.category ?? null;
+	if (curatedCategory !== dbEntry.category) {
+		input.category = curatedCategory;
+		diffs.push(`category: "${dbEntry.category ?? ''}" -> "${curatedCategory ?? ''}"`);
+	}
+
+	// Aliases change (full replacement, not additive)
+	if (!aliasesEqual(curatedEntry.aliases, dbEntry.aliases)) {
+		input.aliases = curatedEntry.aliases;
+		diffs.push(`aliases: [${dbEntry.aliases.join(', ')}] -> [${curatedEntry.aliases.join(', ')}]`);
+	}
+
+	if (diffs.length === 0) {
+		return null;
+	}
+
+	return { input, details: diffs.join('; ') };
+}
+
+// ────────────────────────────────────────────────────────────
+// Merge
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Merges curated YAML changes into the taxonomy database.
+ *
+ * Flow:
+ * 1. Parse YAML, validate against CuratedTaxonomySchema
+ * 2. Check for duplicate (canonical, entityType) pairs in the YAML
+ * 3. Load all current taxonomy entries from database
+ * 4. Build lookup maps (byId, byNameType)
+ * 5. Diff: for each YAML entry, determine create/update/unchanged
+ * 6. Deletion detection: DB entries for types in YAML but missing from YAML
+ * 7. If dryRun, return changes without applying
+ * 8. Apply all writes in a single transaction
+ */
+export async function mergeTaxonomy(options: MergeOptions): Promise<MergeResult> {
+	const { pool, yamlContent, dryRun, logger } = options;
+	const mergeLogger = createChildLogger(logger, { module: 'taxonomy-merge' });
+
+	// Step 1: Parse YAML
+	let parsed: unknown;
+	try {
+		parsed = yamlParse(yamlContent);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new TaxonomyError(
+			`Invalid YAML in curated taxonomy file: ${message}`,
+			TAXONOMY_ERROR_CODES.TAXONOMY_VALIDATION_FAILED,
+			{ context: { parseError: message } },
+		);
+	}
+
+	// Handle empty YAML (null/undefined)
+	if (parsed === null || parsed === undefined) {
+		parsed = {};
+	}
+
+	// Validate against schema
+	let curated: Record<string, CuratedEntry[]>;
+	try {
+		curated = CuratedTaxonomySchema.parse(parsed);
+	} catch (error: unknown) {
+		if (error instanceof ZodError) {
+			const issues = error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+			throw new TaxonomyError(
+				`Curated taxonomy validation failed: ${issues}`,
+				TAXONOMY_ERROR_CODES.TAXONOMY_VALIDATION_FAILED,
+				{ context: { issues: error.issues } },
+			);
+		}
+		throw error;
+	}
+
+	// Step 2: Check for duplicates within YAML
+	const seen = new Set<string>();
+	for (const [entityType, entries] of Object.entries(curated)) {
+		for (const entry of entries) {
+			const key = entryKey(entry.canonical, entityType);
+			if (seen.has(key)) {
+				throw new TaxonomyError(
+					`Duplicate entry in curated taxonomy: "${entry.canonical}" of type "${entityType}"`,
+					TAXONOMY_ERROR_CODES.TAXONOMY_DUPLICATE_ENTRY,
+					{ context: { canonical: entry.canonical, entityType } },
+				);
+			}
+			seen.add(key);
+		}
+	}
+
+	// Step 3: Load all current entries from database
+	const dbEntries = await findAllTaxonomyEntriesUnpaginated(pool);
+	mergeLogger.debug({ dbEntryCount: dbEntries.length }, 'Loaded current taxonomy entries');
+
+	// Step 4: Build lookup maps
+	const byId = new Map<string, TaxonomyEntry>();
+	const byNameType = new Map<string, TaxonomyEntry>();
+	for (const entry of dbEntries) {
+		byId.set(entry.id, entry);
+		byNameType.set(entryKey(entry.canonicalName, entry.entityType), entry);
+	}
+
+	// Step 5: Process each YAML entry
+	const changes: MergeChange[] = [];
+	const errors: string[] = [];
+
+	const creates: CreateTaxonomyEntryInput[] = [];
+	const updates: Array<{ id: string; input: UpdateTaxonomyEntryInput }> = [];
+	const processedDbIds = new Set<string>();
+
+	// Track which entity types appear in the YAML (for deletion detection)
+	const yamlEntityTypes = new Set(Object.keys(curated));
+
+	for (const [entityType, entries] of Object.entries(curated)) {
+		for (const curatedEntry of entries) {
+			if (curatedEntry.id) {
+				// Has ID: look up by ID
+				const dbEntry = byId.get(curatedEntry.id);
+				if (!dbEntry) {
+					errors.push(
+						`Entry with ID "${curatedEntry.id}" (${curatedEntry.canonical}) not found in database — skipping`,
+					);
+					changes.push({
+						action: 'unchanged',
+						entityType,
+						canonicalName: curatedEntry.canonical,
+						id: curatedEntry.id,
+						details: 'ID not found in database (skipped)',
+					});
+					continue;
+				}
+
+				processedDbIds.add(dbEntry.id);
+
+				const diff = computeDiff(curatedEntry, dbEntry);
+				if (diff) {
+					updates.push({ id: dbEntry.id, input: diff.input });
+					changes.push({
+						action: 'updated',
+						entityType,
+						canonicalName: curatedEntry.canonical,
+						id: dbEntry.id,
+						details: diff.details,
+					});
+				} else {
+					changes.push({
+						action: 'unchanged',
+						entityType,
+						canonicalName: curatedEntry.canonical,
+						id: dbEntry.id,
+					});
+				}
+			} else {
+				// No ID: look up by (canonical, entityType)
+				const key = entryKey(curatedEntry.canonical, entityType);
+				const dbEntry = byNameType.get(key);
+
+				if (dbEntry) {
+					processedDbIds.add(dbEntry.id);
+
+					const diff = computeDiff(curatedEntry, dbEntry);
+					if (diff) {
+						updates.push({ id: dbEntry.id, input: diff.input });
+						changes.push({
+							action: 'updated',
+							entityType,
+							canonicalName: curatedEntry.canonical,
+							id: dbEntry.id,
+							details: diff.details,
+						});
+					} else {
+						changes.push({
+							action: 'unchanged',
+							entityType,
+							canonicalName: curatedEntry.canonical,
+							id: dbEntry.id,
+						});
+					}
+				} else {
+					// New entry
+					creates.push({
+						canonicalName: curatedEntry.canonical,
+						entityType,
+						status: curatedEntry.status,
+						category: curatedEntry.category,
+						aliases: curatedEntry.aliases,
+					});
+					changes.push({
+						action: 'created',
+						entityType,
+						canonicalName: curatedEntry.canonical,
+						details: `new entry (status: ${curatedEntry.status})`,
+					});
+				}
+			}
+		}
+	}
+
+	// Step 6: Deletion detection
+	// Only delete entries whose entityType appears in the YAML
+	const deletes: string[] = [];
+	for (const dbEntry of dbEntries) {
+		if (yamlEntityTypes.has(dbEntry.entityType) && !processedDbIds.has(dbEntry.id)) {
+			deletes.push(dbEntry.id);
+			changes.push({
+				action: 'deleted',
+				entityType: dbEntry.entityType,
+				canonicalName: dbEntry.canonicalName,
+				id: dbEntry.id,
+				details: 'removed from curated YAML',
+			});
+		}
+	}
+
+	// Compute summary
+	const result: MergeResult = {
+		created: creates.length,
+		updated: updates.length,
+		deleted: deletes.length,
+		unchanged: changes.filter((c) => c.action === 'unchanged').length,
+		changes,
+		errors,
+	};
+
+	mergeLogger.info(
+		{
+			created: result.created,
+			updated: result.updated,
+			deleted: result.deleted,
+			unchanged: result.unchanged,
+			errors: errors.length,
+		},
+		'Merge diff computed',
+	);
+
+	// Step 7: If dry-run, return without applying
+	if (dryRun) {
+		mergeLogger.info('Dry-run mode — no changes applied');
+		return result;
+	}
+
+	// Step 8: Apply all writes in a single transaction
+	if (creates.length > 0 || updates.length > 0 || deletes.length > 0) {
+		const batchChanges: ApplyTaxonomyChangesInput = { creates, updates, deletes };
+
+		try {
+			await applyTaxonomyChanges(pool, batchChanges);
+			mergeLogger.info('Taxonomy changes applied successfully');
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new TaxonomyError(
+				`Failed to apply taxonomy changes: ${message}`,
+				TAXONOMY_ERROR_CODES.TAXONOMY_MERGE_FAILED,
+				{ cause: error },
+			);
+		}
+	}
+
+	return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/tests/specs/50_taxonomy_export_curate_merge.test.ts
+++ b/tests/specs/50_taxonomy_export_curate_merge.test.ts
@@ -1,0 +1,1068 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { ensureSchema } from '../lib/schema.js';
+
+/**
+ * Black-box QA tests for Spec 50: Taxonomy Export/Curate/Merge
+ *
+ * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
+ * Tests interact through system boundaries only: CLI subprocess calls,
+ * SQL via `docker exec psql`, and filesystem.
+ * Never imports from packages/ or src/ or apps/.
+ *
+ * Requires:
+ * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - Built CLI at apps/cli/dist/index.js
+ */
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+
+const PG_CONTAINER = 'mulder-pg-test';
+const PG_USER = 'mulder';
+const PG_PASSWORD = 'mulder';
+
+// Temporary file paths for test artifacts
+const TMP_DIR = resolve(ROOT, 'tmp-test-50');
+const CURATED_YAML_PATH = resolve(TMP_DIR, 'taxonomy.curated.yaml');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 30000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function runSql(sql: string): string {
+	const result = spawnSync(
+		'docker',
+		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
+		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
+	);
+	if (result.status !== 0) {
+		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
+	}
+	return (result.stdout ?? '').trim();
+}
+
+function isPgAvailable(): boolean {
+	try {
+		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
+			encoding: 'utf-8',
+			timeout: 5000,
+		});
+		return result.status === 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Seed taxonomy entries directly into the database.
+ */
+function seedTaxonomy(
+	entries: Array<{
+		id?: string;
+		canonical_name: string;
+		entity_type: string;
+		status: string;
+		category?: string;
+		aliases?: string[];
+	}>,
+): string[] {
+	const ids: string[] = [];
+	for (const entry of entries) {
+		const id = entry.id ?? randomUUID();
+		const aliasArray = entry.aliases?.length
+			? `ARRAY[${entry.aliases.map((a) => `'${a.replace(/'/g, "''")}'`).join(',')}]`
+			: 'ARRAY[]::text[]';
+		const categoryValue = entry.category ? `'${entry.category.replace(/'/g, "''")}'` : 'NULL';
+		runSql(
+			`INSERT INTO taxonomy (id, canonical_name, entity_type, status, category, aliases) ` +
+				`VALUES ('${id}', '${entry.canonical_name.replace(/'/g, "''")}', '${entry.entity_type}', '${entry.status}', ${categoryValue}, ${aliasArray}) ` +
+				`ON CONFLICT (canonical_name, entity_type) DO UPDATE SET status = '${entry.status}', aliases = ${aliasArray}, category = ${categoryValue};`,
+		);
+		ids.push(id);
+	}
+	return ids;
+}
+
+function cleanTestData(): void {
+	// Use TRUNCATE CASCADE for robustness against foreign key ordering issues
+	// when the database has leftover data from other test suites
+	runSql(
+		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
+			'taxonomy, entities, stories, source_steps, ' +
+			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
+	);
+}
+
+function cleanupTmpFiles(): void {
+	try {
+		if (existsSync(CURATED_YAML_PATH)) unlinkSync(CURATED_YAML_PATH);
+		// Clean any other temp files in TMP_DIR
+		if (existsSync(TMP_DIR)) {
+			const { readdirSync, rmSync } = require('node:fs');
+			for (const f of readdirSync(TMP_DIR)) {
+				rmSync(resolve(TMP_DIR, f), { force: true });
+			}
+			rmSync(TMP_DIR, { force: true, recursive: true });
+		}
+	} catch {
+		// best-effort cleanup
+	}
+}
+
+/**
+ * Count taxonomy entries in the database, optionally filtered by entity type.
+ */
+function countTaxonomy(entityType?: string): number {
+	const where = entityType ? ` WHERE entity_type = '${entityType}'` : '';
+	return Number(runSql(`SELECT COUNT(*) FROM taxonomy${where};`));
+}
+
+/**
+ * Get a taxonomy entry by ID.
+ */
+function getTaxonomyById(id: string): { canonical_name: string; status: string; aliases: string; category: string | null } | null {
+	const row = runSql(
+		`SELECT canonical_name, status, aliases, category FROM taxonomy WHERE id = '${id}';`,
+	);
+	if (!row) return null;
+	const parts = row.split('|');
+	return {
+		canonical_name: parts[0],
+		status: parts[1],
+		aliases: parts[2],
+		category: parts[3] === '' ? null : parts[3],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test state
+// ---------------------------------------------------------------------------
+
+let pgAvailable = false;
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+	pgAvailable = isPgAvailable();
+	if (!pgAvailable) return;
+	ensureSchema();
+	cleanTestData();
+	// Create tmp directory
+	const { mkdirSync } = require('node:fs');
+	mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterAll(() => {
+	if (!pgAvailable) return;
+	cleanTestData();
+	cleanupTmpFiles();
+});
+
+// ---------------------------------------------------------------------------
+// QA Contract Tests (QA-01 to QA-15)
+// ---------------------------------------------------------------------------
+
+describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanTestData();
+	});
+
+	it('QA-01: Export produces valid YAML', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Alice Smith', entity_type: 'person', status: 'confirmed', aliases: ['Alice', 'A. Smith'] },
+			{ canonical_name: 'Roswell', entity_type: 'location', status: 'auto', aliases: ['Roswell NM'] },
+		]);
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export']);
+		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
+
+		// stdout should be valid YAML
+		expect(stdout.length).toBeGreaterThan(0);
+
+		// Parse as YAML (use js-yaml-compatible parsing check: valid YAML should not throw)
+		// We can't import js-yaml (black-box), so validate structural markers
+		// The output should contain entity type top-level keys
+		expect(stdout).toContain('person:');
+		expect(stdout).toContain('location:');
+
+		// Each entry should include id, canonical, status, aliases
+		expect(stdout).toMatch(/id:\s+/);
+		expect(stdout).toMatch(/canonical:\s+/);
+		expect(stdout).toMatch(/status:\s+/);
+		expect(stdout).toMatch(/aliases:/);
+	});
+
+	it('QA-02: Export includes all entries', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Person One', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Location One', entity_type: 'location', status: 'confirmed' },
+			{ canonical_name: 'Org One', entity_type: 'organization', status: 'auto' },
+		]);
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export']);
+		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
+
+		// All three types should appear as top-level keys
+		expect(stdout).toContain('person:');
+		expect(stdout).toContain('location:');
+		expect(stdout).toContain('organization:');
+
+		// All entries should be included
+		expect(stdout).toContain('Person One');
+		expect(stdout).toContain('Location One');
+		expect(stdout).toContain('Org One');
+	});
+
+	it('QA-03: Export with --type filter', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Person A', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Location A', entity_type: 'location', status: 'auto' },
+			{ canonical_name: 'Org A', entity_type: 'organization', status: 'auto' },
+		]);
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export', '--type', 'person']);
+		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
+
+		// Only person entries should appear
+		expect(stdout).toContain('person:');
+		expect(stdout).toContain('Person A');
+
+		// Other types should NOT appear
+		expect(stdout).not.toContain('location:');
+		expect(stdout).not.toContain('organization:');
+		expect(stdout).not.toContain('Location A');
+		expect(stdout).not.toContain('Org A');
+	});
+
+	it('QA-04: Export with --output writes to file', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'File Test Person', entity_type: 'person', status: 'auto', aliases: ['FTP'] },
+		]);
+
+		const outputPath = resolve(TMP_DIR, 'export-test.yaml');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'export', '--output', outputPath]);
+		expect(exitCode, `Export to file failed: ${stderr}`).toBe(0);
+
+		// File should exist
+		expect(existsSync(outputPath)).toBe(true);
+
+		// File content should match stdout export
+		const fileContent = readFileSync(outputPath, 'utf-8');
+		expect(fileContent).toContain('person:');
+		expect(fileContent).toContain('File Test Person');
+		expect(fileContent).toContain('FTP');
+
+		// Compare with stdout export
+		const { stdout: stdoutExport } = runCli(['taxonomy', 'export']);
+		// The content in the file should be the same YAML (ignoring potential stderr messages)
+		expect(fileContent).toContain('person:');
+		expect(fileContent).toContain('File Test Person');
+
+		// Cleanup
+		unlinkSync(outputPath);
+	});
+
+	it('QA-05: Export round-trips through merge unchanged', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Round Trip Person', entity_type: 'person', status: 'confirmed', aliases: ['RTP'] },
+			{ canonical_name: 'Round Trip Location', entity_type: 'location', status: 'auto', aliases: ['RTL'] },
+		]);
+
+		const countBefore = countTaxonomy();
+
+		// Export to file
+		const exportPath = resolve(TMP_DIR, 'roundtrip.yaml');
+		const { exitCode: exportExit, stderr: exportErr } = runCli(['taxonomy', 'export', '--output', exportPath]);
+		expect(exportExit, `Export failed: ${exportErr}`).toBe(0);
+
+		// Merge without edits
+		const { exitCode: mergeExit, stdout: mergeOut, stderr: mergeErr } = runCli(['taxonomy', 'merge', '--input', exportPath]);
+		expect(mergeExit, `Merge failed: ${mergeErr}`).toBe(0);
+
+		const combined = mergeOut + mergeErr;
+
+		// Should report 0 created, 0 updated, 0 deleted, N unchanged
+		expect(combined).toMatch(/0\s*(created|new)/i);
+		expect(combined).toMatch(/0\s*(updated|changed)/i);
+		expect(combined).toMatch(/0\s*deleted/i);
+
+		// Entry count should be the same
+		const countAfter = countTaxonomy();
+		expect(countAfter).toBe(countBefore);
+
+		unlinkSync(exportPath);
+	});
+
+	it('QA-06: Merge creates new entries', () => {
+		if (!pgAvailable) return;
+
+		// Start with one existing entry
+		seedTaxonomy([
+			{ canonical_name: 'Existing Person', entity_type: 'person', status: 'auto' },
+		]);
+
+		// Create a YAML with the existing entry plus a new one (no id)
+		const yamlContent = `person:
+  - id: "${runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Existing Person';")}"
+    canonical: "Existing Person"
+    status: auto
+    aliases: []
+  - canonical: "Brand New Person"
+    status: confirmed
+    aliases:
+      - "BNP"
+      - "New P"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-create.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stdout}\n${stderr}`).toBe(0);
+
+		// A new entry should be created
+		const newEntry = runSql(
+			"SELECT canonical_name, status, aliases FROM taxonomy WHERE canonical_name = 'Brand New Person';",
+		);
+		expect(newEntry).toContain('Brand New Person');
+		expect(newEntry).toContain('confirmed');
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-07: Merge updates status', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'Status Update Person', entity_type: 'person', status: 'auto', aliases: ['SUP'] },
+		]);
+
+		// Create YAML with status changed from auto to confirmed
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "Status Update Person"
+    status: confirmed
+    aliases:
+      - "SUP"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-status.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stderr}`).toBe(0);
+
+		// Status should be updated
+		const entry = getTaxonomyById(id);
+		expect(entry).not.toBeNull();
+		expect(entry!.status).toBe('confirmed');
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-08: Merge renames canonical name', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'Old Name', entity_type: 'person', status: 'auto', aliases: ['ON'] },
+		]);
+
+		// Create YAML with same ID but different canonical name
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "New Renamed Name"
+    status: auto
+    aliases:
+      - "ON"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-rename.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stderr}`).toBe(0);
+
+		// canonical_name should be updated
+		const entry = getTaxonomyById(id);
+		expect(entry).not.toBeNull();
+		expect(entry!.canonical_name).toBe('New Renamed Name');
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-09: Merge updates aliases', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'Alias Person', entity_type: 'person', status: 'auto', aliases: ['AP', 'OldAlias'] },
+		]);
+
+		// Create YAML with changed aliases (replacement, not additive)
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "Alias Person"
+    status: auto
+    aliases:
+      - "AP"
+      - "NewAlias"
+      - "AnotherNew"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-aliases.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stderr}`).toBe(0);
+
+		// Aliases should be replaced (not merged)
+		const entry = getTaxonomyById(id);
+		expect(entry).not.toBeNull();
+		// The aliases should contain the new ones
+		expect(entry!.aliases).toContain('NewAlias');
+		expect(entry!.aliases).toContain('AnotherNew');
+		expect(entry!.aliases).toContain('AP');
+		// OldAlias should be gone (replaced, not merged)
+		expect(entry!.aliases).not.toContain('OldAlias');
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-10: Merge deletes removed entries', () => {
+		if (!pgAvailable) return;
+
+		const ids = seedTaxonomy([
+			{ canonical_name: 'Keep Person 1', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Keep Person 2', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Keep Person 3', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Delete Person 1', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Delete Person 2', entity_type: 'person', status: 'auto' },
+		]);
+
+		expect(countTaxonomy('person')).toBe(5);
+
+		// Create YAML with only 3 of the 5 person entries
+		const yamlContent = `person:
+  - id: "${ids[0]}"
+    canonical: "Keep Person 1"
+    status: auto
+    aliases: []
+  - id: "${ids[1]}"
+    canonical: "Keep Person 2"
+    status: auto
+    aliases: []
+  - id: "${ids[2]}"
+    canonical: "Keep Person 3"
+    status: auto
+    aliases: []
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-delete.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stderr}`).toBe(0);
+
+		// Only 3 person entries should remain
+		expect(countTaxonomy('person')).toBe(3);
+
+		// The deleted entries should not exist
+		expect(getTaxonomyById(ids[3])).toBeNull();
+		expect(getTaxonomyById(ids[4])).toBeNull();
+
+		// The kept entries should still exist
+		expect(getTaxonomyById(ids[0])).not.toBeNull();
+		expect(getTaxonomyById(ids[1])).not.toBeNull();
+		expect(getTaxonomyById(ids[2])).not.toBeNull();
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-11: Merge does not delete entries of unexported types', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Person In YAML', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Location Not In YAML', entity_type: 'location', status: 'auto' },
+			{ canonical_name: 'Org Not In YAML', entity_type: 'organization', status: 'confirmed' },
+		]);
+
+		const personId = runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Person In YAML';");
+
+		// Create YAML that only contains person type
+		const yamlContent = `person:
+  - id: "${personId}"
+    canonical: "Person In YAML"
+    status: auto
+    aliases: []
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-preserve-types.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		expect(exitCode, `Merge failed: ${stderr}`).toBe(0);
+
+		// Location and organization entries should NOT be deleted
+		expect(countTaxonomy('location')).toBe(1);
+		expect(countTaxonomy('organization')).toBe(1);
+		expect(countTaxonomy('person')).toBe(1);
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-12: Merge --dry-run shows changes without applying', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'DryRun Person', entity_type: 'person', status: 'auto', aliases: ['DRP'] },
+		]);
+
+		// Create YAML with status changed
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "DryRun Person"
+    status: confirmed
+    aliases:
+      - "DRP"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-dryrun.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
+		expect(exitCode, `Dry-run failed: ${stderr}`).toBe(0);
+
+		const combined = stdout + stderr;
+		// Should show what would change
+		expect(combined.length).toBeGreaterThan(0);
+
+		// Database should NOT be modified
+		const entry = getTaxonomyById(id);
+		expect(entry).not.toBeNull();
+		expect(entry!.status).toBe('auto'); // Still auto, not confirmed
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-13: Merge validates YAML structure', () => {
+		if (!pgAvailable) return;
+
+		// Create invalid YAML (missing required `canonical` field)
+		const invalidYaml = `person:
+  - status: auto
+    aliases:
+      - "Missing Canonical"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-invalid.yaml');
+		writeFileSync(inputPath, invalidYaml, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		const combined = stdout + stderr;
+
+		// Should fail with validation error
+		expect(exitCode).not.toBe(0);
+		expect(combined.toLowerCase()).toMatch(/valid|error|canonical/i);
+
+		// Database should not be modified (no entries should have been created)
+		expect(countTaxonomy()).toBe(0);
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-14: Merge is transactional', () => {
+		if (!pgAvailable) return;
+
+		const [id1] = seedTaxonomy([
+			{ canonical_name: 'Txn Person 1', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Txn Person 2', entity_type: 'person', status: 'auto' },
+		]);
+
+		const countBefore = countTaxonomy();
+
+		// Create YAML that has a valid update + a reference to a non-existent ID
+		// The non-existent ID should cause a warning/error, but we need to test
+		// that the transaction rolls back all changes if there's a constraint violation.
+		// A better approach: create two entries with the same canonical name which
+		// should cause a unique constraint violation during insert.
+		const yamlContent = `person:
+  - canonical: "New Entry Alpha"
+    status: confirmed
+    aliases: []
+  - canonical: "New Entry Alpha"
+    status: auto
+    aliases: []
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-txn.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		const combined = stdout + stderr;
+
+		// Should fail (duplicate canonical name within same type)
+		expect(exitCode).not.toBe(0);
+
+		// Database should not be modified (transaction rolled back)
+		const countAfter = countTaxonomy();
+		expect(countAfter).toBe(countBefore);
+
+		unlinkSync(inputPath);
+	});
+
+	it('QA-15: Merge detects duplicate entries', () => {
+		if (!pgAvailable) return;
+
+		// Create YAML with two entries having the same canonical and entity type
+		const yamlContent = `person:
+  - canonical: "Duplicate Name"
+    status: confirmed
+    aliases:
+      - "DN"
+  - canonical: "Duplicate Name"
+    status: auto
+    aliases:
+      - "Dupe"
+`;
+
+		const inputPath = resolve(TMP_DIR, 'merge-duplicates.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
+		const combined = stdout + stderr;
+
+		// Should fail with duplicate error
+		expect(exitCode).not.toBe(0);
+		expect(combined.toLowerCase()).toMatch(/duplicate|already exists|conflict/i);
+
+		unlinkSync(inputPath);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// CLI Test Matrix (CLI-01 to CLI-08)
+// ---------------------------------------------------------------------------
+
+describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanTestData();
+	});
+
+	it('CLI-01: `taxonomy export --help` shows usage with --output, --type flags', () => {
+		const { exitCode, stdout } = runCli(['taxonomy', 'export', '--help']);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain('--output');
+		expect(stdout).toContain('--type');
+		expect(stdout).toMatch(/export/i);
+	});
+
+	it('CLI-02: `taxonomy export` (no flags) outputs YAML to stdout', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Stdout Person', entity_type: 'person', status: 'auto', aliases: ['SP'] },
+		]);
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export']);
+		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
+
+		// YAML content should be on stdout
+		expect(stdout).toContain('person:');
+		expect(stdout).toContain('Stdout Person');
+	});
+
+	it('CLI-03: `taxonomy export --type person` shows filtered output', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'CLI Person', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'CLI Location', entity_type: 'location', status: 'auto' },
+		]);
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export', '--type', 'person']);
+		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
+
+		expect(stdout).toContain('person:');
+		expect(stdout).toContain('CLI Person');
+		expect(stdout).not.toContain('location:');
+		expect(stdout).not.toContain('CLI Location');
+	});
+
+	it('CLI-04: `taxonomy export --output` writes to file', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'CLI File Person', entity_type: 'person', status: 'auto' },
+		]);
+
+		const outputPath = resolve(TMP_DIR, 'cli-export-test.yaml');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'export', '--output', outputPath]);
+		expect(exitCode, `Export to file failed: ${stderr}`).toBe(0);
+
+		expect(existsSync(outputPath)).toBe(true);
+		const content = readFileSync(outputPath, 'utf-8');
+		expect(content).toContain('CLI File Person');
+
+		unlinkSync(outputPath);
+	});
+
+	it('CLI-05: `taxonomy merge --help` shows usage with --input, --dry-run flags', () => {
+		const { exitCode, stdout } = runCli(['taxonomy', 'merge', '--help']);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain('--input');
+		expect(stdout).toContain('--dry-run');
+		expect(stdout).toMatch(/merge/i);
+	});
+
+	it('CLI-06: `taxonomy merge --dry-run` shows preview without changes', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'CLI DryRun', entity_type: 'person', status: 'auto' },
+		]);
+
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "CLI DryRun"
+    status: confirmed
+    aliases: []
+`;
+
+		const inputPath = resolve(TMP_DIR, 'cli-dryrun.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
+		expect(exitCode, `Dry-run failed: ${stderr}`).toBe(0);
+
+		// Database should not be modified
+		const entry = getTaxonomyById(id);
+		expect(entry!.status).toBe('auto');
+
+		unlinkSync(inputPath);
+	});
+
+	it('CLI-07: `taxonomy merge --input custom.yaml` reads from custom path', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'Custom Path Person', entity_type: 'person', status: 'auto' },
+		]);
+
+		const customPath = resolve(TMP_DIR, 'custom-merge-path.yaml');
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "Custom Path Person"
+    status: confirmed
+    aliases: []
+`;
+		writeFileSync(customPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', customPath]);
+		expect(exitCode, `Merge from custom path failed: ${stderr}`).toBe(0);
+
+		// Verify the entry was updated
+		const entry = getTaxonomyById(id);
+		expect(entry).not.toBeNull();
+		expect(entry!.status).toBe('confirmed');
+
+		unlinkSync(customPath);
+	});
+
+	it('CLI-08: `taxonomy curate --help` shows usage', () => {
+		const { exitCode, stdout } = runCli(['taxonomy', 'curate', '--help']);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toMatch(/curate/i);
+		// Should mention $EDITOR or editor
+		expect(stdout).toMatch(/editor|\$EDITOR/i);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// CLI Smoke Tests
+// ---------------------------------------------------------------------------
+
+describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanTestData();
+	});
+
+	it('SMOKE-01: `taxonomy --help` lists export, curate, merge subcommands', () => {
+		const { exitCode, stdout } = runCli(['taxonomy', '--help']);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain('export');
+		expect(stdout).toContain('curate');
+		expect(stdout).toContain('merge');
+	});
+
+	it('SMOKE-02: `taxonomy export` with empty taxonomy produces valid output', () => {
+		if (!pgAvailable) return;
+
+		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
+
+		// Should succeed even with no entries
+		expect(exitCode).toBe(0);
+		// Output should either be empty YAML or a comment header
+		// It should not crash
+	});
+
+	it('SMOKE-03: `taxonomy export --type` without value exits non-zero', () => {
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export', '--type']);
+		const combined = stdout + stderr;
+
+		expect(exitCode).not.toBe(0);
+		expect(combined).toMatch(/type|argument|required|missing/i);
+	});
+
+	it('SMOKE-04: `taxonomy export --output` without value exits non-zero', () => {
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export', '--output']);
+		const combined = stdout + stderr;
+
+		expect(exitCode).not.toBe(0);
+		expect(combined).toMatch(/output|argument|required|missing/i);
+	});
+
+	it('SMOKE-05: `taxonomy merge` without existing default file exits non-zero', () => {
+		if (!pgAvailable) return;
+
+		// Ensure the default curated YAML file does not exist in the project root
+		const defaultCuratedPath = resolve(ROOT, 'taxonomy.curated.yaml');
+		let backupContent: string | null = null;
+		if (existsSync(defaultCuratedPath)) {
+			backupContent = readFileSync(defaultCuratedPath, 'utf-8');
+			unlinkSync(defaultCuratedPath);
+		}
+
+		try {
+			// When no --input is given and taxonomy.curated.yaml doesn't exist,
+			// merge should fail gracefully
+			const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge']);
+			const combined = stdout + stderr;
+
+			expect(exitCode).not.toBe(0);
+			// Should mention the missing file or give a meaningful error
+			expect(combined.length).toBeGreaterThan(0);
+		} finally {
+			// Restore the file if it existed before
+			if (backupContent !== null) {
+				writeFileSync(defaultCuratedPath, backupContent, 'utf-8');
+			}
+		}
+	});
+
+	it('SMOKE-06: `taxonomy merge --input nonexistent.yaml` exits non-zero', () => {
+		if (!pgAvailable) return;
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', '/tmp/does-not-exist-99.yaml']);
+		const combined = stdout + stderr;
+
+		expect(exitCode).not.toBe(0);
+		expect(combined.toLowerCase()).toMatch(/not found|no such file|enoent|does not exist|missing/i);
+	});
+
+	it('SMOKE-07: `taxonomy merge --input` without value exits non-zero', () => {
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input']);
+		const combined = stdout + stderr;
+
+		expect(exitCode).not.toBe(0);
+		expect(combined).toMatch(/input|argument|required|missing/i);
+	});
+
+	it('SMOKE-08: `taxonomy export --type nonexistent_type` returns empty output gracefully', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Person Z', entity_type: 'person', status: 'auto' },
+		]);
+
+		const { exitCode, stdout } = runCli(['taxonomy', 'export', '--type', 'nonexistent_type']);
+
+		// Should succeed but produce minimal/empty output
+		expect(exitCode).toBe(0);
+		expect(stdout).not.toContain('Person Z');
+	});
+
+	it('SMOKE-09: `taxonomy export --output --type` combined flags work', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Combo Person', entity_type: 'person', status: 'confirmed' },
+			{ canonical_name: 'Combo Location', entity_type: 'location', status: 'auto' },
+		]);
+
+		const outputPath = resolve(TMP_DIR, 'combo-export.yaml');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'export', '--type', 'person', '--output', outputPath]);
+		expect(exitCode, `Combined flags failed: ${stderr}`).toBe(0);
+
+		expect(existsSync(outputPath)).toBe(true);
+		const content = readFileSync(outputPath, 'utf-8');
+		expect(content).toContain('Combo Person');
+		expect(content).not.toContain('Combo Location');
+
+		unlinkSync(outputPath);
+	});
+
+	it('SMOKE-10: `taxonomy merge --dry-run --input` combined flags work', () => {
+		if (!pgAvailable) return;
+
+		const [id] = seedTaxonomy([
+			{ canonical_name: 'Combo Merge Person', entity_type: 'person', status: 'auto' },
+		]);
+
+		const yamlContent = `person:
+  - id: "${id}"
+    canonical: "Combo Merge Person"
+    status: confirmed
+    aliases: []
+`;
+		const inputPath = resolve(TMP_DIR, 'combo-merge.yaml');
+		writeFileSync(inputPath, yamlContent, 'utf-8');
+
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--dry-run', '--input', inputPath]);
+		expect(exitCode, `Combined flags failed: ${stderr}`).toBe(0);
+
+		// Database should remain unchanged
+		const entry = getTaxonomyById(id);
+		expect(entry!.status).toBe('auto');
+
+		unlinkSync(inputPath);
+	});
+
+	it('SMOKE-11: `taxonomy merge` with malformed YAML exits non-zero', () => {
+		if (!pgAvailable) return;
+
+		const malformedPath = resolve(TMP_DIR, 'malformed.yaml');
+		writeFileSync(malformedPath, '{{{{not valid yaml at all}}}}', 'utf-8');
+
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', malformedPath]);
+		const combined = stdout + stderr;
+
+		expect(exitCode).not.toBe(0);
+		expect(combined.length).toBeGreaterThan(0);
+
+		unlinkSync(malformedPath);
+	});
+
+	it('SMOKE-12: `taxonomy curate` without $EDITOR set uses fallback', () => {
+		// This test checks that curate doesn't crash when EDITOR is unset.
+		// We can't actually test the editor interaction, but we can verify it
+		// tries to proceed. We use a non-interactive approach.
+		// Since curate opens an editor, we'll just verify --help works (already tested in CLI-08).
+		// For safety, skip interactive test.
+		if (!pgAvailable) return;
+
+		// We set EDITOR to a non-existent command to see the error behavior
+		// without actually opening an editor
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'curate'], {
+			env: { EDITOR: '/bin/false' },
+			timeout: 10000,
+		});
+
+		// The command should either:
+		// 1. Try to export first (creating the file), then fail on editor
+		// 2. Fail gracefully
+		// We just verify it doesn't hang forever (timeout handles that)
+		const combined = stdout + stderr;
+		// It ran to completion without hanging
+		expect(typeof exitCode).toBe('number');
+	});
+
+	it('SMOKE-13: Export YAML includes comment header', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Header Test', entity_type: 'person', status: 'auto' },
+		]);
+
+		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
+		expect(exitCode).toBe(0);
+
+		// The spec says: "The comment header is always emitted (timestamp + instructions)"
+		expect(stdout).toContain('#');
+		expect(stdout).toMatch(/mulder taxonomy|Mulder Taxonomy/i);
+	});
+
+	it('SMOKE-14: Export sorting — confirmed before auto before rejected', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Zed Rejected', entity_type: 'person', status: 'rejected' },
+			{ canonical_name: 'Zed Auto', entity_type: 'person', status: 'auto' },
+			{ canonical_name: 'Zed Confirmed', entity_type: 'person', status: 'confirmed' },
+		]);
+
+		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
+		expect(exitCode).toBe(0);
+
+		// Confirmed should appear before auto, auto before rejected
+		const confirmedIdx = stdout.indexOf('Zed Confirmed');
+		const autoIdx = stdout.indexOf('Zed Auto');
+		const rejectedIdx = stdout.indexOf('Zed Rejected');
+
+		expect(confirmedIdx).toBeGreaterThan(-1);
+		expect(autoIdx).toBeGreaterThan(-1);
+		expect(rejectedIdx).toBeGreaterThan(-1);
+
+		expect(confirmedIdx).toBeLessThan(autoIdx);
+		expect(autoIdx).toBeLessThan(rejectedIdx);
+	});
+
+	it('SMOKE-15: Export includes category when present', () => {
+		if (!pgAvailable) return;
+
+		seedTaxonomy([
+			{ canonical_name: 'Categorized Location', entity_type: 'location', status: 'auto', category: 'historical' },
+			{ canonical_name: 'No Category Person', entity_type: 'person', status: 'auto' },
+		]);
+
+		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
+		expect(exitCode).toBe(0);
+
+		// Category should be included when present
+		expect(stdout).toContain('category:');
+		expect(stdout).toContain('historical');
+	});
+});


### PR DESCRIPTION
## Summary

Implements the human-in-the-loop taxonomy curation workflow (roadmap step F2, spec 50):

- **`mulder taxonomy export`** -- dumps current taxonomy to curated YAML format (stdout or `--output` file, optional `--type` filter)
- **`mulder taxonomy curate`** -- opens `taxonomy.curated.yaml` in `$EDITOR`, creates it via export if missing, prompts to merge after editing
- **`mulder taxonomy merge`** -- parses curated YAML, diffs against database, applies creates/updates/deletes in a single transaction (`--dry-run`, `--input` flags)

### Implementation details

- Zod validation schema for curated YAML format (`curated-schema.ts`)
- Export function groups entries by type, sorts by status (confirmed > auto > rejected), includes comment header with instructions
- Merge function supports: rename-by-ID, status changes, alias replacement, new entries without ID, deletion detection (only for types present in YAML), duplicate detection, and full transaction rollback on failure
- Two new repository functions: `findAllTaxonomyEntriesUnpaginated()` for full export, `applyTaxonomyChanges()` for batch transactional writes
- Four new taxonomy error codes: `TAXONOMY_VALIDATION_FAILED`, `TAXONOMY_DUPLICATE_ENTRY`, `TAXONOMY_ID_NOT_FOUND`, `TAXONOMY_MERGE_FAILED`

### Deviation from spec

- Spec mentions `js-yaml` for serialization but codebase uses `yaml` (npm) package throughout -- used `yaml` for consistency

Closes #131

## Test plan

- [ ] QA-01 through QA-15: Verify via separate QA verification agent
- [ ] CLI-01 through CLI-08: Verify CLI test matrix
- [ ] Round-trip test: export then merge without edits produces 0 changes
- [ ] Verify existing spec 46 taxonomy bootstrap tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)