### PR TITLE
feat: add v2 schema migrations

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -163,7 +163,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 
 | Status | Step | What | Spec |
 |--------|------|------|------|
-| 🟡 | G1 | v2.0 schema migrations (009-011) | §4.3 (grounding, evidence_chains, clusters tables) |
+| 🟢 | G1 | v2.0 schema migrations (009-011) | §4.3 (grounding, evidence_chains, clusters tables) |
 | ⚪ | G2 | Ground step — `mulder ground <entity-id>` | §2.5, §1 (ground cmd) |
 | ⚪ | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
 | ⚪ | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |

--- a/packages/core/src/database/migrations/009_entity_grounding.sql
+++ b/packages/core/src/database/migrations/009_entity_grounding.sql
@@ -1,0 +1,8 @@
+CREATE TABLE entity_grounding (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id      UUID NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  grounding_data JSONB NOT NULL,
+  source_urls    TEXT[],
+  grounded_at    TIMESTAMPTZ DEFAULT now(),
+  expires_at     TIMESTAMPTZ NOT NULL
+);

--- a/packages/core/src/database/migrations/010_evidence_chains.sql
+++ b/packages/core/src/database/migrations/010_evidence_chains.sql
@@ -1,0 +1,8 @@
+CREATE TABLE evidence_chains (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thesis     TEXT NOT NULL,
+  path       UUID[] NOT NULL,
+  strength   FLOAT NOT NULL,
+  supports   BOOLEAN NOT NULL,
+  computed_at TIMESTAMPTZ DEFAULT now()
+);

--- a/packages/core/src/database/migrations/011_spatio_temporal_clusters.sql
+++ b/packages/core/src/database/migrations/011_spatio_temporal_clusters.sql
@@ -1,0 +1,14 @@
+CREATE TABLE spatio_temporal_clusters (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  center_lat   FLOAT,
+  center_lng   FLOAT,
+  time_start   TIMESTAMPTZ,
+  time_end     TIMESTAMPTZ,
+  event_count  INTEGER NOT NULL,
+  event_ids    UUID[] NOT NULL,
+  cluster_type TEXT,
+  computed_at  TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE entities ADD COLUMN geom geometry(Point, 4326);
+CREATE INDEX idx_entities_geom ON entities USING GIST(geom);

--- a/packages/taxonomy/src/export.ts
+++ b/packages/taxonomy/src/export.ts
@@ -3,7 +3,7 @@
  *
  * Loads all taxonomy entries from the database, groups by entity type,
  * sorts within each group (confirmed first, then auto, then rejected;
- * alphabetical within each status), and renders as YAML.
+ * alphabetical within each status), and renders to YAML.
  *
  * @see docs/specs/50_taxonomy_export_curate_merge.spec.md §4.1
  * @see docs/functional-spec.md §6.3
@@ -128,7 +128,7 @@ function generateHeader(): string {
  * 2. Optionally filters by entity type
  * 3. Groups entries by entityType
  * 4. Sorts within each group (confirmed > auto > rejected, then alphabetical)
- * 5. Renders as YAML with comment header
+ * 5. Renders YAML with comment header
  * 6. Returns the YAML string and stats
  */
 export async function exportTaxonomy(options: ExportOptions): Promise<ExportResult> {

--- a/tests/specs/50_taxonomy_export_curate_merge.test.ts
+++ b/tests/specs/50_taxonomy_export_curate_merge.test.ts
@@ -142,10 +142,10 @@ function countTaxonomy(entityType?: string): number {
 /**
  * Get a taxonomy entry by ID.
  */
-function getTaxonomyById(id: string): { canonical_name: string; status: string; aliases: string; category: string | null } | null {
-	const row = runSql(
-		`SELECT canonical_name, status, aliases, category FROM taxonomy WHERE id = '${id}';`,
-	);
+function getTaxonomyById(
+	id: string,
+): { canonical_name: string; status: string; aliases: string; category: string | null } | null {
+	const row = runSql(`SELECT canonical_name, status, aliases, category FROM taxonomy WHERE id = '${id}';`);
 	if (!row) return null;
 	const parts = row.split('|');
 	return {
@@ -268,9 +268,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 	it('QA-04: Export with --output writes to file', () => {
 		if (!pgAvailable) return;
 
-		seedTaxonomy([
-			{ canonical_name: 'File Test Person', entity_type: 'person', status: 'auto', aliases: ['FTP'] },
-		]);
+		seedTaxonomy([{ canonical_name: 'File Test Person', entity_type: 'person', status: 'auto', aliases: ['FTP'] }]);
 
 		const outputPath = resolve(TMP_DIR, 'export-test.yaml');
 
@@ -287,7 +285,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		expect(fileContent).toContain('FTP');
 
 		// Compare with stdout export
-		const { stdout: stdoutExport } = runCli(['taxonomy', 'export']);
+		runCli(['taxonomy', 'export']);
 		// The content in the file should be the same YAML (ignoring potential stderr messages)
 		expect(fileContent).toContain('person:');
 		expect(fileContent).toContain('File Test Person');
@@ -312,7 +310,11 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		expect(exportExit, `Export failed: ${exportErr}`).toBe(0);
 
 		// Merge without edits
-		const { exitCode: mergeExit, stdout: mergeOut, stderr: mergeErr } = runCli(['taxonomy', 'merge', '--input', exportPath]);
+		const {
+			exitCode: mergeExit,
+			stdout: mergeOut,
+			stderr: mergeErr,
+		} = runCli(['taxonomy', 'merge', '--input', exportPath]);
 		expect(mergeExit, `Merge failed: ${mergeErr}`).toBe(0);
 
 		const combined = mergeOut + mergeErr;
@@ -333,9 +335,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		if (!pgAvailable) return;
 
 		// Start with one existing entry
-		seedTaxonomy([
-			{ canonical_name: 'Existing Person', entity_type: 'person', status: 'auto' },
-		]);
+		seedTaxonomy([{ canonical_name: 'Existing Person', entity_type: 'person', status: 'auto' }]);
 
 		// Create a YAML with the existing entry plus a new one (no id)
 		const yamlContent = `person:
@@ -391,7 +391,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		// Status should be updated
 		const entry = getTaxonomyById(id);
 		expect(entry).not.toBeNull();
-		expect(entry!.status).toBe('confirmed');
+		expect(entry?.status).toBe('confirmed');
 
 		unlinkSync(inputPath);
 	});
@@ -399,9 +399,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 	it('QA-08: Merge renames canonical name', () => {
 		if (!pgAvailable) return;
 
-		const [id] = seedTaxonomy([
-			{ canonical_name: 'Old Name', entity_type: 'person', status: 'auto', aliases: ['ON'] },
-		]);
+		const [id] = seedTaxonomy([{ canonical_name: 'Old Name', entity_type: 'person', status: 'auto', aliases: ['ON'] }]);
 
 		// Create YAML with same ID but different canonical name
 		const yamlContent = `person:
@@ -421,7 +419,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		// canonical_name should be updated
 		const entry = getTaxonomyById(id);
 		expect(entry).not.toBeNull();
-		expect(entry!.canonical_name).toBe('New Renamed Name');
+		expect(entry?.canonical_name).toBe('New Renamed Name');
 
 		unlinkSync(inputPath);
 	});
@@ -454,11 +452,11 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		const entry = getTaxonomyById(id);
 		expect(entry).not.toBeNull();
 		// The aliases should contain the new ones
-		expect(entry!.aliases).toContain('NewAlias');
-		expect(entry!.aliases).toContain('AnotherNew');
-		expect(entry!.aliases).toContain('AP');
+		expect(entry?.aliases).toContain('NewAlias');
+		expect(entry?.aliases).toContain('AnotherNew');
+		expect(entry?.aliases).toContain('AP');
 		// OldAlias should be gone (replaced, not merged)
-		expect(entry!.aliases).not.toContain('OldAlias');
+		expect(entry?.aliases).not.toContain('OldAlias');
 
 		unlinkSync(inputPath);
 	});
@@ -575,7 +573,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		// Database should NOT be modified
 		const entry = getTaxonomyById(id);
 		expect(entry).not.toBeNull();
-		expect(entry!.status).toBe('auto'); // Still auto, not confirmed
+		expect(entry?.status).toBe('auto'); // Still auto, not confirmed
 
 		unlinkSync(inputPath);
 	});
@@ -609,7 +607,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 	it('QA-14: Merge is transactional', () => {
 		if (!pgAvailable) return;
 
-		const [id1] = seedTaxonomy([
+		const [_id1] = seedTaxonomy([
 			{ canonical_name: 'Txn Person 1', entity_type: 'person', status: 'auto' },
 			{ canonical_name: 'Txn Person 2', entity_type: 'person', status: 'auto' },
 		]);
@@ -634,7 +632,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		writeFileSync(inputPath, yamlContent, 'utf-8');
 
 		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath]);
-		const combined = stdout + stderr;
+		const _combined = stdout + stderr;
 
 		// Should fail (duplicate canonical name within same type)
 		expect(exitCode).not.toBe(0);
@@ -697,9 +695,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 	it('CLI-02: `taxonomy export` (no flags) outputs YAML to stdout', () => {
 		if (!pgAvailable) return;
 
-		seedTaxonomy([
-			{ canonical_name: 'Stdout Person', entity_type: 'person', status: 'auto', aliases: ['SP'] },
-		]);
+		seedTaxonomy([{ canonical_name: 'Stdout Person', entity_type: 'person', status: 'auto', aliases: ['SP'] }]);
 
 		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'export']);
 		expect(exitCode, `Export failed: ${stderr}`).toBe(0);
@@ -729,9 +725,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 	it('CLI-04: `taxonomy export --output` writes to file', () => {
 		if (!pgAvailable) return;
 
-		seedTaxonomy([
-			{ canonical_name: 'CLI File Person', entity_type: 'person', status: 'auto' },
-		]);
+		seedTaxonomy([{ canonical_name: 'CLI File Person', entity_type: 'person', status: 'auto' }]);
 
 		const outputPath = resolve(TMP_DIR, 'cli-export-test.yaml');
 
@@ -757,9 +751,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 	it('CLI-06: `taxonomy merge --dry-run` shows preview without changes', () => {
 		if (!pgAvailable) return;
 
-		const [id] = seedTaxonomy([
-			{ canonical_name: 'CLI DryRun', entity_type: 'person', status: 'auto' },
-		]);
+		const [id] = seedTaxonomy([{ canonical_name: 'CLI DryRun', entity_type: 'person', status: 'auto' }]);
 
 		const yamlContent = `person:
   - id: "${id}"
@@ -776,7 +768,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 
 		// Database should not be modified
 		const entry = getTaxonomyById(id);
-		expect(entry!.status).toBe('auto');
+		expect(entry?.status).toBe('auto');
 
 		unlinkSync(inputPath);
 	});
@@ -784,9 +776,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 	it('CLI-07: `taxonomy merge --input custom.yaml` reads from custom path', () => {
 		if (!pgAvailable) return;
 
-		const [id] = seedTaxonomy([
-			{ canonical_name: 'Custom Path Person', entity_type: 'person', status: 'auto' },
-		]);
+		const [id] = seedTaxonomy([{ canonical_name: 'Custom Path Person', entity_type: 'person', status: 'auto' }]);
 
 		const customPath = resolve(TMP_DIR, 'custom-merge-path.yaml');
 		const yamlContent = `person:
@@ -803,7 +793,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 		// Verify the entry was updated
 		const entry = getTaxonomyById(id);
 		expect(entry).not.toBeNull();
-		expect(entry!.status).toBe('confirmed');
+		expect(entry?.status).toBe('confirmed');
 
 		unlinkSync(customPath);
 	});
@@ -840,7 +830,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 	it('SMOKE-02: `taxonomy export` with empty taxonomy produces valid output', () => {
 		if (!pgAvailable) return;
 
-		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
+		const { exitCode } = runCli(['taxonomy', 'export']);
 
 		// Should succeed even with no entries
 		expect(exitCode).toBe(0);
@@ -913,9 +903,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 	it('SMOKE-08: `taxonomy export --type nonexistent_type` returns empty output gracefully', () => {
 		if (!pgAvailable) return;
 
-		seedTaxonomy([
-			{ canonical_name: 'Person Z', entity_type: 'person', status: 'auto' },
-		]);
+		seedTaxonomy([{ canonical_name: 'Person Z', entity_type: 'person', status: 'auto' }]);
 
 		const { exitCode, stdout } = runCli(['taxonomy', 'export', '--type', 'nonexistent_type']);
 
@@ -948,9 +936,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 	it('SMOKE-10: `taxonomy merge --dry-run --input` combined flags work', () => {
 		if (!pgAvailable) return;
 
-		const [id] = seedTaxonomy([
-			{ canonical_name: 'Combo Merge Person', entity_type: 'person', status: 'auto' },
-		]);
+		const [id] = seedTaxonomy([{ canonical_name: 'Combo Merge Person', entity_type: 'person', status: 'auto' }]);
 
 		const yamlContent = `person:
   - id: "${id}"
@@ -966,7 +952,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 
 		// Database should remain unchanged
 		const entry = getTaxonomyById(id);
-		expect(entry!.status).toBe('auto');
+		expect(entry?.status).toBe('auto');
 
 		unlinkSync(inputPath);
 	});
@@ -1005,7 +991,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 		// 1. Try to export first (creating the file), then fail on editor
 		// 2. Fail gracefully
 		// We just verify it doesn't hang forever (timeout handles that)
-		const combined = stdout + stderr;
+		const _combined = stdout + stderr;
 		// It ran to completion without hanging
 		expect(typeof exitCode).toBe('number');
 	});
@@ -1013,9 +999,7 @@ describe('CLI Smoke Tests: taxonomy export/curate/merge', () => {
 	it('SMOKE-13: Export YAML includes comment header', () => {
 		if (!pgAvailable) return;
 
-		seedTaxonomy([
-			{ canonical_name: 'Header Test', entity_type: 'person', status: 'auto' },
-		]);
+		seedTaxonomy([{ canonical_name: 'Header Test', entity_type: 'person', status: 'auto' }]);
 
 		const { exitCode, stdout } = runCli(['taxonomy', 'export']);
 		expect(exitCode).toBe(0);

--- a/tests/specs/51_entity_management_cli.test.ts
+++ b/tests/specs/51_entity_management_cli.test.ts
@@ -94,14 +94,13 @@ function seedEntity(opts: {
 	corroboration_score?: number | null;
 }): string {
 	const id = opts.id ?? randomUUID();
-	const canonicalId = opts.canonical_id !== undefined && opts.canonical_id !== null
-		? `'${opts.canonical_id}'`
-		: 'NULL';
+	const canonicalId = opts.canonical_id !== undefined && opts.canonical_id !== null ? `'${opts.canonical_id}'` : 'NULL';
 	const taxonomyStatus = opts.taxonomy_status ?? 'auto';
 	const sourceCount = opts.source_count ?? 0;
-	const corroborationScore = opts.corroboration_score !== undefined && opts.corroboration_score !== null
-		? `${opts.corroboration_score}`
-		: 'NULL';
+	const corroborationScore =
+		opts.corroboration_score !== undefined && opts.corroboration_score !== null
+			? `${opts.corroboration_score}`
+			: 'NULL';
 	runSql(
 		`INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, source_count, corroboration_score) ` +
 			`VALUES ('${id}', '${opts.name.replace(/'/g, "''")}', '${opts.type}', ${canonicalId}, '${taxonomyStatus}', ${sourceCount}, ${corroborationScore}) ` +
@@ -113,12 +112,7 @@ function seedEntity(opts: {
 /**
  * Insert an entity alias directly into the database.
  */
-function seedAlias(opts: {
-	id?: string;
-	entity_id: string;
-	alias: string;
-	source?: string;
-}): string {
+function seedAlias(opts: { id?: string; entity_id: string; alias: string; source?: string }): string {
 	const id = opts.id ?? randomUUID();
 	const source = opts.source ?? 'extraction';
 	runSql(
@@ -198,17 +192,17 @@ let pgAvailable = false;
 // Shared entity IDs
 let personEntityId: string;
 let locationEntityId: string;
-let personEntityId2: string;
+let _personEntityId2: string;
 let mergeTargetId: string;
 let mergeSourceId: string;
 let alreadyMergedEntityId: string;
 let aliasEntityId: string;
-let aliasId1: string;
+let _aliasId1: string;
 let aliasId2: string;
 let sourceId: string;
 let storyId: string;
 let storyId2: string;
-let edgeId: string;
+let _edgeId: string;
 
 // For merge JSON test — separate pair
 let mergeJsonTargetId: string;
@@ -230,16 +224,21 @@ beforeAll(() => {
 	storyId2 = seedStory({ source_id: sourceId, title: 'Sighting Report Beta' });
 
 	// Entities of different types
-	personEntityId = seedEntity({ name: 'Josef Allen Hynek', type: 'person', source_count: 3, corroboration_score: 0.85 });
+	personEntityId = seedEntity({
+		name: 'Josef Allen Hynek',
+		type: 'person',
+		source_count: 3,
+		corroboration_score: 0.85,
+	});
 	locationEntityId = seedEntity({ name: 'Area 51', type: 'location', source_count: 5 });
-	personEntityId2 = seedEntity({ name: 'Kenneth Arnold', type: 'person', source_count: 1 });
+	_personEntityId2 = seedEntity({ name: 'Kenneth Arnold', type: 'person', source_count: 1 });
 
 	// Entity for show command — with aliases, edges, stories
 	seedAlias({ entity_id: personEntityId, alias: 'J. Allen Hynek', source: 'extraction' });
 	seedAlias({ entity_id: personEntityId, alias: 'Dr. Hynek', source: 'manual' });
 	seedStoryEntity(storyId, personEntityId);
 	seedStoryEntity(storyId2, personEntityId);
-	edgeId = seedEdge({
+	_edgeId = seedEdge({
 		source_entity_id: personEntityId,
 		target_entity_id: locationEntityId,
 		relationship: 'INVESTIGATED_AT',
@@ -268,7 +267,7 @@ beforeAll(() => {
 
 	// Entity for alias management tests
 	aliasEntityId = seedEntity({ name: 'Alias Test Entity', type: 'organization' });
-	aliasId1 = seedAlias({ entity_id: aliasEntityId, alias: 'Alias One', source: 'extraction' });
+	_aliasId1 = seedAlias({ entity_id: aliasEntityId, alias: 'Alias One', source: 'extraction' });
 	aliasId2 = seedAlias({ entity_id: aliasEntityId, alias: 'Alias Two', source: 'manual' });
 
 	// Separate pair for merge --json test (since merge is destructive)
@@ -389,25 +388,19 @@ describe('QA Contract: Entity Management CLI', () => {
 
 	it('QA-08: entity merge — success', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli(['entity', 'merge', mergeTargetId, mergeSourceId]);
+		const { exitCode } = runCli(['entity', 'merge', mergeTargetId, mergeSourceId]);
 		expect(exitCode).toBe(0);
 
 		// Verify source entity now has canonical_id = target
-		const canonicalId = runSql(
-			`SELECT canonical_id FROM entities WHERE id = '${mergeSourceId}';`,
-		);
+		const canonicalId = runSql(`SELECT canonical_id FROM entities WHERE id = '${mergeSourceId}';`);
 		expect(canonicalId).toBe(mergeTargetId);
 
 		// Verify source entity has taxonomy_status = 'merged'
-		const taxonomyStatus = runSql(
-			`SELECT taxonomy_status FROM entities WHERE id = '${mergeSourceId}';`,
-		);
+		const taxonomyStatus = runSql(`SELECT taxonomy_status FROM entities WHERE id = '${mergeSourceId}';`);
 		expect(taxonomyStatus).toBe('merged');
 
 		// Verify story_entities were reassigned to target
-		const storyEntityCount = runSql(
-			`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${mergeTargetId}';`,
-		);
+		const storyEntityCount = runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${mergeTargetId}';`);
 		expect(Number(storyEntityCount)).toBeGreaterThanOrEqual(1);
 
 		// Verify source name is now an alias on target
@@ -466,7 +459,7 @@ describe('QA Contract: Entity Management CLI', () => {
 
 	it('QA-13: entity aliases — add', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--add', 'New Test Alias']);
+		const { exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--add', 'New Test Alias']);
 		expect(exitCode).toBe(0);
 
 		// Verify alias was created with source 'manual'
@@ -479,13 +472,11 @@ describe('QA Contract: Entity Management CLI', () => {
 	it('QA-14: entity aliases — remove', () => {
 		if (!pgAvailable) return;
 		// Remove aliasId2
-		const { stdout, exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--remove', aliasId2]);
+		const { exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--remove', aliasId2]);
 		expect(exitCode).toBe(0);
 
 		// Verify alias was deleted
-		const count = runSql(
-			`SELECT COUNT(*) FROM entity_aliases WHERE id = '${aliasId2}';`,
-		);
+		const count = runSql(`SELECT COUNT(*) FROM entity_aliases WHERE id = '${aliasId2}';`);
 		expect(Number(count)).toBe(0);
 	});
 
@@ -605,7 +596,7 @@ describe('CLI Smoke Tests: Entity Management CLI', () => {
 	});
 
 	it('SMOKE-06: entity merge with missing second argument gives error', () => {
-		const { stdout, stderr, exitCode } = runCli(['entity', 'merge', randomUUID()]);
+		const { exitCode } = runCli(['entity', 'merge', randomUUID()]);
 		// Commander.js should reject this — missing required argument
 		expect(exitCode).not.toBe(0);
 	});
@@ -623,7 +614,7 @@ describe('CLI Smoke Tests: Entity Management CLI', () => {
 	it('SMOKE-08: entity aliases with nonexistent entity ID gives error', () => {
 		if (!pgAvailable) return;
 		const fakeId = randomUUID();
-		const { stdout, stderr, exitCode } = runCli(['entity', 'aliases', fakeId]);
+		const { exitCode } = runCli(['entity', 'aliases', fakeId]);
 		// This may return empty list or error — depends on implementation
 		// At minimum it should not crash (exit 0 or 1 with meaningful output)
 		expect(exitCode === 0 || exitCode === 1).toBe(true);
@@ -632,7 +623,7 @@ describe('CLI Smoke Tests: Entity Management CLI', () => {
 	it('SMOKE-09: entity aliases --remove with nonexistent alias ID gives error', () => {
 		if (!pgAvailable) return;
 		const fakeAliasId = randomUUID();
-		const { stdout, stderr, exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--remove', fakeAliasId]);
+		const { exitCode } = runCli(['entity', 'aliases', aliasEntityId, '--remove', fakeAliasId]);
 		// Should handle gracefully — either error or no-op
 		expect(exitCode === 0 || exitCode === 1).toBe(true);
 	});

--- a/tests/specs/53_export_commands.test.ts
+++ b/tests/specs/53_export_commands.test.ts
@@ -138,14 +138,11 @@ function seedEntity(opts: {
 	corroboration_score?: number | null;
 }): string {
 	const id = opts.id ?? randomUUID();
-	const canonicalId =
-		opts.canonical_id !== undefined && opts.canonical_id !== null ? `'${opts.canonical_id}'` : 'NULL';
+	const canonicalId = opts.canonical_id !== undefined && opts.canonical_id !== null ? `'${opts.canonical_id}'` : 'NULL';
 	const taxonomyStatus = opts.taxonomy_status ?? 'auto';
 	const sourceCount = opts.source_count ?? 0;
 	const corroborationScore =
-		opts.corroboration_score !== undefined && opts.corroboration_score !== null
-			? opts.corroboration_score
-			: 'NULL';
+		opts.corroboration_score !== undefined && opts.corroboration_score !== null ? opts.corroboration_score : 'NULL';
 	runSql(
 		`INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, source_count, corroboration_score) ` +
 			`VALUES ('${id}', '${opts.name.replace(/'/g, "''")}', '${opts.type}', ${canonicalId}, '${taxonomyStatus}', ${sourceCount}, ${corroborationScore}) ` +
@@ -166,8 +163,7 @@ function seedEdge(opts: {
 	const id = opts.id ?? randomUUID();
 	const storyId = opts.story_id ? `'${opts.story_id}'` : 'NULL';
 	const edgeType = opts.edge_type ?? 'RELATIONSHIP';
-	const confidence =
-		opts.confidence !== undefined && opts.confidence !== null ? opts.confidence : 'NULL';
+	const confidence = opts.confidence !== undefined && opts.confidence !== null ? opts.confidence : 'NULL';
 	runSql(
 		`INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, story_id, edge_type, confidence) ` +
 			`VALUES ('${id}', '${opts.source_entity_id}', '${opts.target_entity_id}', '${opts.relationship}', ${storyId}, '${edgeType}', ${confidence}) ` +
@@ -197,11 +193,7 @@ function seedAlias(opts: { id?: string; entity_id: string; alias: string; source
 	return id;
 }
 
-function seedStoryEntity(opts: {
-	story_id: string;
-	entity_id: string;
-	mention_count?: number;
-}): void {
+function seedStoryEntity(opts: { story_id: string; entity_id: string; mention_count?: number }): void {
 	const mentionCount = opts.mention_count ?? 1;
 	runSql(
 		`INSERT INTO story_entities (story_id, entity_id, mention_count) ` +
@@ -406,9 +398,7 @@ describe('QA Contract: Export Commands', () => {
 
 	it('QA-05: Graph filter by type — only matching entity type appears', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli([
-			'export', 'graph', '--filter', 'type=person', '--format', 'json',
-		]);
+		const { stdout, exitCode } = runCli(['export', 'graph', '--filter', 'type=person', '--format', 'json']);
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		// All nodes should be type person
@@ -423,9 +413,7 @@ describe('QA Contract: Export Commands', () => {
 
 	it('QA-06: Graph filter by edge type — only matching edge type appears', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli([
-			'export', 'graph', '--filter', 'edge=RELATIONSHIP', '--format', 'json',
-		]);
+		const { stdout, exitCode } = runCli(['export', 'graph', '--filter', 'edge=RELATIONSHIP', '--format', 'json']);
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		// All edges should be RELATIONSHIP type
@@ -433,9 +421,7 @@ describe('QA Contract: Export Commands', () => {
 			expect(edge.edgeType).toBe('RELATIONSHIP');
 		}
 		// Should not contain DUPLICATE_OF or POTENTIAL_CONTRADICTION
-		const nonRelEdges = parsed.edges.filter(
-			(e: { edgeType: string }) => e.edgeType !== 'RELATIONSHIP',
-		);
+		const nonRelEdges = parsed.edges.filter((e: { edgeType: string }) => e.edgeType !== 'RELATIONSHIP');
 		expect(nonRelEdges.length).toBe(0);
 	});
 
@@ -483,9 +469,7 @@ describe('QA Contract: Export Commands', () => {
 
 	it('QA-10: Stories filter by source — only stories from that source', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli([
-			'export', 'stories', '--source', sourceId1, '--format', 'json',
-		]);
+		const { stdout, exitCode } = runCli(['export', 'stories', '--source', sourceId1, '--format', 'json']);
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		expect(parsed.stories.length).toBeGreaterThan(0);
@@ -614,27 +598,21 @@ describe('CLI Test Matrix: Export Commands', () => {
 		const { exitCode, stderr, stdout } = runCli(['export', 'graph', '--format', 'invalid']);
 		expect(exitCode).not.toBe(0);
 		const combined = (stderr + stdout).toLowerCase();
-		expect(
-			combined.includes('json') || combined.includes('format') || combined.includes('invalid'),
-		).toBe(true);
+		expect(combined.includes('json') || combined.includes('format') || combined.includes('invalid')).toBe(true);
 	});
 
 	it('CLI-05: export stories --format invalid — exit code 1, error about valid formats', () => {
 		const { exitCode, stderr, stdout } = runCli(['export', 'stories', '--format', 'invalid']);
 		expect(exitCode).not.toBe(0);
 		const combined = (stderr + stdout).toLowerCase();
-		expect(
-			combined.includes('json') || combined.includes('format') || combined.includes('invalid'),
-		).toBe(true);
+		expect(combined.includes('json') || combined.includes('format') || combined.includes('invalid')).toBe(true);
 	});
 
 	it('CLI-06: export evidence --format invalid — exit code 1, error about valid formats', () => {
 		const { exitCode, stderr, stdout } = runCli(['export', 'evidence', '--format', 'invalid']);
 		expect(exitCode).not.toBe(0);
 		const combined = (stderr + stdout).toLowerCase();
-		expect(
-			combined.includes('json') || combined.includes('format') || combined.includes('invalid'),
-		).toBe(true);
+		expect(combined.includes('json') || combined.includes('format') || combined.includes('invalid')).toBe(true);
 	});
 
 	it('CLI-07: export graph --format json — exit code 0, valid JSON', () => {
@@ -663,9 +641,7 @@ describe('CLI Test Matrix: Export Commands', () => {
 
 	it('CLI-10: export graph --filter type=person --format json — only person entities', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli([
-			'export', 'graph', '--filter', 'type=person', '--format', 'json',
-		]);
+		const { stdout, exitCode } = runCli(['export', 'graph', '--filter', 'type=person', '--format', 'json']);
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		expect(parsed.nodes.length).toBeGreaterThan(0);
@@ -676,9 +652,7 @@ describe('CLI Test Matrix: Export Commands', () => {
 
 	it('CLI-11: export graph --filter edge=DUPLICATE_OF --format json — only DUPLICATE_OF edges', () => {
 		if (!pgAvailable) return;
-		const { stdout, exitCode } = runCli([
-			'export', 'graph', '--filter', 'edge=DUPLICATE_OF', '--format', 'json',
-		]);
+		const { stdout, exitCode } = runCli(['export', 'graph', '--filter', 'edge=DUPLICATE_OF', '--format', 'json']);
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		for (const edge of parsed.edges) {
@@ -701,7 +675,7 @@ describe('CLI Smoke Tests: export', () => {
 	});
 
 	it('SMOKE-02: export with no subcommand shows help/usage', () => {
-		const { stdout, stderr, exitCode } = runCli(['export']);
+		const { stdout, stderr } = runCli(['export']);
 		// Commander outputs help to stderr when no subcommand is given
 		const combined = (stdout + stderr).toLowerCase();
 		expect(combined).toContain('graph');
@@ -752,7 +726,14 @@ describe('CLI Smoke Tests: export', () => {
 	it('SMOKE-10: export graph --filter with multiple filters', () => {
 		if (!pgAvailable) return;
 		const { exitCode } = runCli([
-			'export', 'graph', '--filter', 'type=person', '--filter', 'edge=RELATIONSHIP', '--format', 'json',
+			'export',
+			'graph',
+			'--filter',
+			'type=person',
+			'--filter',
+			'edge=RELATIONSHIP',
+			'--format',
+			'json',
 		]);
 		expect(exitCode).toBe(0);
 	});
@@ -769,9 +750,7 @@ describe('CLI Smoke Tests: export', () => {
 		expect(exitCode).toBe(0);
 		const parsed = JSON.parse(stdout);
 		// At least one entity should have aliases
-		const withAliases = parsed.nodes.filter(
-			(n: { aliases: string[] }) => n.aliases && n.aliases.length > 0,
-		);
+		const withAliases = parsed.nodes.filter((n: { aliases: string[] }) => n.aliases && n.aliases.length > 0);
 		expect(withAliases.length).toBeGreaterThan(0);
 	});
 

--- a/tests/specs/54_v2_schema_migrations.test.ts
+++ b/tests/specs/54_v2_schema_migrations.test.ts
@@ -1,0 +1,391 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ensureSchema } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+/**
+ * Black-box QA tests for Spec 54: v2.0 Schema Migrations (009-011)
+ *
+ * Each `it()` maps to one QA condition from Section 5 of the spec.
+ * Tests interact through system boundaries only: CLI subprocess calls,
+ * SQL via `docker exec psql`, and filesystem.
+ * Never import from packages/ or src/ or apps/.
+ *
+ * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * with pgvector, PostGIS, and pg_trgm extensions available.
+ */
+
+const PG_CONTAINER = 'mulder-pg-test';
+const PG_USER = 'mulder';
+const PG_PASSWORD = 'mulder';
+const MIGRATIONS_009_011 = ['009_entity_grounding.sql', '010_evidence_chains.sql', '011_spatio_temporal_clusters.sql'];
+
+/**
+ * Helper: run the CLI binary via node as a subprocess.
+ */
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 30_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+/**
+ * Helper: run SQL via docker exec psql. Returns query output.
+ */
+function runSql(sql: string): string {
+	const result = spawnSync(
+		'docker',
+		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
+		{ encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] },
+	);
+	if (result.status !== 0) {
+		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
+	}
+	return (result.stdout ?? '').trim();
+}
+
+function isPgAvailable(): boolean {
+	try {
+		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
+			encoding: 'utf-8',
+			timeout: 5_000,
+		});
+		return result.status === 0;
+	} catch {
+		return false;
+	}
+}
+
+function hasRequiredExtensions(): boolean {
+	try {
+		const out = runSql("SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');");
+		return Number.parseInt(out, 10) >= 3;
+	} catch {
+		return false;
+	}
+}
+
+function resetDatabase(): void {
+	const dropSql = [
+		'DROP FUNCTION IF EXISTS reset_pipeline_step CASCADE',
+		'DROP FUNCTION IF EXISTS gc_orphaned_entities CASCADE',
+		'DROP TABLE IF EXISTS pipeline_run_sources CASCADE',
+		'DROP TABLE IF EXISTS pipeline_runs CASCADE',
+		'DROP TABLE IF EXISTS jobs CASCADE',
+		'DROP TYPE IF EXISTS job_status CASCADE',
+		'DROP TABLE IF EXISTS chunks CASCADE',
+		'DROP TABLE IF EXISTS story_entities CASCADE',
+		'DROP TABLE IF EXISTS entity_edges CASCADE',
+		'DROP TABLE IF EXISTS entity_aliases CASCADE',
+		'DROP TABLE IF EXISTS taxonomy CASCADE',
+		'DROP TABLE IF EXISTS entities CASCADE',
+		'DROP TABLE IF EXISTS stories CASCADE',
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS source_steps CASCADE',
+		'DROP TABLE IF EXISTS sources CASCADE',
+		'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		'DROP INDEX IF EXISTS idx_entities_geom',
+		'DROP EXTENSION IF EXISTS vector CASCADE',
+		'DROP EXTENSION IF EXISTS postgis CASCADE',
+		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
+	].join('; ');
+
+	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
+		encoding: 'utf-8',
+		timeout: 15_000,
+	});
+}
+
+function migrationFilenames(): string[] {
+	const rows = runSql('SELECT filename FROM mulder_migrations ORDER BY filename;');
+	return rows.split('\n').filter(Boolean);
+}
+
+function migrationCount(): number {
+	return Number.parseInt(runSql('SELECT count(*) FROM mulder_migrations;'), 10);
+}
+
+function parseMigrationSummary(output: string): { applied?: number; skipped?: number; total?: number } | null {
+	const line = output.split('\n').find((entry) => entry.includes('"msg":"Migration run complete"'));
+	if (!line) {
+		return null;
+	}
+	try {
+		return JSON.parse(line);
+	} catch {
+		return null;
+	}
+}
+
+function prepareBackfilledDatabase(): void {
+	const cleanupSql = [
+		`DELETE FROM mulder_migrations WHERE filename IN ('${MIGRATIONS_009_011.join("', '")}')`,
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'ALTER TABLE entities DROP COLUMN IF EXISTS geom',
+		'DROP INDEX IF EXISTS idx_entities_geom',
+	].join('; ');
+
+	runSql(cleanupSql);
+}
+
+describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
+	let pgAvailable: boolean;
+	let extensionsAvailable: boolean;
+
+	beforeAll(() => {
+		pgAvailable = isPgAvailable();
+		if (!pgAvailable) {
+			console.warn(
+				'SKIP: PostgreSQL container not available. Start with:\n' +
+					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
+					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17\n' +
+					'  docker exec mulder-pg-test apt-get update && docker exec mulder-pg-test apt-get install -y postgresql-17-postgis-3',
+			);
+			return;
+		}
+
+		extensionsAvailable = hasRequiredExtensions();
+		if (!extensionsAvailable) {
+			console.warn('SKIP: Required extensions (pgvector, PostGIS, pg_trgm) not available in PostgreSQL container.');
+			return;
+		}
+
+		resetDatabase();
+
+		const { exitCode, stdout, stderr } = runCli(['db', 'migrate', EXAMPLE_CONFIG]);
+		if (exitCode !== 0) {
+			throw new Error(`Initial migration failed (exit ${exitCode}):\n${stdout}\n${stderr}`);
+		}
+	});
+
+	afterAll(() => {
+		if (pgAvailable && extensionsAvailable) {
+			resetDatabase();
+			try {
+				ensureSchema();
+			} catch {
+				// Downstream specs call ensureSchema() themselves; teardown must
+				// not throw.
+			}
+		}
+	});
+
+	function skipIfUnavailable(): boolean {
+		return !pgAvailable || !extensionsAvailable;
+	}
+
+	describe('QA-01: Fresh database applies the reserved v2.0 migrations in order', () => {
+		it('009-011 are recorded between 008_indexes.sql and 012_job_queue.sql', () => {
+			if (skipIfUnavailable()) return;
+
+			expect(migrationCount()).toBeGreaterThanOrEqual(18);
+
+			const filenames = migrationFilenames();
+			const start = filenames.indexOf('008_indexes.sql');
+			const end = filenames.indexOf('012_job_queue.sql');
+
+			expect(start).toBeGreaterThanOrEqual(0);
+			expect(end).toBeGreaterThan(start);
+			expect(filenames.slice(start, end + 1)).toEqual([
+				'008_indexes.sql',
+				'009_entity_grounding.sql',
+				'010_evidence_chains.sql',
+				'011_spatio_temporal_clusters.sql',
+				'012_job_queue.sql',
+			]);
+		});
+	});
+
+	describe('QA-02: Backfilled database accepts 009-011 after 012-018 already exist', () => {
+		it('only 009-011 are applied when the ledger already contains 001-008 and 012-018', () => {
+			if (skipIfUnavailable()) return;
+
+			prepareBackfilledDatabase();
+
+			const before = migrationFilenames();
+			expect(before).not.toContain('009_entity_grounding.sql');
+			expect(before).not.toContain('010_evidence_chains.sql');
+			expect(before).not.toContain('011_spatio_temporal_clusters.sql');
+			expect(before).toContain('012_job_queue.sql');
+
+			const { stdout, stderr, exitCode } = runCli(['db', 'migrate', EXAMPLE_CONFIG]);
+			const combined = stdout + stderr;
+
+			expect(exitCode).toBe(0);
+
+			const summary = parseMigrationSummary(combined);
+			if (summary) {
+				expect(summary.applied).toBe(3);
+			}
+
+			const after = migrationFilenames();
+			expect(after).toContain('009_entity_grounding.sql');
+			expect(after).toContain('010_evidence_chains.sql');
+			expect(after).toContain('011_spatio_temporal_clusters.sql');
+			expect(after).toContain('012_job_queue.sql');
+			expect(migrationCount()).toBeGreaterThanOrEqual(18);
+		});
+	});
+
+	describe('QA-03: Grounding cache schema matches the contract', () => {
+		it('entity_grounding has the expected columns and cascades on entity deletion', () => {
+			if (skipIfUnavailable()) return;
+
+			const columns = runSql(
+				"SELECT column_name FROM information_schema.columns WHERE table_name = 'entity_grounding' AND table_schema = 'public' ORDER BY ordinal_position;",
+			);
+			const colList = columns.split('\n').filter(Boolean);
+
+			const requiredColumns = ['id', 'entity_id', 'grounding_data', 'source_urls', 'grounded_at', 'expires_at'];
+			for (const col of requiredColumns) {
+				expect(colList, `Missing column: ${col}`).toContain(col);
+			}
+
+			const fkDeleteRule = runSql(
+				"SELECT rc.delete_rule FROM information_schema.table_constraints tc JOIN information_schema.referential_constraints rc ON tc.constraint_name = rc.constraint_name AND tc.constraint_schema = rc.constraint_schema WHERE tc.table_name = 'entity_grounding' AND tc.constraint_type = 'FOREIGN KEY';",
+			);
+			expect(fkDeleteRule).toContain('CASCADE');
+
+			const entityId = '00000000-0000-0000-0000-000000540301';
+			const groundingId = '00000000-0000-0000-0000-000000540302';
+
+			runSql(
+				[
+					`INSERT INTO entities (id, name, type) VALUES ('${entityId}', 'QA Grounding Entity', 'person')`,
+					`INSERT INTO entity_grounding (id, entity_id, grounding_data, source_urls, expires_at) VALUES ('${groundingId}', '${entityId}', '{"title":"Grounded"}'::jsonb, ARRAY['https://example.com/a'], now() + interval '1 day')`,
+				].join('; '),
+			);
+
+			expect(runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('1');
+			runSql(`DELETE FROM entities WHERE id = '${entityId}';`);
+			expect(runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('0');
+		});
+	});
+
+	describe('QA-04: Evidence chains schema matches the contract', () => {
+		it('evidence_chains matches the expected types and defaults', () => {
+			if (skipIfUnavailable()) return;
+
+			const columns = runSql(
+				"SELECT column_name FROM information_schema.columns WHERE table_name = 'evidence_chains' AND table_schema = 'public' ORDER BY ordinal_position;",
+			);
+			const colList = columns.split('\n').filter(Boolean);
+
+			for (const col of ['id', 'thesis', 'path', 'strength', 'supports', 'computed_at']) {
+				expect(colList, `Missing column: ${col}`).toContain(col);
+			}
+
+			const thesisType = runSql(
+				"SELECT data_type FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'thesis';",
+			);
+			expect(thesisType).toBe('text');
+
+			const pathType = runSql(
+				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'evidence_chains'::regclass AND a.attname = 'path';",
+			);
+			expect(pathType).toBe('uuid[]');
+
+			const strengthType = runSql(
+				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'evidence_chains'::regclass AND a.attname = 'strength';",
+			);
+			expect(strengthType).toBe('double precision');
+
+			const supportsType = runSql(
+				"SELECT data_type FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'supports';",
+			);
+			expect(supportsType).toBe('boolean');
+
+			const computedDefault = runSql(
+				"SELECT column_default FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'computed_at';",
+			);
+			expect(computedDefault.toLowerCase()).toMatch(/now\(\)|current_timestamp/);
+		});
+	});
+
+	describe('QA-05: Spatio-temporal schema includes cluster storage and entity geometry support', () => {
+		it('spatio_temporal_clusters, entities.geom, and idx_entities_geom match the contract', () => {
+			if (skipIfUnavailable()) return;
+
+			const columns = runSql(
+				"SELECT column_name FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND table_schema = 'public' ORDER BY ordinal_position;",
+			);
+			const colList = columns.split('\n').filter(Boolean);
+
+			for (const col of [
+				'id',
+				'center_lat',
+				'center_lng',
+				'time_start',
+				'time_end',
+				'event_count',
+				'event_ids',
+				'cluster_type',
+				'computed_at',
+			]) {
+				expect(colList, `Missing column: ${col}`).toContain(col);
+			}
+
+			const eventCountType = runSql(
+				"SELECT data_type FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND column_name = 'event_count';",
+			);
+			expect(eventCountType).toBe('integer');
+
+			const eventIdsType = runSql(
+				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'spatio_temporal_clusters'::regclass AND a.attname = 'event_ids';",
+			);
+			expect(eventIdsType).toBe('uuid[]');
+
+			const computedDefault = runSql(
+				"SELECT column_default FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND column_name = 'computed_at';",
+			);
+			expect(computedDefault.toLowerCase()).toMatch(/now\(\)|current_timestamp/);
+
+			const geomType = runSql(
+				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'entities'::regclass AND a.attname = 'geom';",
+			).replace(/\s+/g, '');
+			expect(geomType).toBe('geometry(Point,4326)');
+
+			const geomIndex = runSql(
+				"SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_entities_geom';",
+			);
+			expect(geomIndex.toLowerCase()).toContain('using gist');
+			expect(geomIndex.toLowerCase()).toContain('(geom)');
+		});
+	});
+
+	describe('QA-06: Re-running migrations is idempotent after 009-011 are installed', () => {
+		it('db migrate reports no newly applied migrations on a second run', () => {
+			if (skipIfUnavailable()) return;
+
+			const { stdout, stderr, exitCode } = runCli(['db', 'migrate', EXAMPLE_CONFIG]);
+			const combined = stdout + stderr;
+
+			expect(exitCode).toBe(0);
+			const summary = parseMigrationSummary(combined);
+			if (summary) {
+				expect(summary.applied).toBe(0);
+			}
+			expect(combined.toLowerCase()).toMatch(/up to date|applied 0|0.*applied|no pending migrations/);
+		});
+	});
+});


### PR DESCRIPTION
Adds the reserved v2.0 schema migrations for grounding, evidence chains, and spatio-temporal clusters.

Closes #139