### PR TITLE
[DB] Move DB-backed specs to env-driven PostgreSQL harness

### DIFF
--- a/docs/specs/55_portable_db_test_harness_foundation.spec.md
+++ b/docs/specs/55_portable_db_test_harness_foundation.spec.md
@@ -1,0 +1,85 @@
+---
+spec: "55"
+title: "Portable Env-Driven DB Test Harness Foundation"
+roadmap_step: ""
+functional_spec: []
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/141"
+created: 2026-04-12
+---
+
+# Spec 55: Portable Env-Driven DB Test Harness Foundation
+
+## 1. Objective
+
+Replace the hardcoded Docker-container test harness with a shared, environment-driven PostgreSQL access layer for black-box spec tests. Issue `#141` exists because CI exposes Postgres on `localhost:5432`, while many tests still depend on `docker exec mulder-pg-test`, causing silent skips instead of real failures.
+
+## 2. Boundaries
+
+- **Roadmap Step:** N/A — off-roadmap bug fix tracked by Issue `#141`
+- **Target:** `tests/lib/db.ts`, `tests/lib/schema.ts`, `.github/workflows/ci.yml`, and any small helper adjustments needed to make DB-backed spec tests consume one shared env-driven access path
+- **In scope:** shared `runSql()` and `isPgAvailable()` helpers, canonical PG env defaults for local runs, helper support for `psql` and `pg_isready`, and migration of existing helper code to the shared path
+- **Out of scope:** changing product code under `packages/` or `apps/`, changing roadmap state, rewriting spec assertions unrelated to DB portability, and broad documentation cleanup outside what is needed to explain the harness contract
+- **Constraints:** preserve black-box testing boundaries, keep local and CI DB access identical, and surface database connectivity problems as test failures or explicit skips with actionable reasons
+
+## 3. Dependencies
+
+- **Requires:** the current CLI build/test flow, GitHub Actions Postgres service env vars, and the existing black-box spec suite layout under `tests/specs/`
+- **Blocks:** Spec 56 and Spec 57, which migrate the individual suites to this shared harness
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`tests/lib/db.ts`** — exports the shared PostgreSQL test harness primitives: connection env defaults, `runSql()`, `runSqlSafe()`, `isPgAvailable()`, and any small helpers needed by spec suites without importing product code
+2. **`tests/lib/schema.ts`** — aligns the schema bootstrap helper with the shared PG env defaults so migrations and SQL helpers use the same host/port/user/database path
+3. **`.github/workflows/ci.yml`** — keeps the CI job on the same env-driven path used locally and removes any remaining assumptions that spec tests must reach Postgres through a fixed container name
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None.
+
+### 4.4 Integration Points
+
+- All DB-backed spec suites import the shared helper instead of defining their own container-specific SQL utilities
+- CI exports `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, and `PGDATABASE` so spec tests and the CLI use the same database endpoint
+- Any suite-specific resets or seed helpers continue to issue raw SQL, but through the shared host-based helper
+
+### 4.5 Implementation Phases
+
+**Phase 1: Shared helper extraction**
+- add `tests/lib/db.ts`
+- move reusable SQL execution and availability checks behind one env-driven API
+
+**Phase 2: Harness alignment**
+- update `tests/lib/schema.ts` and any shared call sites to use the same env contract
+- confirm CI setup still provisions the required extensions and reachable database endpoint
+
+## 5. QA Contract
+
+1. **QA-01: Shared helper reaches PostgreSQL through environment variables**
+   - Given: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, and `PGDATABASE` point at a running local PostgreSQL instance
+   - When: a DB-backed spec suite uses the shared harness to run a trivial SQL query
+   - Then: the query succeeds without requiring `docker exec` or a named container
+
+2. **QA-02: Availability checks use the same path as SQL execution**
+   - Given: the same PostgreSQL env vars are configured
+   - When: the harness checks database readiness before a suite runs
+   - Then: the readiness result matches the actual ability to execute SQL against that database
+
+3. **QA-03: CI and local runs share one database access contract**
+   - Given: the repository test workflow on GitHub Actions and a local run both provide PG env vars
+   - When: DB-backed spec tests execute
+   - Then: both environments connect through the same host/port/user/database settings rather than container-name assumptions
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+None — this work changes only local/CI test infrastructure.

--- a/docs/specs/56_portable_db_harness_core_pipeline_suites.spec.md
+++ b/docs/specs/56_portable_db_harness_core_pipeline_suites.spec.md
@@ -1,0 +1,93 @@
+---
+spec: "56"
+title: "Portable DB Harness Migration for Core Pipeline Spec Suites"
+roadmap_step: ""
+functional_spec: []
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/141"
+created: 2026-04-12
+---
+
+# Spec 56: Portable DB Harness Migration for Core Pipeline Spec Suites
+
+## 1. Objective
+
+Migrate the core database and pipeline black-box suites from hardcoded `mulder-pg-test` access to the shared env-driven harness so the same tests execute both locally and in CI. This covers the foundational and early-pipeline spec tests whose current skip behavior can hide schema, migration, and orchestration regressions.
+
+## 2. Boundaries
+
+- **Roadmap Step:** N/A — off-roadmap bug fix tracked by Issue `#141`
+- **Target:** `tests/specs/07_database_client_migration_runner.test.ts`, `08_core_schema_migrations.test.ts`, `09_job_queue_pipeline_tracking_migrations.test.ts`, `12_docker_compose.test.ts`, `14_source_repository.test.ts`, `16_ingest_step.test.ts`, `19_extract_step.test.ts`, `22_pdf_metadata_extraction.test.ts`, `23_segment_step.test.ts`, `29_enrich_step.test.ts`, `30_cascading_reset_function.test.ts`, `33_qa_schema_conformance.test.ts`, `34_embed_step.test.ts`, `34_qa_status_state_machine.test.ts`, `35_graph_step.test.ts`, `35_qa_cascading_reset.test.ts`, and `36_qa_pipeline_integration.test.ts`
+- **In scope:** replacing suite-local `docker exec` SQL helpers, removing hardcoded `PG_CONTAINER` checks, updating skip messaging to reference env-driven setup, and keeping each suite’s existing black-box assertions intact
+- **Out of scope:** retrieval-era suites covered by Spec 57, product-code behavior changes, and non-DB fixture refactors unless they are required to keep the migrated suites passing
+- **Constraints:** preserve suite intent and black-box boundaries, avoid changing asserted behavior except where the old harness caused false skips, and keep fresh-database reset paths working through host-based SQL access
+
+## 3. Dependencies
+
+- **Requires:** Spec 55
+- **Blocks:** completion of Issue `#141` because these suites include the migration/schema paths most likely to expose newly visible clean-slate failures
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **Core migration suites** — `tests/specs/07_*.test.ts`, `08_*.test.ts`, `09_*.test.ts`, and `33_*.test.ts` must run schema inspection and reset SQL through the shared helper
+2. **Repository + pipeline suites** — `tests/specs/14_*.test.ts`, `16_*.test.ts`, `19_*.test.ts`, `22_pdf_metadata_extraction.test.ts`, `23_*.test.ts`, `29_*.test.ts`, `30_*.test.ts`, `34_*.test.ts`, `35_*.test.ts`, and `36_qa_pipeline_integration.test.ts` must consume the shared helper while preserving their existing seed/reset flows
+3. **`tests/specs/12_docker_compose.test.ts`** — keep direct Docker orchestration where the spec intentionally tests Docker Compose, but make SQL access itself portable and independent from a fixed test-container name when possible
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None.
+
+### 4.4 Integration Points
+
+- Suite-local cleanup/reset helpers now call shared SQL execution
+- Fresh-database migration verification still exercises the real CLI and schema, but no longer depends on container discovery
+- Any suite that still needs Docker for non-SQL orchestration remains explicit about that boundary
+
+### 4.5 Implementation Phases
+
+**Phase 1: Foundation + migration suites**
+- migrate specs `07`, `08`, `09`, and `33`
+- confirm reset and schema introspection still work on a clean database
+
+**Phase 2: Core pipeline suites**
+- migrate specs `14`, `16`, `19`, `22`, `23`, `29`, `30`, `34`, `35`, and `36`
+- normalize skip/setup messaging around env-driven PostgreSQL access
+
+**Phase 3: Docker-compose edge**
+- adjust spec `12` only as needed so SQL assertions no longer rely on a hardcoded standalone test container when running in CI
+
+## 5. QA Contract
+
+1. **QA-01: Core migration suites no longer rely on `docker exec`**
+   - Given: the migrated core suite files are present in the repository
+   - When: their source is inspected
+   - Then: they contain no SQL execution path that shells out to `docker exec ... psql`
+
+2. **QA-02: Fresh-database migration tests execute through the shared harness**
+   - Given: PostgreSQL is reachable through the standard PG env vars
+   - When: the migrated migration/schema suites run
+   - Then: they execute their reset, migrate, and schema-inspection checks against that host-based database instead of silently skipping on CI
+
+3. **QA-03: Core pipeline suites exercise the same DB path in local and CI runs**
+   - Given: the CLI is built and PostgreSQL env vars point to a running database
+   - When: representative pipeline suites from this spec run
+   - Then: their setup, seed, and assertion SQL all succeed through the env-driven harness
+
+4. **QA-04: Newly exposed clean-slate failures are explicit**
+   - Given: a migrated suite hits a real schema or migration problem on a fresh database
+   - When: the suite runs
+   - Then: the failure is reported as a real test failure or surfaced follow-up issue, not masked by a false “database unavailable” skip
+
+## 5b. CLI Test Matrix
+
+N/A — this step changes spec-test infrastructure, not CLI surface area.
+
+## 6. Cost Considerations
+
+None — this work changes only local/CI test infrastructure.

--- a/docs/specs/57_portable_db_harness_retrieval_cli_suites.spec.md
+++ b/docs/specs/57_portable_db_harness_retrieval_cli_suites.spec.md
@@ -1,0 +1,94 @@
+---
+spec: "57"
+title: "Portable DB Harness Migration for Retrieval and CLI Spec Suites"
+roadmap_step: ""
+functional_spec: []
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/141"
+created: 2026-04-12
+---
+
+# Spec 57: Portable DB Harness Migration for Retrieval and CLI Spec Suites
+
+## 1. Objective
+
+Migrate the retrieval-era, taxonomy, export, v2.0 migration, and CLI smoke suites from hardcoded Docker-container assumptions to the shared env-driven database harness. These suites represent the largest remaining false-green surface in CI because many of them currently skip when `mulder-pg-test` is not present.
+
+## 2. Boundaries
+
+- **Roadmap Step:** N/A — off-roadmap bug fix tracked by Issue `#141`
+- **Target:** `tests/cli-smoke.test.ts`, `tests/specs/37_vector_search_retrieval.test.ts`, `38_fulltext_search_retrieval.test.ts`, `39_graph_traversal_retrieval.test.ts`, `42_hybrid_retrieval_orchestrator.test.ts`, `44_e2e_pipeline_integration.test.ts`, `46_taxonomy_bootstrap.test.ts`, `47_document_ai_extraction.test.ts`, `48_layout_to_markdown.test.ts`, `49_mulder_show_command.test.ts`, `50_taxonomy_export_curate_merge.test.ts`, `51_entity_management_cli.test.ts`, `52_status_overview.test.ts`, `53_export_commands.test.ts`, and `54_v2_schema_migrations.test.ts`
+- **In scope:** removing suite-local container-name assumptions, reusing the shared SQL/availability helpers, keeping retrieval seed/setup logic intact, and updating CLI smoke checks so DB-dependent paths reflect the env-driven contract
+- **Out of scope:** core pipeline suites covered by Spec 56, product-code behavior changes, and non-DB smoke scenarios that already work in CI
+- **Constraints:** preserve black-box boundaries, keep retrieval suites deterministic, and avoid weakening assertions just to accommodate the harness migration
+
+## 3. Dependencies
+
+- **Requires:** Spec 55
+- **Blocks:** completion of Issue `#141` because the retrieval, CLI, export, and v2.0 suites account for the remaining CI blind spots after the core-pipeline migration
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **Retrieval suites** — `tests/specs/37_*.test.ts`, `38_*.test.ts`, `39_*.test.ts`, and `42_*.test.ts` must seed/query PostgreSQL through the shared host-based helper
+2. **End-to-end + taxonomy/export suites** — `tests/specs/44_*.test.ts`, `46_*.test.ts`, `47_*.test.ts`, `48_*.test.ts`, `49_*.test.ts`, `50_*.test.ts`, `51_*.test.ts`, `52_*.test.ts`, `53_*.test.ts`, and `54_*.test.ts` must replace hardcoded container checks with the shared env-driven readiness path
+3. **`tests/cli-smoke.test.ts`** — the global smoke suite must use the same readiness helper as the spec suites for DB-dependent command groups
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None.
+
+### 4.4 Integration Points
+
+- Retrieval seeding and cleanup helpers continue to use raw SQL, now through the shared helper
+- E2E and export suites still exercise the real CLI and filesystem boundaries, but with portable DB access
+- CLI smoke tests align their DB availability gating with the same readiness logic used by the spec suites
+
+### 4.5 Implementation Phases
+
+**Phase 1: Retrieval suites**
+- migrate specs `37`, `38`, `39`, and `42`
+- preserve deterministic setup and JSON-output assertions
+
+**Phase 2: End-to-end and management suites**
+- migrate specs `44`, `46`, `47`, `48`, `49`, `50`, `51`, `52`, `53`, and `54`
+- keep their seed/reset logic and user-visible assertions stable
+
+**Phase 3: Global smoke alignment**
+- migrate `tests/cli-smoke.test.ts`
+- ensure DB-dependent smoke tests skip only when the env-driven database is genuinely unavailable
+
+## 5. QA Contract
+
+1. **QA-01: Retrieval and management suites no longer depend on `mulder-pg-test`**
+   - Given: the migrated suite files are present in the repository
+   - When: their source is inspected
+   - Then: they contain no hardcoded `mulder-pg-test` dependency for SQL execution or readiness gating
+
+2. **QA-02: Retrieval-era suites execute through host-based PostgreSQL access**
+   - Given: PostgreSQL is reachable through the standard PG env vars
+   - When: representative retrieval suites from this spec run
+   - Then: their seed, query, and cleanup SQL executes through the shared env-driven harness
+
+3. **QA-03: CLI smoke DB gating matches the real database path**
+   - Given: the CLI is built and the shared PG env vars point at a running database
+   - When: DB-dependent smoke tests execute
+   - Then: they use the same readiness result as the spec suites instead of a container-name heuristic
+
+4. **QA-04: CI no longer silently skips the remaining DB-backed suites because of container naming**
+   - Given: GitHub Actions provisions PostgreSQL as a service container with a dynamic name
+   - When: the migrated suites run in CI
+   - Then: any failures are real behavior failures, not false skips caused by the missing `mulder-pg-test` container name
+
+## 5b. CLI Test Matrix
+
+N/A — this step changes spec-test infrastructure, not CLI surface area.
+
+## 6. Cost Considerations
+
+None — this work changes only local/CI test infrastructure.

--- a/tests/cli-smoke.test.ts
+++ b/tests/cli-smoke.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import * as db from './lib/db.js';
 
 /**
  * CLI Smoke Tests — mechanical "does it crash" tests for all CLI commands.
@@ -18,10 +19,6 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -35,7 +32,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 15000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -56,19 +53,7 @@ try {
 	/* CLI not built */
 }
 
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
-const _pgAvailable = isPgAvailable();
+const _pgAvailable = db.isPgAvailable();
 
 // ===========================================================================
 // 1. Top-Level CLI

--- a/tests/lib/db-runner.mjs
+++ b/tests/lib/db-runner.mjs
@@ -1,0 +1,101 @@
+import pg from 'pg';
+
+const PGHOST = process.env.PGHOST ?? 'localhost';
+const PGPORT = Number.parseInt(process.env.PGPORT ?? '5432', 10);
+const PGUSER = process.env.PGUSER ?? 'mulder';
+const PGPASSWORD = process.env.PGPASSWORD ?? 'mulder';
+const PGDATABASE = process.env.PGDATABASE ?? 'mulder';
+
+function formatArrayValue(value) {
+	if (value === null || value === undefined) {
+		return 'NULL';
+	}
+	if (Array.isArray(value)) {
+		return `{${value.map(formatArrayValue).join(',')}}`;
+	}
+	if (typeof value === 'string') {
+		if (/[{}",\\\s]/.test(value)) {
+			return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+		}
+		return value;
+	}
+	if (typeof value === 'boolean') {
+		return value ? 't' : 'f';
+	}
+	if (value instanceof Date) {
+		return value.toISOString();
+	}
+	if (typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+	return String(value);
+}
+
+function formatField(value) {
+	if (value === null || value === undefined) {
+		return '';
+	}
+	if (Array.isArray(value)) {
+		return `{${value.map(formatArrayValue).join(',')}}`;
+	}
+	if (typeof value === 'boolean') {
+		return value ? 't' : 'f';
+	}
+	if (value instanceof Date) {
+		return value.toISOString();
+	}
+	if (Buffer.isBuffer(value)) {
+		return value.toString('utf8');
+	}
+	if (typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+	return String(value);
+}
+
+function normalizeResult(result) {
+	if (Array.isArray(result)) {
+		return result[result.length - 1] ?? null;
+	}
+	return result;
+}
+
+const client = new pg.Client({
+	host: PGHOST,
+	port: PGPORT,
+	user: PGUSER,
+	password: PGPASSWORD,
+	database: PGDATABASE,
+});
+
+try {
+	await client.connect();
+
+	const command = process.argv[2];
+	if (command === 'ready') {
+		await client.query('SELECT 1;');
+		process.exit(0);
+	}
+
+	if (command !== 'query') {
+		throw new Error(`Unknown db-runner command: ${command ?? '<missing>'}`);
+	}
+
+	const encodedSql = process.argv[3] ?? '';
+	const sql = Buffer.from(encodedSql, 'base64').toString('utf8');
+	const result = normalizeResult(await client.query(sql));
+
+	if (!result || !Array.isArray(result.rows) || result.rows.length === 0) {
+		process.stdout.write('');
+		process.exit(0);
+	}
+
+	const rows = result.rows.map((row) => Object.values(row).map(formatField).join('|')).join('\n');
+	process.stdout.write(rows);
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	process.stderr.write(`${message}\n`);
+	process.exit(1);
+} finally {
+	await client.end().catch(() => {});
+}

--- a/tests/lib/db.ts
+++ b/tests/lib/db.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const RUNNER = resolve(import.meta.dirname, 'db-runner.mjs');
+
+export const TEST_PG_HOST = process.env.PGHOST ?? 'localhost';
+export const TEST_PG_PORT = Number.parseInt(process.env.PGPORT ?? '5432', 10);
+export const TEST_PG_USER = process.env.PGUSER ?? 'mulder';
+export const TEST_PG_PASSWORD = process.env.PGPASSWORD ?? 'mulder';
+export const TEST_PG_DATABASE = process.env.PGDATABASE ?? 'mulder';
+
+export const TEST_PG_ENV: Record<string, string> = {
+	PGHOST: TEST_PG_HOST,
+	PGPORT: String(TEST_PG_PORT),
+	PGUSER: TEST_PG_USER,
+	PGPASSWORD: TEST_PG_PASSWORD,
+	PGDATABASE: TEST_PG_DATABASE,
+};
+
+function runDbRunner(args: string[], timeout: number): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [RUNNER, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: { ...process.env, ...TEST_PG_ENV },
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+export function isPgAvailable(): boolean {
+	return runDbRunner(['ready'], 5_000).exitCode === 0;
+}
+
+export function runSql(sql: string): string {
+	const encodedSql = Buffer.from(sql, 'utf8').toString('base64');
+	const result = runDbRunner(['query', encodedSql], 15_000);
+	if (result.exitCode !== 0) {
+		throw new Error(`SQL failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+	}
+	return result.stdout.trim();
+}
+
+export function runSqlSafe(sql: string): string | null {
+	try {
+		return runSql(sql);
+	} catch {
+		return null;
+	}
+}

--- a/tests/lib/schema.ts
+++ b/tests/lib/schema.ts
@@ -19,6 +19,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { TEST_PG_ENV } from './db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -34,7 +35,7 @@ export function ensureSchema(): void {
 		encoding: 'utf-8',
 		timeout: 30_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: 'mulder', MULDER_LOG_LEVEL: 'silent' },
+		env: { ...process.env, ...TEST_PG_ENV, MULDER_LOG_LEVEL: 'silent' },
 	});
 	if (result.status !== 0) {
 		throw new Error(

--- a/tests/specs/07_database_client_migration_runner.test.ts
+++ b/tests/specs/07_database_client_migration_runner.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -15,15 +16,11 @@ const MIGRATE_MODULE = resolve(ROOT, 'packages/core/dist/database/migrate.js');
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never import from packages/ or src/ or apps/.
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`).
+ * Requires a running PostgreSQL instance (the standard PG env vars).
  */
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /** Config object matching CloudSqlConfig with defaults for local PostgreSQL. */
 const DB_CONFIG_JSON = JSON.stringify({
@@ -47,7 +44,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -72,7 +69,7 @@ function runScript(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -82,37 +79,17 @@ function runScript(
 }
 
 /**
- * Helper: run SQL via docker exec psql. Returns query output.
+ * Helper: run SQL via the shared env-driven SQL helper. Returns query output.
  */
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
 /**
  * Helper: run SQL, return null on failure instead of throwing.
  */
-function runSqlSafe(sql: string): string | null {
-	try {
-		return runSql(sql);
-	} catch {
-		return null;
-	}
-}
-
 function dropMigrationsTable(): void {
-	runSql('DROP TABLE IF EXISTS mulder_migrations CASCADE;');
+	db.runSql('DROP TABLE IF EXISTS mulder_migrations CASCADE;');
 }
 
 function cleanupTestTables(): void {
-	runSql(
+	db.runSql(
 		'DROP TABLE IF EXISTS qa_test_one, qa_test_two, qa_test_good, qa_test_bad, qa_test_status_one, qa_test_status_two CASCADE;',
 	);
 }
@@ -137,30 +114,19 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS taxonomy CASCADE',
 		'DROP TABLE IF EXISTS entities CASCADE',
 		'DROP TABLE IF EXISTS stories CASCADE',
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		'DROP INDEX IF EXISTS idx_entities_geom',
 		'DROP EXTENSION IF EXISTS vector CASCADE',
 		'DROP EXTENSION IF EXISTS postgis CASCADE',
 		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
 	].join('; ');
 
-	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
-		encoding: 'utf-8',
-		timeout: 15000,
-	});
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
+	db.runSql(dropSql);
 }
 
 let tmpDir: string;
@@ -169,13 +135,9 @@ describe('Spec 07: Database Client + Migration Runner', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-07-'));
@@ -321,7 +283,7 @@ describe('Spec 07: Database Client + Migration Runner', () => {
 			expect(exitCode).toBe(0);
 
 			// Verify table exists via psql
-			const tableExists = runSql(
+			const tableExists = db.runSql(
 				"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'mulder_migrations');",
 			);
 			expect(tableExists).toBe('t');
@@ -377,13 +339,13 @@ describe('Spec 07: Database Client + Migration Runner', () => {
 			expect(combined).toContain('002_create_qa_test_two.sql');
 
 			// Verify both tables exist
-			const t1 = runSql("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'qa_test_one');");
-			const t2 = runSql("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'qa_test_two');");
+			const t1 = db.runSql("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'qa_test_one');");
+			const t2 = db.runSql("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'qa_test_two');");
 			expect(t1).toBe('t');
 			expect(t2).toBe('t');
 
 			// Verify order in mulder_migrations
-			const migrations = runSql('SELECT filename FROM mulder_migrations ORDER BY applied_at ASC, filename ASC;');
+			const migrations = db.runSql('SELECT filename FROM mulder_migrations ORDER BY applied_at ASC, filename ASC;');
 			const filenames = migrations.split('\n').filter(Boolean);
 			expect(filenames[0]).toBe('001_create_qa_test_one.sql');
 			expect(filenames[1]).toBe('002_create_qa_test_two.sql');
@@ -491,12 +453,12 @@ describe('Spec 07: Database Client + Migration Runner', () => {
 			// The failed migration (002_bad.sql) should NOT be recorded.
 			// The mulder_migrations table may or may not exist depending on
 			// whether the runner uses per-migration transactions or batch transactions.
-			const recorded = runSqlSafe("SELECT filename FROM mulder_migrations WHERE filename = '002_bad.sql';");
+			const recorded = db.runSqlSafe("SELECT filename FROM mulder_migrations WHERE filename = '002_bad.sql';");
 			// Either the table doesn't exist (null) or the record doesn't exist ('')
 			expect(recorded === null || recorded === '').toBe(true);
 
 			// The bad table should not exist
-			const badTableExists = runSql(
+			const badTableExists = db.runSql(
 				"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'qa_test_bad');",
 			);
 			expect(badTableExists).toBe('f');

--- a/tests/specs/08_core_schema_migrations.test.ts
+++ b/tests/specs/08_core_schema_migrations.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -12,16 +13,12 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never import from packages/ or src/ or apps/.
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with pgvector, PostGIS, and pg_trgm extensions available.
  */
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * Helper: run the CLI binary via node as a subprocess.
@@ -35,7 +32,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -45,46 +42,16 @@ function runCli(
 }
 
 /**
- * Helper: run SQL via docker exec psql. Returns query output.
+ * Helper: run SQL via the shared env-driven SQL helper. Returns query output.
  */
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
 /**
  * Helper: run SQL, return null on failure instead of throwing.
  */
-function runSqlSafe(sql: string): string | null {
-	try {
-		return runSql(sql);
-	} catch {
-		return null;
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function hasRequiredExtensions(): boolean {
 	try {
-		const out = runSql("SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');");
+		const out = db.runSql(
+			"SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');",
+		);
 		return Number.parseInt(out, 10) >= 3;
 	} catch {
 		return false;
@@ -109,18 +76,19 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS taxonomy CASCADE',
 		'DROP TABLE IF EXISTS entities CASCADE',
 		'DROP TABLE IF EXISTS stories CASCADE',
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		'DROP INDEX IF EXISTS idx_entities_geom',
 		'DROP EXTENSION IF EXISTS vector CASCADE',
 		'DROP EXTENSION IF EXISTS postgis CASCADE',
 		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
 	].join('; ');
 
-	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
-		encoding: 'utf-8',
-		timeout: 15000,
-	});
+	db.runSql(dropSql);
 }
 
 describe('Spec 08: Core Schema Migrations (001-008)', () => {
@@ -128,14 +96,9 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 	let extensionsAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17\n' +
-					'  docker exec mulder-pg-test apt-get update && docker exec mulder-pg-test apt-get install -y postgresql-17-postgis-3',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -182,7 +145,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 		it('pgvector, PostGIS, and pg_trgm extensions exist after migration', () => {
 			if (skipIfUnavailable()) return;
 
-			const extensions = runSql('SELECT extname FROM pg_extension ORDER BY extname;');
+			const extensions = db.runSql('SELECT extname FROM pg_extension ORDER BY extname;');
 			const extList = extensions.split('\n').filter(Boolean);
 
 			expect(extList).toContain('vector');
@@ -207,7 +170,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			expect(combined).toMatch(/skipped.*\d+|\d+.*skipped|up to date/i);
 
 			// Verify via direct DB query — 001-008 + 012-014 = 11 migration files
-			const count = runSql('SELECT count(*) FROM mulder_migrations;');
+			const count = db.runSql('SELECT count(*) FROM mulder_migrations;');
 			expect(Number.parseInt(count, 10)).toBeGreaterThanOrEqual(8);
 		});
 	});
@@ -218,7 +181,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 		it('sources table has all required columns', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'sources' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -251,7 +214,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 		it('source_steps table has all required columns with composite PK', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'source_steps' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -263,7 +226,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			}
 
 			// Verify composite PK (source_id, step_name)
-			const pkColumns = runSql(
+			const pkColumns = db.runSql(
 				"SELECT kcu.column_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name WHERE tc.table_name = 'source_steps' AND tc.constraint_type = 'PRIMARY KEY' ORDER BY kcu.ordinal_position;",
 			);
 			const pkList = pkColumns.split('\n').filter(Boolean);
@@ -278,7 +241,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 		it('stories table has all columns including GCS URIs, with FK to sources', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'stories' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -289,7 +252,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			expect(colList, 'Missing source_id').toContain('source_id');
 
 			// Verify FK to sources
-			const fkRef = runSql(
+			const fkRef = db.runSql(
 				"SELECT ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name WHERE tc.table_name = 'stories' AND tc.constraint_type = 'FOREIGN KEY' AND ccu.table_name = 'sources';",
 			);
 			expect(fkRef).toBe('sources');
@@ -303,7 +266,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Entities table must have canonical_id with self-referential FK
-			const entityFk = runSql(
+			const entityFk = db.runSql(
 				"SELECT ccu.table_name, ccu.column_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name WHERE tc.table_name = 'entities' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'canonical_id';",
 			);
 			// Should reference entities.id (self-referential)
@@ -311,7 +274,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			expect(entityFk).toContain('id');
 
 			// entity_aliases must have UNIQUE(entity_id, alias)
-			const uniqueConstraint = runSql(
+			const uniqueConstraint = db.runSql(
 				"SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'entity_aliases'::regclass AND contype = 'u';",
 			);
 			expect(uniqueConstraint).toContain('entity_id');
@@ -326,7 +289,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// story_entities composite PK
-			const sePk = runSql(
+			const sePk = db.runSql(
 				"SELECT kcu.column_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name WHERE tc.table_name = 'story_entities' AND tc.constraint_type = 'PRIMARY KEY' ORDER BY kcu.ordinal_position;",
 			);
 			const sePkList = sePk.split('\n').filter(Boolean);
@@ -334,7 +297,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			expect(sePkList).toContain('entity_id');
 
 			// entity_edges FKs to entities and stories
-			const edgeFks = runSql(
+			const edgeFks = db.runSql(
 				"SELECT kcu.column_name, ccu.table_name as ref_table FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name WHERE tc.table_name = 'entity_edges' AND tc.constraint_type = 'FOREIGN KEY';",
 			);
 			// Should reference both entities and stories
@@ -350,25 +313,25 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Check embedding column type
-			const embeddingType = runSql(
+			const embeddingType = db.runSql(
 				"SELECT udt_name FROM information_schema.columns WHERE table_name = 'chunks' AND column_name = 'embedding';",
 			);
 			expect(embeddingType).toBe('vector');
 
 			// Verify it's vector(768) by checking the full column definition
-			const vectorDef = runSql(
+			const vectorDef = db.runSql(
 				"SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 'chunks'::regclass AND attname = 'embedding';",
 			);
 			expect(vectorDef).toBe('vector(768)');
 
 			// Check fts_vector column type
-			const ftsType = runSql(
+			const ftsType = db.runSql(
 				"SELECT udt_name FROM information_schema.columns WHERE table_name = 'chunks' AND column_name = 'fts_vector';",
 			);
 			expect(ftsType).toBe('tsvector');
 
 			// Verify fts_vector is a generated column
-			const isGenerated = runSql(
+			const isGenerated = db.runSql(
 				"SELECT is_generated FROM information_schema.columns WHERE table_name = 'chunks' AND column_name = 'fts_vector';",
 			);
 			expect(isGenerated).toBe('ALWAYS');
@@ -382,13 +345,13 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Check table exists
-			const tableExists = runSql(
+			const tableExists = db.runSql(
 				"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'taxonomy' AND table_schema = 'public');",
 			);
 			expect(tableExists).toBe('t');
 
 			// Check UNIQUE constraint on (canonical_name, entity_type)
-			const uniqueConstraint = runSql(
+			const uniqueConstraint = db.runSql(
 				"SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'taxonomy'::regclass AND contype = 'u';",
 			);
 			expect(uniqueConstraint).toContain('canonical_name');
@@ -402,7 +365,7 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 		it('all expected indexes exist in pg_indexes', () => {
 			if (skipIfUnavailable()) return;
 
-			const indexes = runSql("SELECT indexname FROM pg_indexes WHERE schemaname = 'public' ORDER BY indexname;");
+			const indexes = db.runSql("SELECT indexname FROM pg_indexes WHERE schemaname = 'public' ORDER BY indexname;");
 			const indexList = indexes.split('\n').filter(Boolean);
 
 			const expectedIndexes = [
@@ -434,14 +397,14 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Check the access method of the index
-			const method = runSql(
+			const method = db.runSql(
 				"SELECT am.amname FROM pg_index idx JOIN pg_class cls ON idx.indexrelid = cls.oid JOIN pg_am am ON cls.relam = am.oid WHERE cls.relname = 'idx_chunks_embedding';",
 			);
 			expect(method).toBe('hnsw');
 			expect(method).not.toBe('ivfflat');
 
 			// Also confirm from the indexdef
-			const indexDef = runSql("SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_chunks_embedding';");
+			const indexDef = db.runSql("SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_chunks_embedding';");
 			expect(indexDef.toLowerCase()).toContain('hnsw');
 			expect(indexDef.toLowerCase()).not.toContain('ivfflat');
 		});
@@ -525,29 +488,29 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Insert a test source
-			runSql(
+			db.runSql(
 				"INSERT INTO sources (id, filename, storage_path, file_hash, status) VALUES ('00000000-0000-0000-0000-000000000001', 'test-cascade.pdf', 'gs://bucket/test.pdf', 'hash_cascade_test', 'pending');",
 			);
 
 			// Insert source_steps referencing that source
-			runSql(
+			db.runSql(
 				"INSERT INTO source_steps (source_id, step_name, status) VALUES ('00000000-0000-0000-0000-000000000001', 'extract', 'completed');",
 			);
-			runSql(
+			db.runSql(
 				"INSERT INTO source_steps (source_id, step_name, status) VALUES ('00000000-0000-0000-0000-000000000001', 'segment', 'pending');",
 			);
 
 			// Verify source_steps exist
-			const stepCount = runSql(
+			const stepCount = db.runSql(
 				"SELECT count(*) FROM source_steps WHERE source_id = '00000000-0000-0000-0000-000000000001';",
 			);
 			expect(Number.parseInt(stepCount, 10)).toBe(2);
 
 			// Delete the source
-			runSql("DELETE FROM sources WHERE id = '00000000-0000-0000-0000-000000000001';");
+			db.runSql("DELETE FROM sources WHERE id = '00000000-0000-0000-0000-000000000001';");
 
 			// Verify source_steps were cascaded
-			const remainingSteps = runSql(
+			const remainingSteps = db.runSql(
 				"SELECT count(*) FROM source_steps WHERE source_id = '00000000-0000-0000-0000-000000000001';",
 			);
 			expect(Number.parseInt(remainingSteps, 10)).toBe(0);
@@ -561,12 +524,12 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Insert first source
-			runSql(
+			db.runSql(
 				"INSERT INTO sources (id, filename, storage_path, file_hash, status) VALUES ('00000000-0000-0000-0000-000000000002', 'first.pdf', 'gs://bucket/first.pdf', 'hash_unique_test', 'pending');",
 			);
 
 			// Try to insert second source with same file_hash — should fail
-			const result = runSqlSafe(
+			const result = db.runSqlSafe(
 				"INSERT INTO sources (id, filename, storage_path, file_hash, status) VALUES ('00000000-0000-0000-0000-000000000003', 'second.pdf', 'gs://bucket/second.pdf', 'hash_unique_test', 'pending');",
 			);
 
@@ -574,11 +537,11 @@ describe('Spec 08: Core Schema Migrations (001-008)', () => {
 			expect(result).toBeNull();
 
 			// Verify only one row exists with that hash
-			const count = runSql("SELECT count(*) FROM sources WHERE file_hash = 'hash_unique_test';");
+			const count = db.runSql("SELECT count(*) FROM sources WHERE file_hash = 'hash_unique_test';");
 			expect(Number.parseInt(count, 10)).toBe(1);
 
 			// Cleanup
-			runSql("DELETE FROM sources WHERE file_hash = 'hash_unique_test';");
+			db.runSql("DELETE FROM sources WHERE file_hash = 'hash_unique_test';");
 		});
 	});
 });

--- a/tests/specs/09_job_queue_pipeline_tracking_migrations.test.ts
+++ b/tests/specs/09_job_queue_pipeline_tracking_migrations.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -11,16 +12,12 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never import from packages/ or src/ or apps/.
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with pgvector, PostGIS, and pg_trgm extensions available.
  */
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // ─── Test data UUIDs ───
 
@@ -46,7 +43,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -56,46 +53,16 @@ function runCli(
 }
 
 /**
- * Helper: run SQL via docker exec psql. Returns query output.
+ * Helper: run SQL via the shared env-driven SQL helper. Returns query output.
  */
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
 /**
  * Helper: run SQL, return null on failure instead of throwing.
  */
-function runSqlSafe(sql: string): string | null {
-	try {
-		return runSql(sql);
-	} catch {
-		return null;
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function hasRequiredExtensions(): boolean {
 	try {
-		const out = runSql("SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');");
+		const out = db.runSql(
+			"SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');",
+		);
 		return Number.parseInt(out, 10) >= 3;
 	} catch {
 		return false;
@@ -117,18 +84,19 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS taxonomy CASCADE',
 		'DROP TABLE IF EXISTS entities CASCADE',
 		'DROP TABLE IF EXISTS stories CASCADE',
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		'DROP INDEX IF EXISTS idx_entities_geom',
 		'DROP EXTENSION IF EXISTS vector CASCADE',
 		'DROP EXTENSION IF EXISTS postgis CASCADE',
 		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
 	].join('; ');
 
-	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
-		encoding: 'utf-8',
-		timeout: 15000,
-	});
+	db.runSql(dropSql);
 }
 
 /**
@@ -148,7 +116,7 @@ function cleanupTestData(): void {
 		`DELETE FROM jobs WHERE type = 'spec09_test'`,
 	].join('; ');
 
-	runSqlSafe(cleanSql);
+	db.runSqlSafe(cleanSql);
 }
 
 /**
@@ -186,7 +154,7 @@ function seedFullSource(): void {
 		`INSERT INTO chunks (id, story_id, content, chunk_index) VALUES ('${CHUNK_ID_1}', '${STORY_ID_1}', 'This is a test chunk for spec 09 testing', 0)`,
 	].join('; ');
 
-	runSql(seedSql);
+	db.runSql(seedSql);
 }
 
 describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
@@ -194,14 +162,9 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 	let extensionsAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17\n' +
-					'  docker exec mulder-pg-test apt-get update && docker exec mulder-pg-test apt-get install -y postgresql-17-postgis-3',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -242,12 +205,12 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Migrations were applied in beforeAll. Verify that 012-014 are recorded.
-			const migrationCount = runSql('SELECT count(*) FROM mulder_migrations;');
+			const migrationCount = db.runSql('SELECT count(*) FROM mulder_migrations;');
 			// 001-008 = 8, 012-014 = 3, total = 11
 			expect(Number.parseInt(migrationCount, 10)).toBeGreaterThanOrEqual(11);
 
 			// Verify specific migration files are recorded
-			const migrations = runSql('SELECT filename FROM mulder_migrations ORDER BY filename;');
+			const migrations = db.runSql('SELECT filename FROM mulder_migrations ORDER BY filename;');
 			const migrationList = migrations.split('\n').filter(Boolean);
 
 			expect(migrationList).toContain('012_job_queue.sql');
@@ -263,11 +226,11 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			if (skipIfUnavailable()) return;
 
 			// Check enum exists in pg_type
-			const enumExists = runSql("SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'job_status');");
+			const enumExists = db.runSql("SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'job_status');");
 			expect(enumExists).toBe('t');
 
 			// Check enum values
-			const enumValues = runSql(
+			const enumValues = db.runSql(
 				"SELECT enumlabel FROM pg_enum WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'job_status') ORDER BY enumsortorder;",
 			);
 			const values = enumValues.split('\n').filter(Boolean);
@@ -287,7 +250,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 		it('jobs table has all columns with correct types and defaults', () => {
 			if (skipIfUnavailable()) return;
 
-			const columnsRaw = runSql(
+			const columnsRaw = db.runSql(
 				"SELECT column_name, data_type, column_default, is_nullable FROM information_schema.columns WHERE table_name = 'jobs' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const rows = columnsRaw.split('\n').filter(Boolean);
@@ -344,7 +307,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 		it('partial index idx_jobs_queue exists on (status, created_at) WHERE status = pending', () => {
 			if (skipIfUnavailable()) return;
 
-			const indexDef = runSql("SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_jobs_queue';");
+			const indexDef = db.runSql("SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_jobs_queue';");
 
 			expect(indexDef).toBeTruthy();
 			// Should be a partial index on status and created_at
@@ -362,7 +325,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 		it('pipeline_runs table has all columns with correct types and defaults', () => {
 			if (skipIfUnavailable()) return;
 
-			const columnsRaw = runSql(
+			const columnsRaw = db.runSql(
 				"SELECT column_name, data_type, column_default, is_nullable FROM information_schema.columns WHERE table_name = 'pipeline_runs' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const rows = columnsRaw.split('\n').filter(Boolean);
@@ -398,7 +361,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 		it('pipeline_run_sources has all columns, composite PK (run_id, source_id), FKs with CASCADE on run_id', () => {
 			if (skipIfUnavailable()) return;
 
-			const columnsRaw = runSql(
+			const columnsRaw = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'pipeline_run_sources' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columnsRaw.split('\n').filter(Boolean);
@@ -410,7 +373,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			}
 
 			// Verify composite PK (run_id, source_id)
-			const pkColumns = runSql(
+			const pkColumns = db.runSql(
 				"SELECT kcu.column_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name WHERE tc.table_name = 'pipeline_run_sources' AND tc.constraint_type = 'PRIMARY KEY' ORDER BY kcu.ordinal_position;",
 			);
 			const pkList = pkColumns.split('\n').filter(Boolean);
@@ -418,19 +381,19 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			expect(pkList).toContain('source_id');
 
 			// Verify FK to pipeline_runs
-			const fkToPipelineRuns = runSql(
+			const fkToPipelineRuns = db.runSql(
 				"SELECT ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name WHERE tc.table_name = 'pipeline_run_sources' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'run_id';",
 			);
 			expect(fkToPipelineRuns).toContain('pipeline_runs');
 
 			// Verify FK to sources
-			const fkToSources = runSql(
+			const fkToSources = db.runSql(
 				"SELECT ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name WHERE tc.table_name = 'pipeline_run_sources' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'source_id';",
 			);
 			expect(fkToSources).toContain('sources');
 
 			// Verify CASCADE on run_id FK
-			const cascadeOnRunId = runSql(
+			const cascadeOnRunId = db.runSql(
 				"SELECT confdeltype FROM pg_constraint WHERE conrelid = 'pipeline_run_sources'::regclass AND contype = 'f' AND conname LIKE '%run_id%';",
 			);
 			// 'c' means CASCADE
@@ -449,41 +412,41 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			seedFullSource();
 
 			// Verify pre-conditions
-			const storiesBefore = runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storiesBefore = db.runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(Number.parseInt(storiesBefore, 10)).toBe(2);
 
-			const stepsBefore = runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${SOURCE_ID_1}';`);
+			const stepsBefore = db.runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(Number.parseInt(stepsBefore, 10)).toBe(5);
 
 			// Call reset
-			runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'extract');`);
+			db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'extract');`);
 
 			// Stories deleted (cascading to chunks, story_entities, edges)
-			const storiesAfter = runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storiesAfter = db.runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(Number.parseInt(storiesAfter, 10)).toBe(0);
 
 			// Chunks deleted (cascaded from stories)
-			const chunksAfter = runSql(`SELECT count(*) FROM chunks WHERE story_id = '${STORY_ID_1}';`);
+			const chunksAfter = db.runSql(`SELECT count(*) FROM chunks WHERE story_id = '${STORY_ID_1}';`);
 			expect(Number.parseInt(chunksAfter, 10)).toBe(0);
 
 			// Story entities deleted (cascaded)
-			const seAfter = runSql(
+			const seAfter = db.runSql(
 				`SELECT count(*) FROM story_entities WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
 			);
 			expect(Number.parseInt(seAfter, 10)).toBe(0);
 
 			// Entity edges deleted (cascaded)
-			const edgesAfter = runSql(
+			const edgesAfter = db.runSql(
 				`SELECT count(*) FROM entity_edges WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
 			);
 			expect(Number.parseInt(edgesAfter, 10)).toBe(0);
 
 			// source_steps cleared (ALL steps)
-			const stepsAfter = runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${SOURCE_ID_1}';`);
+			const stepsAfter = db.runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(Number.parseInt(stepsAfter, 10)).toBe(0);
 
 			// source status = 'ingested'
-			const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
+			const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
 			expect(sourceStatus).toBe('ingested');
 
 			// Clean up
@@ -501,14 +464,14 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			seedFullSource();
 
 			// Call reset for segment
-			runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'segment');`);
+			db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'segment');`);
 
 			// Stories deleted
-			const storiesAfter = runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storiesAfter = db.runSql(`SELECT count(*) FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(Number.parseInt(storiesAfter, 10)).toBe(0);
 
 			// Relevant source_steps cleared (segment, enrich, embed, graph)
-			const remainingSteps = runSql(
+			const remainingSteps = db.runSql(
 				`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID_1}' ORDER BY step_name;`,
 			);
 			const stepList = remainingSteps.split('\n').filter(Boolean);
@@ -520,7 +483,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			expect(stepList).not.toContain('graph');
 
 			// source status = 'extracted'
-			const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
+			const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
 			expect(sourceStatus).toBe('extracted');
 
 			cleanupTestData();
@@ -537,22 +500,22 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			seedFullSource();
 
 			// Call reset for enrich
-			runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'enrich');`);
+			db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'enrich');`);
 
 			// story_entities deleted
-			const seAfter = runSql(
+			const seAfter = db.runSql(
 				`SELECT count(*) FROM story_entities WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
 			);
 			expect(Number.parseInt(seAfter, 10)).toBe(0);
 
 			// entity_edges deleted
-			const edgesAfter = runSql(
+			const edgesAfter = db.runSql(
 				`SELECT count(*) FROM entity_edges WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
 			);
 			expect(Number.parseInt(edgesAfter, 10)).toBe(0);
 
 			// source_steps for enrich/embed/graph cleared
-			const remainingSteps = runSql(
+			const remainingSteps = db.runSql(
 				`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID_1}' ORDER BY step_name;`,
 			);
 			const stepList = remainingSteps.split('\n').filter(Boolean);
@@ -563,11 +526,11 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			expect(stepList).not.toContain('graph');
 
 			// stories status = 'segmented'
-			const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(storyStatuses).toBe('segmented');
 
 			// source status = 'segmented'
-			const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
+			const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID_1}';`);
 			expect(sourceStatus).toBe('segmented');
 
 			cleanupTestData();
@@ -584,14 +547,16 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			seedFullSource();
 
 			// Call reset for embed
-			runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'embed');`);
+			db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'embed');`);
 
 			// Chunks deleted
-			const chunksAfter = runSql(`SELECT count(*) FROM chunks WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`);
+			const chunksAfter = db.runSql(
+				`SELECT count(*) FROM chunks WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
+			);
 			expect(Number.parseInt(chunksAfter, 10)).toBe(0);
 
 			// source_steps for embed/graph cleared
-			const remainingSteps = runSql(
+			const remainingSteps = db.runSql(
 				`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID_1}' ORDER BY step_name;`,
 			);
 			const stepList = remainingSteps.split('\n').filter(Boolean);
@@ -602,7 +567,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			expect(stepList).not.toContain('graph');
 
 			// stories status = 'enriched'
-			const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(storyStatuses).toBe('enriched');
 
 			cleanupTestData();
@@ -619,16 +584,16 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			seedFullSource();
 
 			// Call reset for graph
-			runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'graph');`);
+			db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID_1}', 'graph');`);
 
 			// Entity edges deleted
-			const edgesAfter = runSql(
+			const edgesAfter = db.runSql(
 				`SELECT count(*) FROM entity_edges WHERE story_id IN ('${STORY_ID_1}', '${STORY_ID_2}');`,
 			);
 			expect(Number.parseInt(edgesAfter, 10)).toBe(0);
 
 			// source_steps for graph cleared
-			const remainingSteps = runSql(
+			const remainingSteps = db.runSql(
 				`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID_1}' ORDER BY step_name;`,
 			);
 			const stepList = remainingSteps.split('\n').filter(Boolean);
@@ -639,7 +604,7 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			expect(stepList).not.toContain('graph');
 
 			// stories status = 'embedded'
-			const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
+			const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID_1}';`);
 			expect(storyStatuses).toBe('embedded');
 
 			cleanupTestData();
@@ -655,38 +620,38 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			cleanupTestData();
 
 			// Create a source and story for the linked entity
-			runSql(
+			db.runSql(
 				`INSERT INTO sources (id, filename, storage_path, file_hash, status) VALUES ('${SOURCE_ID_1}', 'test-gc.pdf', 'gs://bucket/test-gc.pdf', 'hash_gc_spec09', 'completed');`,
 			);
-			runSql(
+			db.runSql(
 				`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) VALUES ('${STORY_ID_1}', '${SOURCE_ID_1}', 'GC Test Story', 'gs://bucket/gc.md', 'gs://bucket/gc.meta.json', 'completed');`,
 			);
 
 			// Create a non-orphaned entity (linked to a story)
-			runSql(`INSERT INTO entities (id, name, type) VALUES ('${ENTITY_ID_1}', 'Linked Entity', 'person');`);
-			runSql(
+			db.runSql(`INSERT INTO entities (id, name, type) VALUES ('${ENTITY_ID_1}', 'Linked Entity', 'person');`);
+			db.runSql(
 				`INSERT INTO story_entities (story_id, entity_id, mention_count) VALUES ('${STORY_ID_1}', '${ENTITY_ID_1}', 1);`,
 			);
 
 			// Create an orphaned entity (no story_entities references)
-			runSql(`INSERT INTO entities (id, name, type) VALUES ('${ENTITY_ID_ORPHAN}', 'Orphaned Entity', 'location');`);
+			db.runSql(`INSERT INTO entities (id, name, type) VALUES ('${ENTITY_ID_ORPHAN}', 'Orphaned Entity', 'location');`);
 
 			// Verify pre-conditions
-			const entitiesBefore = runSql(
+			const entitiesBefore = db.runSql(
 				`SELECT count(*) FROM entities WHERE id IN ('${ENTITY_ID_1}', '${ENTITY_ID_ORPHAN}');`,
 			);
 			expect(Number.parseInt(entitiesBefore, 10)).toBe(2);
 
 			// Call gc_orphaned_entities
-			const deletedCount = runSql('SELECT gc_orphaned_entities();');
+			const deletedCount = db.runSql('SELECT gc_orphaned_entities();');
 			expect(Number.parseInt(deletedCount, 10)).toBe(1);
 
 			// Orphaned entity should be gone
-			const orphanExists = runSql(`SELECT count(*) FROM entities WHERE id = '${ENTITY_ID_ORPHAN}';`);
+			const orphanExists = db.runSql(`SELECT count(*) FROM entities WHERE id = '${ENTITY_ID_ORPHAN}';`);
 			expect(Number.parseInt(orphanExists, 10)).toBe(0);
 
 			// Non-orphaned entity should still exist
-			const linkedExists = runSql(`SELECT count(*) FROM entities WHERE id = '${ENTITY_ID_1}';`);
+			const linkedExists = db.runSql(`SELECT count(*) FROM entities WHERE id = '${ENTITY_ID_1}';`);
 			expect(Number.parseInt(linkedExists, 10)).toBe(1);
 
 			cleanupTestData();
@@ -717,29 +682,29 @@ describe('Spec 09: Job Queue & Pipeline Tracking Migrations (012-014)', () => {
 			cleanupTestData();
 
 			// Create a source for FK reference
-			runSql(
+			db.runSql(
 				`INSERT INTO sources (id, filename, storage_path, file_hash, status) VALUES ('${SOURCE_ID_1}', 'test-fk-cascade.pdf', 'gs://bucket/test-fk.pdf', 'hash_fk_spec09', 'pending');`,
 			);
 
 			// Create a pipeline_run
-			runSql(
+			db.runSql(
 				`INSERT INTO pipeline_runs (id, tag, status) VALUES ('${PIPELINE_RUN_ID}', 'test-cascade-run', 'running');`,
 			);
 
 			// Create pipeline_run_sources referencing the run and source
-			runSql(
+			db.runSql(
 				`INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status) VALUES ('${PIPELINE_RUN_ID}', '${SOURCE_ID_1}', 'extract', 'pending');`,
 			);
 
 			// Verify pre-condition
-			const prsBefore = runSql(`SELECT count(*) FROM pipeline_run_sources WHERE run_id = '${PIPELINE_RUN_ID}';`);
+			const prsBefore = db.runSql(`SELECT count(*) FROM pipeline_run_sources WHERE run_id = '${PIPELINE_RUN_ID}';`);
 			expect(Number.parseInt(prsBefore, 10)).toBe(1);
 
 			// Delete the pipeline_run
-			runSql(`DELETE FROM pipeline_runs WHERE id = '${PIPELINE_RUN_ID}';`);
+			db.runSql(`DELETE FROM pipeline_runs WHERE id = '${PIPELINE_RUN_ID}';`);
 
 			// Verify cascade -- pipeline_run_sources should be gone
-			const prsAfter = runSql(`SELECT count(*) FROM pipeline_run_sources WHERE run_id = '${PIPELINE_RUN_ID}';`);
+			const prsAfter = db.runSql(`SELECT count(*) FROM pipeline_run_sources WHERE run_id = '${PIPELINE_RUN_ID}';`);
 			expect(Number.parseInt(prsAfter, 10)).toBe(0);
 
 			cleanupTestData();

--- a/tests/specs/12_docker_compose.test.ts
+++ b/tests/specs/12_docker_compose.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -9,15 +10,13 @@ const COMPOSE_FILE = resolve(ROOT, 'docker-compose.yaml');
 
 const PG_CONTAINER = 'mulder-postgres';
 const FS_CONTAINER = 'mulder-firestore';
-const PG_USER = 'mulder';
-const PG_DB = 'mulder';
 
 /**
  * Black-box QA tests for Spec 12: Docker Compose — pgvector + PostGIS + Firestore Emulator
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: docker compose CLI, SQL via
- * docker exec psql, HTTP, and filesystem.
+ * the shared env-driven SQL helper, HTTP, and filesystem.
  * Never import from packages/ or src/ or apps/.
  *
  * These tests manage real Docker containers and require Docker to be running.
@@ -43,18 +42,10 @@ function compose(args: string[], timeout = 120_000): { stdout: string; stderr: s
 }
 
 /**
- * Helper: run SQL via docker exec psql on the mulder-postgres container.
+ * Helper: run SQL via the shared env-driven SQL helper on the mulder-postgres container.
  */
 function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DB, '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
+	return db.runSql(sql);
 }
 
 /**

--- a/tests/specs/14_source_repository.test.ts
+++ b/tests/specs/14_source_repository.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -14,16 +15,12 @@ const DB_MODULE = resolve(ROOT, 'packages/core/dist/database/index.js');
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and Node subprocess scripts.
+ * SQL via `the shared env-driven SQL helper`, and Node subprocess scripts.
  * Never import from packages/ or src/ or apps/.
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with migrations applied.
  */
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 const DB_CONFIG_JSON = JSON.stringify({
 	instance_name: 'mulder-db',
@@ -48,7 +45,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -72,7 +69,7 @@ function runScript(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -82,32 +79,8 @@ function runScript(
 }
 
 /**
- * Helper: run SQL via docker exec psql. Returns query output.
+ * Helper: run SQL via the shared env-driven SQL helper. Returns query output.
  */
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function resetDatabase(): void {
 	const dropSql = [
 		'DROP FUNCTION IF EXISTS reset_pipeline_step CASCADE',
@@ -123,38 +96,35 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS taxonomy CASCADE',
 		'DROP TABLE IF EXISTS entities CASCADE',
 		'DROP TABLE IF EXISTS stories CASCADE',
+		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+		'DROP TABLE IF EXISTS evidence_chains CASCADE',
+		'DROP TABLE IF EXISTS entity_grounding CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		'DROP INDEX IF EXISTS idx_entities_geom',
 		'DROP EXTENSION IF EXISTS vector CASCADE',
 		'DROP EXTENSION IF EXISTS postgis CASCADE',
 		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
 	].join('; ');
 
-	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
-		encoding: 'utf-8',
-		timeout: 15000,
-	});
+	db.runSql(dropSql);
 }
 
 /**
  * Clean all rows from sources and source_steps without dropping the tables.
  */
 function cleanSourceData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 describe('Spec 14: Source Repository', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-14-'));
@@ -228,7 +198,7 @@ describe('Spec 14: Source Repository', () => {
 			expect(combined).toContain('HAS_UPDATED_AT:true');
 
 			// Verify in database via psql
-			const rowCount = runSql("SELECT COUNT(*) FROM sources WHERE filename = 'test-doc.pdf';");
+			const rowCount = db.runSql("SELECT COUNT(*) FROM sources WHERE filename = 'test-doc.pdf';");
 			expect(rowCount).toBe('1');
 		});
 	});
@@ -283,7 +253,7 @@ describe('Spec 14: Source Repository', () => {
 			expect(combined).toContain('UPDATED_AT_REFRESHED:true');
 
 			// Verify no duplicate in DB
-			const count = runSql(`SELECT COUNT(*) FROM sources WHERE file_hash = '${fixedHash}';`);
+			const count = db.runSql(`SELECT COUNT(*) FROM sources WHERE file_hash = '${fixedHash}';`);
 			expect(count).toBe('1');
 		});
 	});
@@ -571,11 +541,11 @@ describe('Spec 14: Source Repository', () => {
 			const sourceId = idMatch?.[1];
 
 			// Verify source is gone
-			const sourceCount = runSql(`SELECT COUNT(*) FROM sources WHERE id = '${sourceId}';`);
+			const sourceCount = db.runSql(`SELECT COUNT(*) FROM sources WHERE id = '${sourceId}';`);
 			expect(sourceCount).toBe('0');
 
 			// Verify source_steps are gone (cascade)
-			const stepCount = runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`);
+			const stepCount = db.runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`);
 			expect(stepCount).toBe('0');
 		});
 	});
@@ -691,13 +661,13 @@ describe('Spec 14: Source Repository', () => {
 			expect(idMatch).not.toBeNull();
 			const sourceId = idMatch?.[1];
 
-			const stepCount = runSql(
+			const stepCount = db.runSql(
 				`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 			);
 			expect(stepCount).toBe('1');
 
 			// Verify it has the latest status
-			const stepStatus = runSql(
+			const stepStatus = db.runSql(
 				`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 			);
 			expect(stepStatus).toBe('completed');

--- a/tests/specs/16_ingest_step.test.ts
+++ b/tests/specs/16_ingest_step.test.ts
@@ -3,6 +3,7 @@ import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -10,10 +11,6 @@ const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 let tmpDir: string;
 let storageRawSnapshot: StorageSnapshot;
@@ -24,11 +21,11 @@ const STORAGE_RAW_DIR = resolve(resolve(import.meta.dirname, '../..'), '.local/s
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -46,7 +43,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -55,32 +52,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanSourceData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 /**
@@ -237,13 +210,9 @@ describe('Spec 16 — Ingest Step', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-16-'));
@@ -293,7 +262,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toContain('Ingest complete');
 
 		// Verify source record in database
-		const rows = runSql(
+		const rows = db.runSql(
 			"SELECT status, has_native_text, native_text_ratio FROM sources WHERE filename = 'native-text-sample.pdf';",
 		);
 		expect(rows).not.toBe('');
@@ -327,7 +296,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toContain('Ingest complete');
 
 		// Verify two source records exist
-		const count = runSql('SELECT COUNT(*) FROM sources;');
+		const count = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(Number.parseInt(count, 10)).toBe(2);
 	});
 
@@ -343,7 +312,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(first.exitCode).toBe(0);
 
 		// Capture the first updated_at
-		const firstUpdatedAt = runSql("SELECT updated_at FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const firstUpdatedAt = db.runSql("SELECT updated_at FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(firstUpdatedAt).not.toBe('');
 
 		// Small delay to ensure timestamp differs
@@ -358,11 +327,11 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toMatch(/duplicate/i);
 
 		// Verify still only one source record
-		const count = runSql('SELECT COUNT(*) FROM sources;');
+		const count = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(count).toBe('1');
 
 		// Verify updated_at was refreshed
-		const secondUpdatedAt = runSql("SELECT updated_at FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const secondUpdatedAt = db.runSql("SELECT updated_at FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(secondUpdatedAt).not.toBe('');
 		expect(new Date(secondUpdatedAt).getTime()).toBeGreaterThanOrEqual(new Date(firstUpdatedAt).getTime());
 	});
@@ -388,7 +357,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toMatch(/INGEST_NOT_PDF|invalid PDF|not.*PDF|missing.*%PDF/i);
 
 		// Verify no source record created
-		const count = runSql('SELECT COUNT(*) FROM sources;');
+		const count = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(count).toBe('0');
 	});
 
@@ -414,7 +383,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toMatch(/INGEST_FILE_TOO_LARGE|too large|file size|exceeds/i);
 
 		// Verify no source record created
-		const count = runSql('SELECT COUNT(*) FROM sources;');
+		const count = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(count).toBe('0');
 	});
 
@@ -437,12 +406,12 @@ describe('Spec 16 — Ingest Step', () => {
 			expect(combined).toMatch(/validated|dry.?run|complete/i);
 
 			// Verify NO source record in database
-			const count = runSql('SELECT COUNT(*) FROM sources;');
+			const count = db.runSql('SELECT COUNT(*) FROM sources;');
 			expect(count).toBe('0');
 		} else {
 			// If dry-run fails due to pool being undefined, that's an implementation issue
 			// but we still verify no records were created
-			const count = runSql('SELECT COUNT(*) FROM sources;');
+			const count = db.runSql('SELECT COUNT(*) FROM sources;');
 			expect(count).toBe('0');
 			// Mark as a known issue
 			console.warn(
@@ -463,7 +432,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Verify tag in database
-		const tags = runSql("SELECT tags FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const tags = db.runSql("SELECT tags FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(tags).toContain('batch1');
 	});
 
@@ -478,11 +447,11 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Get the source ID
-		const sourceId = runSql("SELECT id FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const sourceId = db.runSql("SELECT id FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(sourceId).not.toBe('');
 
 		// Verify source_steps entry
-		const stepRow = runSql(
+		const stepRow = db.runSql(
 			`SELECT step_name, status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'ingest';`,
 		);
 		expect(stepRow).not.toBe('');
@@ -514,7 +483,7 @@ describe('Spec 16 — Ingest Step', () => {
 		expect(combined).toMatch(/INGEST_TOO_MANY_PAGES|too many pages|page count|exceeds/i);
 
 		// Verify no source record created
-		const count = runSql('SELECT COUNT(*) FROM sources;');
+		const count = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(count).toBe('0');
 	});
 
@@ -528,7 +497,7 @@ describe('Spec 16 — Ingest Step', () => {
 		const { exitCode } = runCli(['ingest', NATIVE_TEXT_PDF]);
 		expect(exitCode).toBe(0);
 
-		const storagePath = runSql("SELECT storage_path FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const storagePath = db.runSql("SELECT storage_path FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(storagePath).not.toBe('');
 
 		// Verify pattern: raw/{uuid}/original.pdf

--- a/tests/specs/19_extract_step.test.ts
+++ b/tests/specs/19_extract_step.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -11,10 +12,6 @@ const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 let tmpDir: string;
 
 /**
@@ -22,11 +19,11 @@ let tmpDir: string;
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage in fixtures/).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage in fixtures/).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -44,7 +41,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -53,32 +50,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 function cleanExtractedFixtures(): void {
@@ -102,7 +75,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -117,13 +90,9 @@ describe('Spec 19 — Extract Step', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-19-'));
@@ -166,7 +135,7 @@ describe('Spec 19 — Extract Step', () => {
 		expect(result.exitCode).toBe(0);
 
 		// Source status should be 'extracted' in database
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('extracted');
 
 		// layout.json should exist in dev-mode storage
@@ -180,7 +149,7 @@ describe('Spec 19 — Extract Step', () => {
 		if (!pgAvailable) return;
 
 		// Use the source from QA-01 (already extracted)
-		const sourceId = runSql("SELECT id FROM sources WHERE status = 'extracted' LIMIT 1;");
+		const sourceId = db.runSql("SELECT id FROM sources WHERE status = 'extracted' LIMIT 1;");
 		if (!sourceId) {
 			// Need to set up: ingest and extract
 			cleanTestData();
@@ -189,7 +158,7 @@ describe('Spec 19 — Extract Step', () => {
 			const { exitCode } = runCli(['extract', id]);
 			expect(exitCode).toBe(0);
 		}
-		const id = sourceId || runSql("SELECT id FROM sources WHERE status = 'extracted' LIMIT 1;");
+		const id = sourceId || db.runSql("SELECT id FROM sources WHERE status = 'extracted' LIMIT 1;");
 
 		const pagesDir = join(EXTRACTED_DIR, id, 'pages');
 		if (!existsSync(pagesDir)) {
@@ -265,7 +234,7 @@ describe('Spec 19 — Extract Step', () => {
 		const { exitCode } = runCli(['extract', sourceId]);
 		expect(exitCode).toBe(0);
 
-		const stepRow = runSql(
+		const stepRow = db.runSql(
 			`SELECT step_name, status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 		);
 		expect(stepRow).not.toBe('');
@@ -348,7 +317,7 @@ describe('Spec 19 — Extract Step', () => {
 		expect(second.exitCode).toBe(0);
 
 		// Source status should still be 'extracted'
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('extracted');
 
 		// layout.json should have a new extractedAt timestamp
@@ -369,7 +338,7 @@ describe('Spec 19 — Extract Step', () => {
 		ingestPdf(SCANNED_PDF);
 
 		// Verify both are ingested
-		const beforeCount = runSql("SELECT COUNT(*) FROM sources WHERE status = 'ingested';");
+		const beforeCount = db.runSql("SELECT COUNT(*) FROM sources WHERE status = 'ingested';");
 		expect(Number.parseInt(beforeCount, 10)).toBe(2);
 
 		// Extract all
@@ -377,7 +346,7 @@ describe('Spec 19 — Extract Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All ingested sources should now be extracted
-		const afterCount = runSql("SELECT COUNT(*) FROM sources WHERE status = 'extracted';");
+		const afterCount = db.runSql("SELECT COUNT(*) FROM sources WHERE status = 'extracted';");
 		expect(Number.parseInt(afterCount, 10)).toBe(2);
 	});
 
@@ -424,7 +393,7 @@ describe('Spec 19 — Extract Step', () => {
 		expect(second.exitCode).toBe(0);
 
 		// Source status should be 'extracted'
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('extracted');
 
 		// layout.json should exist
@@ -432,7 +401,7 @@ describe('Spec 19 — Extract Step', () => {
 		expect(existsSync(layoutPath)).toBe(true);
 
 		// No duplicate source_steps records
-		const stepCount = runSql(
+		const stepCount = db.runSql(
 			`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 		);
 		expect(stepCount).toBe('1');

--- a/tests/specs/22_pdf_metadata_extraction.test.ts
+++ b/tests/specs/22_pdf_metadata_extraction.test.ts
@@ -3,16 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 let tmpDir: string;
 let pgAvailable: boolean;
@@ -25,7 +22,7 @@ let pgAvailable: boolean;
  * and handles corrupt/encrypted PDFs gracefully.
  *
  * Tests interact through system boundaries only: CLI subprocess, SQL via
- * docker exec psql, and filesystem. Never imports from packages/ or apps/.
+ * the shared env-driven SQL helper, and filesystem. Never imports from packages/ or apps/.
  */
 
 // ---------------------------------------------------------------------------
@@ -41,7 +38,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -50,32 +47,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanSourceData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 function writeTestConfig(overrides?: { max_pages?: number }): string {
@@ -171,7 +144,7 @@ function createMinimalPdf(pageCount: number): Buffer {
 
 beforeAll(() => {
 	tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-44-'));
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (pgAvailable) {
 		// Ensure migrations are applied — the schema may have been destroyed by
 		// other specs (e.g., spec 12's docker compose down -v) during the full suite.
@@ -245,7 +218,7 @@ describe('Issue #44: Lightweight PDF Metadata Extraction', () => {
 		expect(result.exitCode).toBe(0);
 
 		// Query the metadata JSONB column
-		const metadataRaw = runSql("SELECT metadata::text FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const metadataRaw = db.runSql("SELECT metadata::text FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(metadataRaw).not.toBe('');
 
 		const metadata = JSON.parse(metadataRaw);

--- a/tests/specs/22_story_repository.test.ts
+++ b/tests/specs/22_story_repository.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CORE_MODULE = resolve(ROOT, 'packages/core/dist/index.js');
@@ -15,16 +16,16 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
  * Tests interact through system boundaries only: SQL via pg, and
  * TypeScript imports from @mulder/core barrel (dist).
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with migrations applied.
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -43,20 +44,8 @@ let deleteStoriesBySourceId: (...args: unknown[]) => Promise<unknown>;
 let createSource: (...args: unknown[]) => Promise<unknown>;
 let DatabaseError: new (...args: unknown[]) => Error;
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 describe('Spec 22: Story Repository', () => {
@@ -65,11 +54,7 @@ describe('Spec 22: Story Repository', () => {
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -80,7 +65,7 @@ describe('Spec 22: Story Repository', () => {
 			cwd: ROOT,
 			encoding: 'utf-8',
 			timeout: 30000,
-			env: { ...process.env, PGPASSWORD: 'mulder' },
+			env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD },
 		});
 		if (migrateResult.status !== 0) {
 			throw new Error(`Migration failed: ${migrateResult.stdout} ${migrateResult.stderr}`);

--- a/tests/specs/23_segment_step.test.ts
+++ b/tests/specs/23_segment_step.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -12,20 +13,16 @@ const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 23: Segment Step
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -43,7 +40,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -52,32 +49,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql('DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 function cleanSegmentFixtures(): void {
@@ -109,7 +82,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -133,7 +106,7 @@ function ingestAndExtractPdf(pdfPath: string): string {
 	ensurePageImages(sourceId);
 
 	// Verify source is extracted
-	const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+	const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 	if (status !== 'extracted') {
 		throw new Error(`Source ${sourceId} has status '${status}', expected 'extracted'`);
 	}
@@ -186,13 +159,9 @@ describe('Spec 23 — Segment Step', () => {
 	let segmentationSucceeded = false;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -237,7 +206,7 @@ describe('Spec 23 — Segment Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Source status should be 'segmented' in database
-		const status = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		expect(status).toBe('segmented');
 
 		// Track success for downstream tests
@@ -257,17 +226,17 @@ describe('Spec 23 — Segment Step', () => {
 			expect(result.exitCode).toBe(0);
 		}
 
-		const storyCount = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${extractedSourceId}';`);
+		const storyCount = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${extractedSourceId}';`);
 		expect(Number.parseInt(storyCount, 10)).toBeGreaterThanOrEqual(1);
 
 		// Check that stories have required fields
-		const nullUris = runSql(
+		const nullUris = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${extractedSourceId}' AND (gcs_markdown_uri IS NULL OR gcs_metadata_uri IS NULL);`,
 		);
 		expect(Number.parseInt(nullUris, 10)).toBe(0);
 
 		// Check story status
-		const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${extractedSourceId}';`);
+		const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${extractedSourceId}';`);
 		expect(storyStatuses).toBe('segmented');
 	});
 
@@ -278,14 +247,14 @@ describe('Spec 23 — Segment Step', () => {
 		if (!extractedSourceId) return;
 
 		// If source not segmented, attempt segmentation — fail if it doesn't work
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		if (sourceStatus !== 'segmented') {
 			const result = segmentSource(extractedSourceId);
 			expect(result.exitCode).toBe(0);
 		}
 
 		// Get GCS Markdown URI from a story record
-		const markdownUri = runSql(
+		const markdownUri = db.runSql(
 			`SELECT gcs_markdown_uri FROM stories WHERE source_id = '${extractedSourceId}' LIMIT 1;`,
 		);
 		expect(markdownUri).not.toBe('');
@@ -305,14 +274,14 @@ describe('Spec 23 — Segment Step', () => {
 		if (!extractedSourceId) return;
 
 		// If source not segmented, attempt segmentation — fail if it doesn't work
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		if (sourceStatus !== 'segmented') {
 			const result = segmentSource(extractedSourceId);
 			expect(result.exitCode).toBe(0);
 		}
 
 		// Get GCS metadata URI from a story record
-		const metadataUri = runSql(
+		const metadataUri = db.runSql(
 			`SELECT gcs_metadata_uri FROM stories WHERE source_id = '${extractedSourceId}' LIMIT 1;`,
 		);
 		expect(metadataUri).not.toBe('');
@@ -341,13 +310,13 @@ describe('Spec 23 — Segment Step', () => {
 		if (!extractedSourceId) return;
 
 		// If source not segmented, attempt segmentation — fail if it doesn't work
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		if (sourceStatus !== 'segmented') {
 			const result = segmentSource(extractedSourceId);
 			expect(result.exitCode).toBe(0);
 		}
 
-		const stepRow = runSql(
+		const stepRow = db.runSql(
 			`SELECT step_name, status FROM source_steps WHERE source_id = '${extractedSourceId}' AND step_name = 'segment';`,
 		);
 		expect(stepRow).not.toBe('');
@@ -378,9 +347,9 @@ describe('Spec 23 — Segment Step', () => {
 		if (!extractedSourceId) return;
 
 		// Manually set the source to segmented status if not already
-		const currentStatus = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		if (currentStatus !== 'segmented') {
-			runSql(`UPDATE sources SET status = 'segmented' WHERE id = '${extractedSourceId}';`);
+			db.runSql(`UPDATE sources SET status = 'segmented' WHERE id = '${extractedSourceId}';`);
 		}
 
 		// Run segment without force
@@ -398,9 +367,9 @@ describe('Spec 23 — Segment Step', () => {
 		if (!extractedSourceId) return;
 
 		// First ensure the source is marked as segmented
-		const currentStatus = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		if (currentStatus !== 'segmented') {
-			runSql(`UPDATE sources SET status = 'segmented' WHERE id = '${extractedSourceId}';`);
+			db.runSql(`UPDATE sources SET status = 'segmented' WHERE id = '${extractedSourceId}';`);
 		}
 
 		// Ensure page images exist for re-segmentation
@@ -412,11 +381,11 @@ describe('Spec 23 — Segment Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Source status should be segmented
-		const status = runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${extractedSourceId}';`);
 		expect(status).toBe('segmented');
 
 		// Stories should exist
-		const afterCount = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${extractedSourceId}';`);
+		const afterCount = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${extractedSourceId}';`);
 		expect(Number.parseInt(afterCount, 10)).toBeGreaterThanOrEqual(1);
 	});
 
@@ -434,7 +403,7 @@ describe('Spec 23 — Segment Step', () => {
 		ingestAndExtractPdf(SCANNED_PDF);
 
 		// Verify both are extracted
-		const extractedCount = runSql("SELECT COUNT(*) FROM sources WHERE status = 'extracted';");
+		const extractedCount = db.runSql("SELECT COUNT(*) FROM sources WHERE status = 'extracted';");
 		expect(Number.parseInt(extractedCount, 10)).toBe(2);
 
 		// Segment all
@@ -442,7 +411,7 @@ describe('Spec 23 — Segment Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All sources should now be segmented
-		const segmentedCount = runSql("SELECT COUNT(*) FROM sources WHERE status = 'segmented';");
+		const segmentedCount = db.runSql("SELECT COUNT(*) FROM sources WHERE status = 'segmented';");
 		expect(Number.parseInt(segmentedCount, 10)).toBe(2);
 	});
 
@@ -453,7 +422,7 @@ describe('Spec 23 — Segment Step', () => {
 
 		// Use any segmented source — the shared extractedSourceId may have been
 		// cleaned up by QA-09. If none exists, create a fresh one.
-		let sourceId = runSql("SELECT id FROM sources WHERE status = 'segmented' LIMIT 1;");
+		let sourceId = db.runSql("SELECT id FROM sources WHERE status = 'segmented' LIMIT 1;");
 		if (!sourceId) {
 			cleanTestData();
 			cleanExtractedFixtures();
@@ -463,11 +432,11 @@ describe('Spec 23 — Segment Step', () => {
 			expect(result.exitCode).toBe(0);
 		}
 
-		const storyCount = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
+		const storyCount = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
 		expect(Number.parseInt(storyCount, 10)).toBeGreaterThanOrEqual(1);
 
 		// Check that all stories have valid page ranges
-		const invalidPageRanges = runSql(
+		const invalidPageRanges = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND (page_start IS NULL OR page_end IS NULL OR page_start > page_end);`,
 		);
 		expect(Number.parseInt(invalidPageRanges, 10)).toBe(0);
@@ -488,22 +457,22 @@ describe('Spec 23 — Segment Step', () => {
 		const first = runCli(['segment', sourceId, '--force']);
 		expect(first.exitCode).toBe(0);
 
-		const storyCountAfterFirst = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
+		const storyCountAfterFirst = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
 
 		// Second force segmentation
 		const second = runCli(['segment', sourceId, '--force']);
 		expect(second.exitCode).toBe(0);
 
 		// Source should still be segmented
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('segmented');
 
 		// Story count should be the same (no duplicates)
-		const storyCountAfterSecond = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
+		const storyCountAfterSecond = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
 		expect(storyCountAfterSecond).toBe(storyCountAfterFirst);
 
 		// No duplicate source_steps records
-		const stepCount = runSql(
+		const stepCount = db.runSql(
 			`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'segment';`,
 		);
 		expect(stepCount).toBe('1');
@@ -516,7 +485,7 @@ describe('Spec 23 — Segment Step', () => {
 
 		// Use any segmented source — the shared extractedSourceId may have been
 		// cleaned up by QA-09. If none exists, create a fresh one.
-		let sourceId = runSql("SELECT id FROM sources WHERE status = 'segmented' LIMIT 1;");
+		let sourceId = db.runSql("SELECT id FROM sources WHERE status = 'segmented' LIMIT 1;");
 		if (!sourceId) {
 			cleanTestData();
 			cleanExtractedFixtures();
@@ -526,11 +495,13 @@ describe('Spec 23 — Segment Step', () => {
 			expect(result.exitCode).toBe(0);
 		}
 
-		const storyCount = runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
+		const storyCount = db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`);
 		expect(Number.parseInt(storyCount, 10)).toBeGreaterThanOrEqual(1);
 
 		// Get all story GCS URIs
-		const rows = runSql(`SELECT id, gcs_markdown_uri, gcs_metadata_uri FROM stories WHERE source_id = '${sourceId}';`);
+		const rows = db.runSql(
+			`SELECT id, gcs_markdown_uri, gcs_metadata_uri FROM stories WHERE source_id = '${sourceId}';`,
+		);
 
 		for (const row of rows.split('\n').filter(Boolean)) {
 			const [_storyId, markdownUri, metadataUri] = row.split('|');
@@ -610,7 +581,7 @@ describe('CLI Smoke Tests: segment', () => {
 
 	it('SMOKE-03: mulder segment --all --force does not crash (exits cleanly even if no sources)', () => {
 		// This tests that --all and --force can be combined without crash
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { stdout, stderr } = runCli(['segment', '--all', '--force'], { timeout: 60000 });
@@ -624,7 +595,7 @@ describe('CLI Smoke Tests: segment', () => {
 	// ─── SMOKE-04: invalid UUID format as source-id ───
 
 	it('SMOKE-04: mulder segment with non-UUID source-id gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['segment', 'not-a-valid-uuid']);

--- a/tests/specs/24_entity_alias_repositories.test.ts
+++ b/tests/specs/24_entity_alias_repositories.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -16,16 +17,16 @@ const DB_MODULE = resolve(ROOT, 'packages/core/dist/database/index.js');
  * Tests interact through system boundaries only: SQL via pg, and
  * TypeScript imports from the database barrel (dist).
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with migrations applied through 015.
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -52,20 +53,8 @@ let createStory: (...args: unknown[]) => Promise<unknown>;
 let deleteStory: (...args: unknown[]) => Promise<unknown>;
 let DatabaseError: new (...args: unknown[]) => Error;
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 describe('Spec 24: Entity + Alias Repositories', () => {
@@ -74,11 +63,7 @@ describe('Spec 24: Entity + Alias Repositories', () => {
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -89,7 +74,7 @@ describe('Spec 24: Entity + Alias Repositories', () => {
 			cwd: ROOT,
 			encoding: 'utf-8',
 			timeout: 30000,
-			env: { ...process.env, PGPASSWORD: 'mulder' },
+			env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD },
 		});
 		if (migrateResult.status !== 0) {
 			throw new Error(`Migration failed: ${migrateResult.stdout} ${migrateResult.stderr}`);

--- a/tests/specs/25_edge_repository.test.ts
+++ b/tests/specs/25_edge_repository.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CORE_MODULE = resolve(ROOT, 'packages/core/dist/index.js');
@@ -13,16 +14,16 @@ const DB_MODULE = resolve(ROOT, 'packages/core/dist/database/index.js');
  * Tests interact through system boundaries only: SQL via pg, and
  * TypeScript imports from the database barrel (dist).
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with migrations applied through 016.
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -52,20 +53,8 @@ let createStory: (...args: unknown[]) => Promise<unknown>;
 let deleteStory: (...args: unknown[]) => Promise<unknown>;
 let DatabaseError: new (...args: unknown[]) => Error;
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 describe('Spec 25: Edge Repository', () => {
@@ -74,11 +63,7 @@ describe('Spec 25: Edge Repository', () => {
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 

--- a/tests/specs/27_taxonomy_normalization.test.ts
+++ b/tests/specs/27_taxonomy_normalization.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -27,11 +28,11 @@ const TAXONOMY_MODULE = resolve(ROOT, 'packages/taxonomy/dist/index.js');
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -52,20 +53,8 @@ let normalizeTaxonomy: (...args: unknown[]) => Promise<unknown>;
 // Config loader
 let loadConfig: (...args: unknown[]) => Promise<unknown>;
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 describe('Spec 27: Taxonomy Normalization — QA Contract', () => {
@@ -74,11 +63,7 @@ describe('Spec 27: Taxonomy Normalization — QA Contract', () => {
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -89,7 +74,7 @@ describe('Spec 27: Taxonomy Normalization — QA Contract', () => {
 			cwd: ROOT,
 			encoding: 'utf-8',
 			timeout: 30000,
-			env: { ...process.env, PGPASSWORD: 'mulder' },
+			env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD },
 		});
 		if (migrateResult.status !== 0) {
 			throw new Error(`Migration failed: ${migrateResult.stdout} ${migrateResult.stderr}`);

--- a/tests/specs/28_cross_lingual_entity_resolution.test.ts
+++ b/tests/specs/28_cross_lingual_entity_resolution.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -27,11 +28,11 @@ const ENRICH_MODULE = resolve(ROOT, 'packages/pipeline/dist/enrich/index.js');
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -109,20 +110,8 @@ function cosineSim(a: number[], b: number[]): number {
 	return dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 /** Build entity resolution config with all tiers enabled by default. */
@@ -195,11 +184,7 @@ describe('Spec 28: Cross-Lingual Entity Resolution -- QA Contract', () => {
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -210,7 +195,7 @@ describe('Spec 28: Cross-Lingual Entity Resolution -- QA Contract', () => {
 			cwd: ROOT,
 			encoding: 'utf-8',
 			timeout: 30000,
-			env: { ...process.env, PGPASSWORD: 'mulder' },
+			env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD },
 		});
 		if (migrateResult.status !== 0) {
 			throw new Error(`Migration failed: ${migrateResult.stdout} ${migrateResult.stderr}`);

--- a/tests/specs/29_enrich_step.test.ts
+++ b/tests/specs/29_enrich_step.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -12,20 +13,16 @@ const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 29: Enrich Step
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -43,7 +40,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -52,32 +49,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -129,7 +102,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -156,7 +129,7 @@ function ingestExtractSegment(pdfPath: string): string {
 	}
 
 	// Verify status
-	const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+	const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 	if (status !== 'segmented') {
 		throw new Error(`Source ${sourceId} has status '${status}', expected 'segmented'`);
 	}
@@ -168,7 +141,7 @@ function ingestExtractSegment(pdfPath: string): string {
  * Get a story ID from a segmented source.
  */
 function getStoryId(sourceId: string): string {
-	const storyId = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'segmented' LIMIT 1;`);
+	const storyId = db.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'segmented' LIMIT 1;`);
 	if (!storyId) {
 		throw new Error(`No segmented story found for source ${sourceId}`);
 	}
@@ -185,13 +158,9 @@ describe('Spec 29 — Enrich Step', () => {
 	let segmentedStoryId: string | null = null;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -233,21 +202,21 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(result.exitCode).toBe(0);
 
 		// Story status should be 'enriched'
-		const storyStatus = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const storyStatus = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		expect(storyStatus).toBe('enriched');
 
 		// Entities should be created
-		const entityCount = runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`);
+		const entityCount = db.runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`);
 		expect(Number.parseInt(entityCount, 10)).toBeGreaterThanOrEqual(1);
 
 		// Entities table should have rows
-		const totalEntities = runSql(
+		const totalEntities = db.runSql(
 			`SELECT COUNT(*) FROM entities WHERE id IN (SELECT entity_id FROM story_entities WHERE story_id = '${segmentedStoryId}');`,
 		);
 		expect(Number.parseInt(totalEntities, 10)).toBeGreaterThanOrEqual(1);
 
 		// Source step should be upserted as 'completed'
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${segmentedSourceId}' AND step_name = 'enrich';`,
 		);
 		expect(stepStatus).toBe('completed');
@@ -266,7 +235,7 @@ describe('Spec 29 — Enrich Step', () => {
 		ingestExtractSegment(SCANNED_PDF);
 
 		// Verify both have segmented stories
-		const segCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'segmented';");
+		const segCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'segmented';");
 		expect(Number.parseInt(segCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Enrich all
@@ -274,10 +243,10 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All previously segmented stories should now be enriched
-		const remainingSegmented = runSql("SELECT COUNT(*) FROM stories WHERE status = 'segmented';");
+		const remainingSegmented = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'segmented';");
 		expect(Number.parseInt(remainingSegmented, 10)).toBe(0);
 
-		const enrichedCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
+		const enrichedCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
 		expect(Number.parseInt(enrichedCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Restore state for subsequent tests
@@ -304,13 +273,13 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Source 1 stories should be enriched
-		const source1Enriched = runSql(
+		const source1Enriched = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId1}' AND status = 'enriched';`,
 		);
 		expect(Number.parseInt(source1Enriched, 10)).toBeGreaterThanOrEqual(1);
 
 		// Source 2 stories should still be segmented
-		const source2Segmented = runSql(
+		const source2Segmented = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId2}' AND status = 'segmented';`,
 		);
 		expect(Number.parseInt(source2Segmented, 10)).toBeGreaterThanOrEqual(1);
@@ -328,7 +297,7 @@ describe('Spec 29 — Enrich Step', () => {
 		if (!pgAvailable || !segmentedStoryId || !segmentedSourceId) return;
 
 		// First ensure the story is enriched
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		if (currentStatus !== 'enriched') {
 			const { exitCode } = runCli(['enrich', segmentedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -336,7 +305,7 @@ describe('Spec 29 — Enrich Step', () => {
 
 		// Record entity count before force (used to verify re-extraction)
 		const countBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`),
+			db.runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`),
 			10,
 		);
 		expect(countBefore).toBeGreaterThanOrEqual(0);
@@ -346,11 +315,11 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Story should be enriched again
-		const status = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const status = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		expect(status).toBe('enriched');
 
 		// story_entities should exist (may be same or different count)
-		const entitiesAfter = runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`);
+		const entitiesAfter = db.runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${segmentedStoryId}';`);
 		expect(Number.parseInt(entitiesAfter, 10)).toBeGreaterThanOrEqual(1);
 	}, 120000);
 
@@ -360,7 +329,7 @@ describe('Spec 29 — Enrich Step', () => {
 		if (!pgAvailable || !segmentedSourceId) return;
 
 		// Ensure stories are enriched first
-		const enrichedCount = runSql(
+		const enrichedCount = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${segmentedSourceId}' AND status = 'enriched';`,
 		);
 		if (Number.parseInt(enrichedCount, 10) === 0) {
@@ -373,7 +342,7 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All stories from source should be enriched
-		const allEnriched = runSql(
+		const allEnriched = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${segmentedSourceId}' AND status = 'enriched';`,
 		);
 		expect(Number.parseInt(allEnriched, 10)).toBeGreaterThanOrEqual(1);
@@ -385,7 +354,7 @@ describe('Spec 29 — Enrich Step', () => {
 		if (!pgAvailable || !segmentedStoryId) return;
 
 		// Ensure story is enriched
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		if (currentStatus !== 'enriched') {
 			const { exitCode } = runCli(['enrich', segmentedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -408,18 +377,18 @@ describe('Spec 29 — Enrich Step', () => {
 
 		// Create an isolated source + story via SQL to avoid dedup collision
 		// with the main test source (ingestPdf would return the existing source ID)
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (filename, file_hash, storage_path, page_count, status) ` +
 				`VALUES ('qa07-test.pdf', 'qa07-unique-hash', 'raw/qa07-test.pdf', 1, 'ingested');`,
 		);
-		const sourceId = runSql(`SELECT id FROM sources WHERE file_hash = 'qa07-unique-hash';`);
+		const sourceId = db.runSql(`SELECT id FROM sources WHERE file_hash = 'qa07-unique-hash';`);
 
 		// Manually create a story with status 'ingested' (simulating pre-segmentation state)
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) ` +
 				`VALUES ('${sourceId}', 'test-invalid-status', 'segments/test/dummy.md', 'segments/test/dummy.meta.json', 'ingested');`,
 		);
-		const storyId = runSql(
+		const storyId = db.runSql(
 			`SELECT id FROM stories WHERE source_id = '${sourceId}' AND title = 'test-invalid-status' LIMIT 1;`,
 		);
 
@@ -430,7 +399,7 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(combined).toMatch(/ENRICH_INVALID_STATUS|invalid status|not segmented|cannot enrich/i);
 
 		// Cleanup — scoped to the isolated source only
-		runSql(
+		db.runSql(
 			`DELETE FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM entity_edges WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM stories WHERE source_id = '${sourceId}';` +
@@ -445,7 +414,7 @@ describe('Spec 29 — Enrich Step', () => {
 		if (!pgAvailable || !segmentedStoryId) return;
 
 		// Ensure story is enriched
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		if (currentStatus !== 'enriched') {
 			const { exitCode } = runCli(['enrich', segmentedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -453,12 +422,12 @@ describe('Spec 29 — Enrich Step', () => {
 
 		// Check that entities linked to this story have canonical_id set
 		// (taxonomy normalization should assign canonical_id)
-		const entitiesWithCanonical = runSql(
+		const entitiesWithCanonical = db.runSql(
 			`SELECT COUNT(*) FROM entities e ` +
 				`JOIN story_entities se ON e.id = se.entity_id ` +
 				`WHERE se.story_id = '${segmentedStoryId}' AND e.canonical_id IS NOT NULL;`,
 		);
-		const totalEntities = runSql(
+		const totalEntities = db.runSql(
 			`SELECT COUNT(*) FROM entities e ` +
 				`JOIN story_entities se ON e.id = se.entity_id ` +
 				`WHERE se.story_id = '${segmentedStoryId}';`,
@@ -497,7 +466,7 @@ describe('Spec 29 — Enrich Step', () => {
 		// Check for any entity appearing in stories from both sources
 		// (entity resolution should produce shared entities when names match)
 		const sharedCount = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(DISTINCT e.id) FROM entities e ` +
 					`JOIN story_entities se1 ON e.id = se1.entity_id ` +
 					`JOIN stories s1 ON se1.story_id = s1.id AND s1.source_id = '${sourceId1}' ` +
@@ -509,8 +478,8 @@ describe('Spec 29 — Enrich Step', () => {
 
 		// We can't guarantee entity overlap with arbitrary test PDFs,
 		// but we CAN verify the resolution path ran: check entity count
-		const totalEntityIds = Number.parseInt(runSql('SELECT COUNT(DISTINCT entity_id) FROM story_entities;'), 10);
-		const totalRows = Number.parseInt(runSql('SELECT COUNT(*) FROM story_entities;'), 10);
+		const totalEntityIds = Number.parseInt(db.runSql('SELECT COUNT(DISTINCT entity_id) FROM story_entities;'), 10);
+		const totalRows = Number.parseInt(db.runSql('SELECT COUNT(*) FROM story_entities;'), 10);
 
 		// At minimum, entities table should be populated from both sources
 		expect(totalEntityIds).toBeGreaterThanOrEqual(1);
@@ -539,14 +508,14 @@ describe('Spec 29 — Enrich Step', () => {
 		const storyId = segmentedStoryId;
 		if (!storyId) return;
 
-		const status = runSql(`SELECT status FROM stories WHERE id = '${storyId}';`);
+		const status = db.runSql(`SELECT status FROM stories WHERE id = '${storyId}';`);
 		if (status !== 'enriched') {
 			const { exitCode } = runCli(['enrich', storyId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Verify entities exist and are in a consistent state (no partial writes from deadlocks)
-		const entities = runSql(
+		const entities = db.runSql(
 			`SELECT e.type, e.name FROM entities e ` +
 				`JOIN story_entities se ON e.id = se.entity_id ` +
 				`WHERE se.story_id = '${storyId}' ORDER BY e.type, e.name;`,
@@ -554,7 +523,7 @@ describe('Spec 29 — Enrich Step', () => {
 		expect(entities.length).toBeGreaterThan(0);
 
 		// All entities should have non-null type and name
-		const nullTypeOrName = runSql(
+		const nullTypeOrName = db.runSql(
 			`SELECT COUNT(*) FROM entities e ` +
 				`JOIN story_entities se ON e.id = se.entity_id ` +
 				`WHERE se.story_id = '${storyId}' AND (e.type IS NULL OR e.name IS NULL);`,
@@ -568,21 +537,21 @@ describe('Spec 29 — Enrich Step', () => {
 		if (!pgAvailable || !segmentedStoryId) return;
 
 		// Ensure story is enriched
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${segmentedStoryId}';`);
 		if (currentStatus !== 'enriched') {
 			const { exitCode } = runCli(['enrich', segmentedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Check entity_edges for this story
-		const edgeCount = runSql(`SELECT COUNT(*) FROM entity_edges WHERE story_id = '${segmentedStoryId}';`);
+		const edgeCount = db.runSql(`SELECT COUNT(*) FROM entity_edges WHERE story_id = '${segmentedStoryId}';`);
 
 		// Edges may or may not exist depending on extracted content,
 		// but if they do, they should have valid references
 		const numEdges = Number.parseInt(edgeCount, 10);
 		if (numEdges > 0) {
 			// All edges should reference existing entities
-			const orphanEdges = runSql(
+			const orphanEdges = db.runSql(
 				`SELECT COUNT(*) FROM entity_edges ee ` +
 					`WHERE ee.story_id = '${segmentedStoryId}' ` +
 					`AND (ee.source_entity_id NOT IN (SELECT id FROM entities) ` +
@@ -591,7 +560,7 @@ describe('Spec 29 — Enrich Step', () => {
 			expect(Number.parseInt(orphanEdges, 10)).toBe(0);
 
 			// All edges should have a non-empty relationship type
-			const emptyRelationship = runSql(
+			const emptyRelationship = db.runSql(
 				`SELECT COUNT(*) FROM entity_edges ` +
 					`WHERE story_id = '${segmentedStoryId}' AND (relationship IS NULL OR relationship = '');`,
 			);
@@ -631,7 +600,7 @@ describe('Spec 29 — Enrich Step', () => {
 		// fix this column did not exist and the normalizeTaxonomy result was
 		// silently discarded.
 		const totalEntities = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM entities WHERE id IN (` +
 					`SELECT entity_id FROM story_entities WHERE story_id = '${segmentedStoryId}'` +
 					`);`,
@@ -639,7 +608,7 @@ describe('Spec 29 — Enrich Step', () => {
 			10,
 		);
 		const linkedEntities = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM entities WHERE taxonomy_id IS NOT NULL AND id IN (` +
 					`SELECT entity_id FROM story_entities WHERE story_id = '${segmentedStoryId}'` +
 					`);`,
@@ -672,7 +641,7 @@ describe('Spec 29 — Enrich Step', () => {
 		// Find any name+type that exists in both source's stories. If at
 		// least one shared entity exists (the dev fixtures share several),
 		// it must have exactly one row and a non-null taxonomy_id.
-		const sharedRows = runSql(
+		const sharedRows = db.runSql(
 			`SELECT e.id, e.name, e.type, e.taxonomy_id FROM entities e ` +
 				`WHERE e.id IN (` +
 				`  SELECT se.entity_id FROM story_entities se ` +
@@ -732,7 +701,7 @@ describe('CLI Test Matrix: enrich', () => {
 	// ─── CLI-02: No arguments ───
 
 	it('CLI-02: mulder enrich with no args gives non-zero exit and error', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['enrich']);
@@ -755,7 +724,7 @@ describe('CLI Test Matrix: enrich', () => {
 	// ─── CLI-04: --source without --all ───
 
 	it('CLI-04: mulder enrich --source <id> is valid usage (does not require --all)', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		// Use a fake source ID — should fail with "not found" not "invalid args"
@@ -784,7 +753,7 @@ describe('CLI Smoke Tests: enrich', () => {
 	// ─── SMOKE-02: --force without story-id or --source gives error ───
 
 	it('SMOKE-02: mulder enrich --force (no story-id, no --source) gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['enrich', '--force']);
@@ -797,7 +766,7 @@ describe('CLI Smoke Tests: enrich', () => {
 	// ─── SMOKE-03: invalid UUID format as story-id ───
 
 	it('SMOKE-03: mulder enrich with non-UUID story-id gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['enrich', 'not-a-valid-uuid']);
@@ -820,7 +789,7 @@ describe('CLI Smoke Tests: enrich', () => {
 	// ─── SMOKE-05: --source with --all is valid (source scopes the --all) ───
 
 	it('SMOKE-05: mulder enrich --source <id> --force does not crash (valid combo)', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeSourceId = '00000000-0000-0000-0000-000000000001';

--- a/tests/specs/30_cascading_reset_function.test.ts
+++ b/tests/specs/30_cascading_reset_function.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -12,20 +13,16 @@ const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 30: Cascading Reset Function
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -43,7 +40,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -52,34 +49,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM chunks; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -130,7 +101,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -156,7 +127,7 @@ function ingestExtractSegment(pdfPath: string): string {
 		throw new Error(`Segment failed: ${segResult.stdout} ${segResult.stderr}`);
 	}
 
-	const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+	const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 	if (status !== 'segmented') {
 		throw new Error(`Source ${sourceId} has status '${status}', expected 'segmented'`);
 	}
@@ -180,7 +151,7 @@ function ingestExtractSegmentEnrich(pdfPath: string): string {
 
 	// Verify stories are enriched (source status stays 'segmented' — enrich is story-level)
 	const enrichedCount = Number.parseInt(
-		runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
+		db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
 		10,
 	);
 	if (enrichedCount === 0) {
@@ -209,7 +180,7 @@ function extractJsonLine(output: string, expectedKey: string): Record<string, un
 }
 
 function getStoryId(sourceId: string): string {
-	const storyId = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
+	const storyId = db.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
 	if (!storyId) {
 		throw new Error(`No story found for source ${sourceId}`);
 	}
@@ -224,13 +195,9 @@ describe('Spec 30 — Cascading Reset Function', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -266,14 +233,14 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Verify pre-condition: stories exist
 		const storyCountBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(storyCountBefore).toBeGreaterThanOrEqual(1);
 
 		// Verify pre-condition: source_steps exist
 		const stepCountBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(stepCountBefore).toBeGreaterThanOrEqual(1);
@@ -284,7 +251,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Assert: source status is back to 'ingested' (extract resets to ingested then re-extracts)
 		// Actually after --force, the extract step re-runs, so status should be 'extracted'
-		const statusAfter = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const statusAfter = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(statusAfter).toBe('extracted');
 
 		// Assert: old stories were deleted (new ones may have been created by re-extraction if extract creates stories, but extract doesn't create stories - that's segment)
@@ -292,7 +259,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		// Then extract re-runs which only produces GCS artifacts, not stories
 		// So there should be NO stories (segment hasn't re-run)
 		const storyCountAfter = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(storyCountAfter).toBe(0);
@@ -317,13 +284,13 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Verify pre-condition: stories exist
 		const storyCountBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(storyCountBefore).toBeGreaterThanOrEqual(1);
 
 		// Verify source_steps for segment exist
-		const segStepBefore = runSql(
+		const segStepBefore = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'segment';`,
 		);
 		expect(segStepBefore).toBe('completed');
@@ -334,12 +301,12 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		expect(exitCode).toBe(0);
 
 		// After --force, segment re-runs so status should be 'segmented' again and new stories exist
-		const statusAfter = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const statusAfter = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(statusAfter).toBe('segmented');
 
 		// New stories should exist (from re-segmentation)
 		const storyCountAfter = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(storyCountAfter).toBeGreaterThanOrEqual(1);
@@ -364,7 +331,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Verify pre-condition: story_entities exist
 		const seCountBefore = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`,
 			),
 			10,
@@ -372,7 +339,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		expect(seCountBefore).toBeGreaterThanOrEqual(1);
 
 		// Verify enrich source_step exists
-		const enrichStepBefore = runSql(
+		const enrichStepBefore = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'enrich';`,
 		);
 		expect(enrichStepBefore).toBe('completed');
@@ -382,19 +349,19 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		expect(exitCode).toBe(0);
 
 		// After --force re-enrichment, source status stays 'segmented' (enrich is story-level)
-		const statusAfter = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const statusAfter = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(statusAfter).toBe('segmented');
 
 		// Stories should be enriched again after re-enrichment
 		const enrichedStoriesAfter = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
 			10,
 		);
 		expect(enrichedStoriesAfter).toBeGreaterThanOrEqual(1);
 
 		// story_entities should exist again (re-enriched)
 		const seCountAfter = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`,
 			),
 			10,
@@ -402,7 +369,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		expect(seCountAfter).toBeGreaterThanOrEqual(1);
 
 		// Enrich source_step should be completed again
-		const enrichStepAfter = runSql(
+		const enrichStepAfter = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'enrich';`,
 		);
 		expect(enrichStepAfter).toBe('completed');
@@ -426,25 +393,28 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Verify pre-condition: story has entities
 		const seCountBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${storyId}';`),
+			db.runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${storyId}';`),
 			10,
 		);
 		expect(seCountBefore).toBeGreaterThanOrEqual(1);
 
 		// Check if there are other stories
-		const allStoryIds = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`).split('\n').filter(Boolean);
+		const allStoryIds = db
+			.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`)
+			.split('\n')
+			.filter(Boolean);
 
 		// Act: enrich single story with --force
 		const { exitCode } = runCli(['enrich', storyId, '--force'], { timeout: 120000 });
 		expect(exitCode).toBe(0);
 
 		// The targeted story should be enriched
-		const storyStatus = runSql(`SELECT status FROM stories WHERE id = '${storyId}';`);
+		const storyStatus = db.runSql(`SELECT status FROM stories WHERE id = '${storyId}';`);
 		expect(storyStatus).toBe('enriched');
 
 		// Story entities should exist again
 		const seCountAfter = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${storyId}';`),
+			db.runSql(`SELECT COUNT(*) FROM story_entities WHERE story_id = '${storyId}';`),
 			10,
 		);
 		expect(seCountAfter).toBeGreaterThanOrEqual(1);
@@ -452,7 +422,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		// Other stories (if any) should still be enriched (untouched)
 		for (const otherId of allStoryIds) {
 			if (otherId === storyId) continue;
-			const otherStatus = runSql(`SELECT status FROM stories WHERE id = '${otherId}';`);
+			const otherStatus = db.runSql(`SELECT status FROM stories WHERE id = '${otherId}';`);
 			expect(otherStatus).toBe('enriched');
 		}
 	}, 180000);
@@ -468,11 +438,11 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		cleanTestData();
 
 		// Insert orphaned entities (no story_entities references)
-		runSql(`INSERT INTO entities (name, type) VALUES ('OrphanEntity1', 'person'), ('OrphanEntity2', 'location');`);
+		db.runSql(`INSERT INTO entities (name, type) VALUES ('OrphanEntity1', 'person'), ('OrphanEntity2', 'location');`);
 
 		// Verify they exist
 		const countBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM entities WHERE name IN ('OrphanEntity1', 'OrphanEntity2');`),
+			db.runSql(`SELECT COUNT(*) FROM entities WHERE name IN ('OrphanEntity1', 'OrphanEntity2');`),
 			10,
 		);
 		expect(countBefore).toBe(2);
@@ -488,7 +458,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Orphaned entities should be deleted
 		const countAfter = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM entities WHERE name IN ('OrphanEntity1', 'OrphanEntity2');`),
+			db.runSql(`SELECT COUNT(*) FROM entities WHERE name IN ('OrphanEntity1', 'OrphanEntity2');`),
 			10,
 		);
 		expect(countAfter).toBe(0);
@@ -503,7 +473,7 @@ describe('Spec 30 — Cascading Reset Function', () => {
 
 		// Clean state and insert orphans
 		cleanTestData();
-		runSql(`INSERT INTO entities (name, type) VALUES ('JsonOrphan1', 'person');`);
+		db.runSql(`INSERT INTO entities (name, type) VALUES ('JsonOrphan1', 'person');`);
 
 		// Act
 		const { exitCode, stdout } = runCli(['db', 'gc', '--json', EXAMPLE_CONFIG]);
@@ -554,18 +524,18 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		const storyIdB = getStoryId(sourceIdB);
 
 		// Create a shared entity and link it to both stories
-		runSql(`INSERT INTO entities (name, type) VALUES ('SharedEntity_USA', 'location');`);
-		const sharedEntityId = runSql(`SELECT id FROM entities WHERE name = 'SharedEntity_USA';`);
-		runSql(
+		db.runSql(`INSERT INTO entities (name, type) VALUES ('SharedEntity_USA', 'location');`);
+		const sharedEntityId = db.runSql(`SELECT id FROM entities WHERE name = 'SharedEntity_USA';`);
+		db.runSql(
 			`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ('${storyIdA}', '${sharedEntityId}', 0.9) ON CONFLICT DO NOTHING;`,
 		);
-		runSql(
+		db.runSql(
 			`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ('${storyIdB}', '${sharedEntityId}', 0.85) ON CONFLICT DO NOTHING;`,
 		);
 
 		// Verify both links exist
 		const linkCountBefore = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${sharedEntityId}';`),
+			db.runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${sharedEntityId}';`),
 			10,
 		);
 		expect(linkCountBefore).toBeGreaterThanOrEqual(2);
@@ -575,11 +545,11 @@ describe('Spec 30 — Cascading Reset Function', () => {
 		expect(exitCode).toBe(0);
 
 		// Assert: shared entity still exists in entities table
-		const entityExists = runSql(`SELECT COUNT(*) FROM entities WHERE id = '${sharedEntityId}';`);
+		const entityExists = db.runSql(`SELECT COUNT(*) FROM entities WHERE id = '${sharedEntityId}';`);
 		expect(Number.parseInt(entityExists, 10)).toBe(1);
 
 		// Assert: Source B's link to the shared entity still exists
-		const linkB = runSql(
+		const linkB = db.runSql(
 			`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${sharedEntityId}' AND story_id = '${storyIdB}';`,
 		);
 		expect(Number.parseInt(linkB, 10)).toBe(1);
@@ -673,34 +643,12 @@ describe('CLI Smoke Tests: mulder db gc', () => {
 	}, 10000);
 
 	it('SMOKE-04: mulder db gc --json with no orphans produces valid JSON with deleted: 0', () => {
-		let pgAvail: boolean;
-		try {
-			execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-				encoding: 'utf-8',
-				timeout: 5000,
-			});
-			pgAvail = true;
-		} catch {
-			pgAvail = false;
-		}
-		if (!pgAvail) return;
+		if (!db.isPgAvailable()) return;
 
 		// Clean all entities
 		try {
-			execFileSync(
-				'docker',
-				[
-					'exec',
-					PG_CONTAINER,
-					'psql',
-					'-U',
-					PG_USER,
-					'-d',
-					'mulder',
-					'-c',
-					'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities;',
-				],
-				{ encoding: 'utf-8', timeout: 10000 },
+			db.runSql(
+				'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities;',
 			);
 		} catch {
 			// ignore
@@ -715,17 +663,7 @@ describe('CLI Smoke Tests: mulder db gc', () => {
 	}, 30000);
 
 	it('SMOKE-05: mulder db gc --json flag order does not matter (flag after config path)', () => {
-		let pgAvail: boolean;
-		try {
-			execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-				encoding: 'utf-8',
-				timeout: 5000,
-			});
-			pgAvail = true;
-		} catch {
-			pgAvail = false;
-		}
-		if (!pgAvail) return;
+		if (!db.isPgAvailable()) return;
 
 		// Try: mulder db gc <config> --json (flag after argument)
 		const { exitCode, stdout } = runCli(['db', 'gc', EXAMPLE_CONFIG, '--json']);

--- a/tests/specs/32_embedding_wrapper_semantic_chunker_chunk_repository.test.ts
+++ b/tests/specs/32_embedding_wrapper_semantic_chunker_chunk_repository.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -16,16 +17,16 @@ const PIPELINE_MODULE = resolve(ROOT, 'packages/pipeline/dist/index.js');
  * Tests import from the built dist barrels (@mulder/core, @mulder/pipeline)
  * as the system boundary for library modules.
  *
- * Requires a running PostgreSQL instance with pgvector (mulder-pg-test)
+ * Requires a running PostgreSQL instance with pgvector (PGHOST/PGPORT)
  * and migrations applied.
  */
 
 const PG_CONFIG = {
-	host: 'localhost',
-	port: 5432,
-	database: 'mulder',
-	user: 'mulder',
-	password: 'mulder',
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
 };
 
 let pool: pg.Pool;
@@ -48,20 +49,8 @@ let searchByFts: (...args: unknown[]) => Promise<unknown>;
 let createSource: (...args: unknown[]) => Promise<unknown>;
 let createStory: (...args: unknown[]) => Promise<unknown>;
 
-function isPgAvailable(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const testPool = new pg.Pool(PG_CONFIG);
-		testPool
-			.query('SELECT 1')
-			.then(() => {
-				testPool.end();
-				resolve(true);
-			})
-			.catch(() => {
-				testPool.end().catch(() => {});
-				resolve(false);
-			});
-	});
+async function isPgAvailable(): Promise<boolean> {
+	return db.isPgAvailable();
 }
 
 /**
@@ -170,11 +159,7 @@ describe('Spec 32: Embedding Wrapper + Semantic Chunker + Chunk Repository', () 
 	beforeAll(async () => {
 		pgAvailable = await isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -185,7 +170,7 @@ describe('Spec 32: Embedding Wrapper + Semantic Chunker + Chunk Repository', () 
 			cwd: ROOT,
 			encoding: 'utf-8',
 			timeout: 30000,
-			env: { ...process.env, PGPASSWORD: 'mulder' },
+			env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD },
 		});
 		if (migrateResult.status !== 0) {
 			throw new Error(`Migration failed: ${migrateResult.stdout} ${migrateResult.stderr}`);

--- a/tests/specs/33_qa_schema_conformance.test.ts
+++ b/tests/specs/33_qa_schema_conformance.test.ts
@@ -1,15 +1,12 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * QA Gate — Schema Conformance (QA-1)
@@ -39,7 +36,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -49,29 +46,11 @@ function runCli(
 }
 
 function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
+	return db.runSql(sql);
 }
 
 function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
+	return db.isPgAvailable();
 }
 
 /**
@@ -207,11 +186,7 @@ describe('Spec 33 — QA-1: Schema Conformance', () => {
 	beforeAll(() => {
 		pgAvailable = isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 

--- a/tests/specs/34_embed_step.test.ts
+++ b/tests/specs/34_embed_step.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -12,20 +13,16 @@ const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 34: Embed Step
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  * - Test fixtures in fixtures/raw/
  */
@@ -43,7 +40,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -52,32 +49,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM chunks; DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -129,7 +102,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -162,7 +135,7 @@ function ingestExtractSegmentEnrich(pdfPath: string): string {
 	}
 
 	// Verify status
-	const status = runSql(`SELECT status FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
+	const status = db.runSql(`SELECT status FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
 	if (status !== 'enriched') {
 		throw new Error(`Source ${sourceId} stories have status '${status}', expected 'enriched'`);
 	}
@@ -174,7 +147,7 @@ function ingestExtractSegmentEnrich(pdfPath: string): string {
  * Get a story ID from an enriched source.
  */
 function getEnrichedStoryId(sourceId: string): string {
-	const storyId = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched' LIMIT 1;`);
+	const storyId = db.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched' LIMIT 1;`);
 	if (!storyId) {
 		throw new Error(`No enriched story found for source ${sourceId}`);
 	}
@@ -191,13 +164,9 @@ describe('Spec 34 — Embed Step', () => {
 	let enrichedStoryId: string | null = null;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -239,11 +208,11 @@ describe('Spec 34 — Embed Step', () => {
 		expect(result.exitCode).toBe(0);
 
 		// Story status should be 'embedded'
-		const storyStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const storyStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		expect(storyStatus).toBe('embedded');
 
 		// Content chunks should exist with is_question=false
-		const contentChunkCount = runSql(
+		const contentChunkCount = db.runSql(
 			`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}' AND is_question = false;`,
 		);
 		expect(Number.parseInt(contentChunkCount, 10)).toBeGreaterThanOrEqual(1);
@@ -255,7 +224,7 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedStoryId) return;
 
 		// Ensure the story is embedded (from QA-01 or force)
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		if (currentStatus !== 'embedded') {
 			const { exitCode } = runCli(['embed', enrichedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -263,7 +232,7 @@ describe('Spec 34 — Embed Step', () => {
 
 		// In dev mode, the LLM stub may not generate questions (question generation is non-fatal per spec).
 		// If no question chunks exist, skip this test rather than failing.
-		const questionChunkCount = runSql(
+		const questionChunkCount = db.runSql(
 			`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}' AND is_question = true;`,
 		);
 		const numQuestions = Number.parseInt(questionChunkCount, 10);
@@ -280,7 +249,7 @@ describe('Spec 34 — Embed Step', () => {
 		expect(numQuestions).toBeGreaterThanOrEqual(1);
 
 		// All question chunks should have a parent_chunk_id pointing to a content chunk
-		const orphanQuestions = runSql(
+		const orphanQuestions = db.runSql(
 			`SELECT COUNT(*) FROM chunks q ` +
 				`WHERE q.story_id = '${enrichedStoryId}' AND q.is_question = true ` +
 				`AND (q.parent_chunk_id IS NULL ` +
@@ -295,18 +264,18 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedStoryId) return;
 
 		// Ensure the story is embedded
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		if (currentStatus !== 'embedded') {
 			const { exitCode } = runCli(['embed', enrichedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Total chunks for this story
-		const totalChunks = runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
+		const totalChunks = db.runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
 		expect(Number.parseInt(totalChunks, 10)).toBeGreaterThanOrEqual(1);
 
 		// Chunks with null embeddings
-		const nullEmbeddings = runSql(
+		const nullEmbeddings = db.runSql(
 			`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}' AND embedding IS NULL;`,
 		);
 		expect(Number.parseInt(nullEmbeddings, 10)).toBe(0);
@@ -318,14 +287,14 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedStoryId) return;
 
 		// Ensure story is embedded
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		if (currentStatus !== 'embedded') {
 			const { exitCode } = runCli(['embed', enrichedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Record chunk count before
-		const chunkCountBefore = runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
+		const chunkCountBefore = db.runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
 
 		// Run embed again without force
 		const { exitCode, stdout, stderr } = runCli(['embed', enrichedStoryId], { timeout: 60000 });
@@ -337,7 +306,7 @@ describe('Spec 34 — Embed Step', () => {
 		expect(combined).toMatch(/already embedded|skipped|skip/i);
 
 		// Chunk count should not change
-		const chunkCountAfter = runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
+		const chunkCountAfter = db.runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
 		expect(chunkCountAfter).toBe(chunkCountBefore);
 	}, 120000);
 
@@ -347,14 +316,14 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedStoryId || !enrichedSourceId) return;
 
 		// Ensure story is embedded
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		if (currentStatus !== 'embedded') {
 			const { exitCode } = runCli(['embed', enrichedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Record old chunk IDs before force
-		const oldChunkIds = runSql(
+		const oldChunkIds = db.runSql(
 			`SELECT id FROM chunks WHERE story_id = '${enrichedStoryId}' ORDER BY chunk_index LIMIT 1;`,
 		);
 		expect(oldChunkIds.length).toBeGreaterThan(0);
@@ -364,11 +333,11 @@ describe('Spec 34 — Embed Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Story should be embedded again
-		const status = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const status = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		expect(status).toBe('embedded');
 
 		// Chunks should exist (may be new UUIDs)
-		const newChunkCount = runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
+		const newChunkCount = db.runSql(`SELECT COUNT(*) FROM chunks WHERE story_id = '${enrichedStoryId}';`);
 		expect(Number.parseInt(newChunkCount, 10)).toBeGreaterThanOrEqual(1);
 	}, 120000);
 
@@ -385,7 +354,7 @@ describe('Spec 34 — Embed Step', () => {
 		ingestExtractSegmentEnrich(SCANNED_PDF);
 
 		// Verify both have enriched stories
-		const enrichedCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
+		const enrichedCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
 		expect(Number.parseInt(enrichedCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Embed all
@@ -393,10 +362,10 @@ describe('Spec 34 — Embed Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All previously enriched stories should now be embedded
-		const remainingEnriched = runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
+		const remainingEnriched = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'enriched';");
 		expect(Number.parseInt(remainingEnriched, 10)).toBe(0);
 
-		const embeddedCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
+		const embeddedCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
 		expect(Number.parseInt(embeddedCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Restore state for subsequent tests
@@ -434,13 +403,13 @@ describe('Spec 34 — Embed Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Source 1 stories should be embedded
-		const source1Embedded = runSql(
+		const source1Embedded = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId1}' AND status = 'embedded';`,
 		);
 		expect(Number.parseInt(source1Embedded, 10)).toBeGreaterThanOrEqual(1);
 
 		// Source 2 stories should still be segmented (not enriched, so embed wouldn't touch them)
-		const source2Status = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId2}';`);
+		const source2Status = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId2}';`);
 		expect(source2Status).not.toBe('embedded');
 
 		// Restore state
@@ -456,7 +425,7 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedSourceId) return;
 
 		// Ensure stories are embedded first
-		const embeddedCount = runSql(
+		const embeddedCount = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${enrichedSourceId}' AND status = 'embedded';`,
 		);
 		if (Number.parseInt(embeddedCount, 10) === 0) {
@@ -469,7 +438,7 @@ describe('Spec 34 — Embed Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All stories from source should be embedded
-		const allEmbedded = runSql(
+		const allEmbedded = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${enrichedSourceId}' AND status = 'embedded';`,
 		);
 		expect(Number.parseInt(allEmbedded, 10)).toBeGreaterThanOrEqual(1);
@@ -481,17 +450,17 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable) return;
 
 		// Create an isolated source + story with status 'segmented'
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (filename, file_hash, storage_path, page_count, status) ` +
 				`VALUES ('qa09-embed-test.pdf', 'qa09-embed-unique-hash', 'raw/qa09-embed-test.pdf', 1, 'segmented');`,
 		);
-		const sourceId = runSql(`SELECT id FROM sources WHERE file_hash = 'qa09-embed-unique-hash';`);
+		const sourceId = db.runSql(`SELECT id FROM sources WHERE file_hash = 'qa09-embed-unique-hash';`);
 
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) ` +
 				`VALUES ('${sourceId}', 'test-invalid-embed-status', 'segments/test/dummy.md', 'segments/test/dummy.meta.json', 'segmented');`,
 		);
-		const storyId = runSql(
+		const storyId = db.runSql(
 			`SELECT id FROM stories WHERE source_id = '${sourceId}' AND title = 'test-invalid-embed-status' LIMIT 1;`,
 		);
 
@@ -502,7 +471,7 @@ describe('Spec 34 — Embed Step', () => {
 		expect(combined).toMatch(/EMBED_INVALID_STATUS|invalid status|not enriched|cannot embed|must be.*enriched/i);
 
 		// Cleanup
-		runSql(
+		db.runSql(
 			`DELETE FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM entity_edges WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
@@ -518,14 +487,14 @@ describe('Spec 34 — Embed Step', () => {
 		if (!pgAvailable || !enrichedStoryId || !enrichedSourceId) return;
 
 		// Ensure story is embedded
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${enrichedStoryId}';`);
 		if (currentStatus !== 'embedded') {
 			const { exitCode } = runCli(['embed', enrichedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
 		}
 
 		// Check source_steps
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${enrichedSourceId}' AND step_name = 'embed';`,
 		);
 		expect(stepStatus).toBe('completed');
@@ -578,7 +547,7 @@ describe('CLI Test Matrix: embed', () => {
 	// ─── CLI-02: No arguments ───
 
 	it('CLI-02: mulder embed with no args gives non-zero exit and error', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['embed']);
@@ -637,7 +606,7 @@ describe('CLI Smoke Tests: embed', () => {
 	// ─── SMOKE-02: --force without story-id or --source gives error ───
 
 	it('SMOKE-02: mulder embed --force (no story-id, no --source) gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['embed', '--force']);
@@ -650,7 +619,7 @@ describe('CLI Smoke Tests: embed', () => {
 	// ─── SMOKE-03: invalid UUID format as story-id ───
 
 	it('SMOKE-03: mulder embed with non-UUID story-id gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['embed', 'not-a-valid-uuid']);
@@ -673,7 +642,7 @@ describe('CLI Smoke Tests: embed', () => {
 	// ─── SMOKE-05: --source with --force is a valid combo ───
 
 	it('SMOKE-05: mulder embed --source <id> --force does not crash (valid combo)', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeSourceId = '00000000-0000-0000-0000-000000000001';
@@ -702,7 +671,7 @@ describe('CLI Smoke Tests: embed', () => {
 	// ─── SMOKE-07: non-existent story-id gives meaningful error ───
 
 	it('SMOKE-07: mulder embed with non-existent UUID gives not-found error', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeId = '00000000-0000-0000-0000-000000000000';
@@ -716,7 +685,7 @@ describe('CLI Smoke Tests: embed', () => {
 	// ─── SMOKE-08: --source with non-existent source-id does not crash ───
 
 	it('SMOKE-08: mulder embed --source <non-existent-id> does not crash', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeSourceId = '00000000-0000-0000-0000-ffffffffffff';

--- a/tests/specs/34_qa_status_state_machine.test.ts
+++ b/tests/specs/34_qa_status_state_machine.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -10,10 +11,6 @@ const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
 const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * QA Gate — Status State Machine (QA-2)
@@ -41,7 +38,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -50,34 +47,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM chunks; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -126,13 +97,9 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 	let sourceId: string;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -168,17 +135,17 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 		expect(exitCode, `Ingest failed: ${stdout} ${stderr}`).toBe(0);
 
 		// Get source ID
-		sourceId = runSql(
+		sourceId = db.runSql(
 			`SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;`,
 		);
 		expect(sourceId).not.toBe('');
 
 		// Verify status
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('ingested');
 
 		// Verify source_step
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'ingest';`,
 		);
 		expect(stepStatus).toBe('completed');
@@ -195,15 +162,15 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 		expect(exitCode, `Extract failed: ${stdout} ${stderr}`).toBe(0);
 
 		// Verify status advanced to 'extracted'
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('extracted');
 
 		// Verify no stories exist yet (stories are created by segment, not extract)
-		const storyCount = Number.parseInt(runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
+		const storyCount = Number.parseInt(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
 		expect(storyCount).toBe(0);
 
 		// Verify source_step for extract
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 		);
 		expect(stepStatus).toBe('completed');
@@ -222,22 +189,22 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 		expect(exitCode, `Segment failed: ${stdout} ${stderr}`).toBe(0);
 
 		// Verify source status
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(sourceStatus).toBe('segmented');
 
 		// Verify stories were created
-		const storyCount = Number.parseInt(runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
+		const storyCount = Number.parseInt(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
 		expect(storyCount).toBeGreaterThanOrEqual(1);
 
 		// Verify all stories have status 'segmented'
 		const nonSegmentedCount = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status != 'segmented';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status != 'segmented';`),
 			10,
 		);
 		expect(nonSegmentedCount).toBe(0);
 
 		// Verify source_step for segment
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'segment';`,
 		);
 		expect(stepStatus).toBe('completed');
@@ -256,26 +223,26 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 		// Key assertion: source status REMAINS 'segmented' after enrich
 		// This is BY DESIGN — enrich operates on stories, not sources.
 		// The pipeline orchestrator (D6, not yet built) advances source status.
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(sourceStatus).toBe('segmented');
 
 		// Verify stories are now 'enriched'
 		const enrichedCount = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`),
 			10,
 		);
 		expect(enrichedCount).toBeGreaterThanOrEqual(1);
 
 		// Verify no stories are still at 'segmented'
 		const segmentedCount = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'segmented';`),
+			db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'segmented';`),
 			10,
 		);
 		expect(segmentedCount).toBe(0);
 
 		// Verify entities were created
 		const entityCount = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(DISTINCT e.id) FROM entities e
 				 JOIN story_entities se ON e.id = se.entity_id
 				 JOIN stories s ON se.story_id = s.id
@@ -296,7 +263,7 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 		const expectedSteps = ['ingest', 'extract', 'segment', 'enrich'];
 
 		for (const stepName of expectedSteps) {
-			const stepStatus = runSql(
+			const stepStatus = db.runSql(
 				`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = '${stepName}';`,
 			);
 			expect(stepStatus, `source_step '${stepName}' should be 'completed'`).toBe('completed');
@@ -304,7 +271,7 @@ describe('Spec 33 — QA-2: Status State Machine', () => {
 
 		// Verify total step count matches (no extra steps)
 		const totalSteps = Number.parseInt(
-			runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`),
+			db.runSql(`SELECT COUNT(*) FROM source_steps WHERE source_id = '${sourceId}';`),
 			10,
 		);
 		expect(totalSteps).toBe(expectedSteps.length);

--- a/tests/specs/35_graph_step.test.ts
+++ b/tests/specs/35_graph_step.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSy
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -14,16 +15,12 @@ const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 35: Graph Step
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
@@ -45,7 +42,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -54,32 +51,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM chunks; DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -106,7 +79,7 @@ function ingestPdf(pdfPath: string): string {
 	}
 	const parts = pdfPath.split('/');
 	const filename = parts[parts.length - 1];
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) {
 		throw new Error(`No source record found for ${filename}`);
 	}
@@ -144,7 +117,7 @@ function ingestExtractSegmentEnrichEmbed(pdfPath: string): string {
 	}
 
 	// Verify status
-	const status = runSql(`SELECT status FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
+	const status = db.runSql(`SELECT status FROM stories WHERE source_id = '${sourceId}' LIMIT 1;`);
 	if (status !== 'embedded') {
 		throw new Error(`Source ${sourceId} stories have status '${status}', expected 'embedded'`);
 	}
@@ -156,7 +129,7 @@ function ingestExtractSegmentEnrichEmbed(pdfPath: string): string {
  * Get a story ID from an embedded source.
  */
 function getEmbeddedStoryId(sourceId: string): string {
-	const storyId = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'embedded' LIMIT 1;`);
+	const storyId = db.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}' AND status = 'embedded' LIMIT 1;`);
 	if (!storyId) {
 		throw new Error(`No embedded story found for source ${sourceId}`);
 	}
@@ -184,7 +157,7 @@ describe('Spec 35 — Graph Step', () => {
 	let embeddedStoryId: string | null = null;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
 			console.warn('SKIP: PostgreSQL container not available. Start with:\n' + '  docker compose up -d');
 			return;
@@ -224,7 +197,7 @@ describe('Spec 35 — Graph Step', () => {
 		expect(result.exitCode).toBe(0);
 
 		// Story status should be 'graphed'
-		const storyStatus = runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
+		const storyStatus = db.runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
 		expect(storyStatus).toBe('graphed');
 
 		// Command should exit 0 (already asserted above)
@@ -243,7 +216,7 @@ describe('Spec 35 — Graph Step', () => {
 		ingestExtractSegmentEnrichEmbed(SCANNED_PDF);
 
 		// Verify both have embedded stories
-		const embCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
+		const embCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
 		expect(Number.parseInt(embCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Graph all
@@ -251,10 +224,10 @@ describe('Spec 35 — Graph Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All previously embedded stories should now be graphed
-		const remainingEmbedded = runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
+		const remainingEmbedded = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'embedded';");
 		expect(Number.parseInt(remainingEmbedded, 10)).toBe(0);
 
-		const graphedCount = runSql("SELECT COUNT(*) FROM stories WHERE status = 'graphed';");
+		const graphedCount = db.runSql("SELECT COUNT(*) FROM stories WHERE status = 'graphed';");
 		expect(Number.parseInt(graphedCount, 10)).toBeGreaterThanOrEqual(2);
 
 		// Restore state
@@ -288,13 +261,13 @@ describe('Spec 35 — Graph Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Source 1 stories should be graphed
-		const source1Graphed = runSql(
+		const source1Graphed = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId1}' AND status = 'graphed';`,
 		);
 		expect(Number.parseInt(source1Graphed, 10)).toBeGreaterThanOrEqual(1);
 
 		// Source 2 stories should NOT be graphed
-		const source2Status = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId2}';`);
+		const source2Status = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId2}';`);
 		expect(source2Status).not.toBe('graphed');
 
 		// Restore state
@@ -310,7 +283,7 @@ describe('Spec 35 — Graph Step', () => {
 		if (!pgAvailable || !embeddedStoryId) return;
 
 		// Ensure story is graphed
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
 		if (currentStatus !== 'graphed') {
 			const { exitCode } = runCli(['graph', embeddedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -332,7 +305,7 @@ describe('Spec 35 — Graph Step', () => {
 		if (!pgAvailable || !embeddedStoryId || !embeddedSourceId) return;
 
 		// Ensure story is graphed first
-		const currentStatus = runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
+		const currentStatus = db.runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
 		if (currentStatus !== 'graphed') {
 			const { exitCode } = runCli(['graph', embeddedStoryId], { timeout: 120000 });
 			expect(exitCode).toBe(0);
@@ -343,7 +316,7 @@ describe('Spec 35 — Graph Step', () => {
 		expect(exitCode).toBe(0);
 
 		// Story should be graphed again
-		const status = runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
+		const status = db.runSql(`SELECT status FROM stories WHERE id = '${embeddedStoryId}';`);
 		expect(status).toBe('graphed');
 	}, 120000);
 
@@ -353,7 +326,7 @@ describe('Spec 35 — Graph Step', () => {
 		if (!pgAvailable || !embeddedSourceId) return;
 
 		// Ensure stories are graphed first
-		const graphedCount = runSql(
+		const graphedCount = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${embeddedSourceId}' AND status = 'graphed';`,
 		);
 		if (Number.parseInt(graphedCount, 10) === 0) {
@@ -366,7 +339,7 @@ describe('Spec 35 — Graph Step', () => {
 		expect(exitCode).toBe(0);
 
 		// All stories from source should be graphed
-		const allGraphed = runSql(
+		const allGraphed = db.runSql(
 			`SELECT COUNT(*) FROM stories WHERE source_id = '${embeddedSourceId}' AND status = 'graphed';`,
 		);
 		expect(Number.parseInt(allGraphed, 10)).toBeGreaterThanOrEqual(1);
@@ -415,14 +388,14 @@ describe('Spec 35 — Graph Step', () => {
 		cleanStorageFixtures();
 
 		// Create two sources
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, file_hash, storage_path, page_count, status) VALUES ` +
 				`('11111111-1111-1111-1111-111111111111', 'qa09-src1.pdf', 'qa09-hash1', 'raw/qa09-src1.pdf', 1, 'embedded'), ` +
 				`('22222222-2222-2222-2222-222222222222', 'qa09-src2.pdf', 'qa09-hash2', 'raw/qa09-src2.pdf', 1, 'embedded');`,
 		);
 
 		// Create 3 stories: 2 from source 1, 1 from source 2
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) VALUES ` +
 				`('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'Story A', 's/a.md', 's/a.meta.json', 'embedded'), ` +
 				`('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', 'Story B', 's/b.md', 's/b.meta.json', 'embedded'), ` +
@@ -430,13 +403,13 @@ describe('Spec 35 — Graph Step', () => {
 		);
 
 		// Create one shared entity
-		runSql(
+		db.runSql(
 			`INSERT INTO entities (id, name, type, attributes) VALUES ` +
 				`('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'Test Entity', 'person', '{}');`,
 		);
 
 		// Link all 3 stories to the entity via story_entities
-		runSql(
+		db.runSql(
 			`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ` +
 				`('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 0.9), ` +
 				`('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 0.9), ` +
@@ -446,7 +419,7 @@ describe('Spec 35 — Graph Step', () => {
 		// Create chunks with embeddings for each story (needed for MinHash dedup)
 		const emb1 = randomEmbeddingLiteral();
 		// Story C gets same embedding (will be detected as duplicate of Story A)
-		runSql(
+		db.runSql(
 			`INSERT INTO chunks (id, story_id, content, chunk_index, embedding) VALUES ` +
 				`('c1111111-1111-1111-1111-111111111111', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Some content about the entity', 0, ${emb1}), ` +
 				`('c2222222-2222-2222-2222-222222222222', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Different content entirely', 0, ${randomEmbeddingLiteral()}), ` +
@@ -455,7 +428,7 @@ describe('Spec 35 — Graph Step', () => {
 
 		// Pre-create a DUPLICATE_OF edge between story A (source 1) and story C (source 2)
 		// to simulate dedup detection
-		runSql(
+		db.runSql(
 			`INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, edge_type, story_id, confidence, attributes) VALUES ` +
 				`('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'DUPLICATE_OF', 'DUPLICATE_OF', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 0.95, ` +
 				`'{"storyIdA": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "storyIdB": "cccccccc-cccc-cccc-cccc-cccccccccccc", "similarity": 0.95}');`,
@@ -470,7 +443,9 @@ describe('Spec 35 — Graph Step', () => {
 		// But A and C are duplicates → they collapse.
 		// So independent sources = 1 (only source 1 with stories A+B, source 2's story C is collapsed)
 		// Per spec: independent_source_count should be 1
-		const sourceCount = runSql(`SELECT source_count FROM entities WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';`);
+		const sourceCount = db.runSql(
+			`SELECT source_count FROM entities WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';`,
+		);
 		// The source_count should reflect dedup-aware counting
 		// With the DUPLICATE_OF edge, the two sources should collapse
 		expect(Number.parseInt(sourceCount, 10)).toBeLessThanOrEqual(2);
@@ -496,14 +471,14 @@ describe('Spec 35 — Graph Step', () => {
 		cleanStorageFixtures();
 
 		// Create two sources
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, file_hash, storage_path, page_count, status) VALUES ` +
 				`('10101010-1010-1010-1010-101010101010', 'qa10-src1.pdf', 'qa10-hash-1', 'raw/qa10-src1.pdf', 1, 'embedded'), ` +
 				`('20202020-2020-2020-2020-202020202020', 'qa10-src2.pdf', 'qa10-hash-2', 'raw/qa10-src2.pdf', 1, 'embedded');`,
 		);
 
 		// Create two stories (both embedded, from different sources)
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) VALUES ` +
 				`('a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', '10101010-1010-1010-1010-101010101010', 'Story Alpha', 's/alpha.md', 's/alpha.meta.json', 'embedded'), ` +
 				`('b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2', '20202020-2020-2020-2020-202020202020', 'Story Beta', 's/beta.md', 's/beta.meta.json', 'embedded');`,
@@ -518,24 +493,24 @@ describe('Spec 35 — Graph Step', () => {
 		// real-world entity with different observed attributes.
 		// entity1 is the canonical, entity2 points to entity1 as canonical.
 
-		runSql(
+		db.runSql(
 			`INSERT INTO entities (id, name, type, attributes) VALUES ` +
 				`('e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1', 'Roswell Incident (Alpha)', 'event', '{"date": "1947-06-14"}');`,
 		);
-		runSql(
+		db.runSql(
 			`INSERT INTO entities (id, canonical_id, name, type, attributes) VALUES ` +
 				`('e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2', 'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1', 'Roswell Incident (Beta)', 'event', '{"date": "1947-07-08"}');`,
 		);
 
 		// Link entities to their respective stories
-		runSql(
+		db.runSql(
 			`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ` +
 				`('a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', 'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1', 0.95), ` +
 				`('b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2', 'e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2', 0.95);`,
 		);
 
 		// Create chunks with embeddings for each story (required for graph step)
-		runSql(
+		db.runSql(
 			`INSERT INTO chunks (id, story_id, content, chunk_index, embedding) VALUES ` +
 				`('ca1a1a1a-a1a1-a1a1-a1a1-a1a1a1a1a1a1', 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', 'Roswell incident occurred on June 14 1947', 0, ${randomEmbeddingLiteral()}), ` +
 				`('cb2b2b2b-b2b2-b2b2-b2b2-b2b2b2b2b2b2', 'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2', 'Roswell incident occurred on July 8 1947', 0, ${randomEmbeddingLiteral()});`,
@@ -551,12 +526,14 @@ describe('Spec 35 — Graph Step', () => {
 		// Check for POTENTIAL_CONTRADICTION edges
 		// Per spec: entities sharing the same canonical_id with different attribute values
 		// should be flagged.
-		const contradictionCount = runSql(`SELECT COUNT(*) FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION';`);
+		const contradictionCount = db.runSql(
+			`SELECT COUNT(*) FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION';`,
+		);
 		expect(Number.parseInt(contradictionCount, 10)).toBeGreaterThanOrEqual(1);
 
 		// Verify the contradiction references the conflicting attribute
 		if (Number.parseInt(contradictionCount, 10) > 0) {
-			const contradictionAttrs = runSql(
+			const contradictionAttrs = db.runSql(
 				`SELECT attributes::text FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION' LIMIT 1;`,
 			);
 			expect(contradictionAttrs).toMatch(/date/i);
@@ -565,7 +542,7 @@ describe('Spec 35 — Graph Step', () => {
 			// canonical entity. Both conflicting claim story IDs live in
 			// attributes.storyIdA / storyIdB. Lock this in so the encoding
 			// cannot drift without flagging the test.
-			const selfLoopRows = runSql(
+			const selfLoopRows = db.runSql(
 				`SELECT source_entity_id = target_entity_id FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION';`,
 			);
 			for (const row of selfLoopRows.split('\n').filter(Boolean)) {
@@ -592,17 +569,17 @@ describe('Spec 35 — Graph Step', () => {
 		if (!pgAvailable) return;
 
 		// Create an isolated source + story with status 'enriched' (not embedded)
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (filename, file_hash, storage_path, page_count, status) ` +
 				`VALUES ('qa11-graph-test.pdf', 'qa11-graph-unique-hash', 'raw/qa11-graph-test.pdf', 1, 'enriched');`,
 		);
-		const sourceId = runSql(`SELECT id FROM sources WHERE file_hash = 'qa11-graph-unique-hash';`);
+		const sourceId = db.runSql(`SELECT id FROM sources WHERE file_hash = 'qa11-graph-unique-hash';`);
 
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) ` +
 				`VALUES ('${sourceId}', 'test-invalid-graph-status', 'segments/test/dummy.md', 'segments/test/dummy.meta.json', 'enriched');`,
 		);
-		const storyId = runSql(
+		const storyId = db.runSql(
 			`SELECT id FROM stories WHERE source_id = '${sourceId}' AND title = 'test-invalid-graph-status' LIMIT 1;`,
 		);
 
@@ -613,7 +590,7 @@ describe('Spec 35 — Graph Step', () => {
 		expect(combined).toMatch(/GRAPH_INVALID_STATUS|invalid status|not embedded|cannot graph|must be.*embedded/i);
 
 		// Cleanup
-		runSql(
+		db.runSql(
 			`DELETE FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM entity_edges WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
@@ -642,23 +619,23 @@ describe('Spec 35 — Graph Step', () => {
 	 * the returned sourceId.
 	 */
 	function seedStoryWithNoRelationships(sourceId: string, storyId: string, entityIds: string[]): void {
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, file_hash, storage_path, page_count, status) ` +
 				`VALUES ('${sourceId}', 'qa13-cooccurrence.pdf', 'qa13-${sourceId}', 'raw/${sourceId}/original.pdf', 1, 'embedded');`,
 		);
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) ` +
 				`VALUES ('${storyId}', '${sourceId}', 'qa13-story', 's/qa13.md', 's/qa13.meta.json', 'embedded');`,
 		);
 		const entityValues = entityIds.map((id, i) => `('${id}', 'Entity ${i}', 'person', '{}')`).join(', ');
-		runSql(`INSERT INTO entities (id, name, type, attributes) VALUES ${entityValues};`);
+		db.runSql(`INSERT INTO entities (id, name, type, attributes) VALUES ${entityValues};`);
 		const linkValues = entityIds.map((id) => `('${storyId}', '${id}', 0.9)`).join(', ');
-		runSql(`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ${linkValues};`);
+		db.runSql(`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES ${linkValues};`);
 	}
 
 	function cleanupCooccurrenceFixture(sourceId: string, entityIds: string[]): void {
 		const idList = entityIds.map((id) => `'${id}'`).join(',');
-		runSql(
+		db.runSql(
 			`DELETE FROM entity_edges WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				` DELETE FROM story_entities WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');` +
 				(idList ? ` DELETE FROM entities WHERE id IN (${idList});` : '') +
@@ -699,7 +676,7 @@ describe('Spec 35 — Graph Step', () => {
 		const result = runCli(['graph', storyId], { timeout: 60_000 });
 		expect(result.exitCode).toBe(0);
 
-		const edgeCount = runSql(
+		const edgeCount = db.runSql(
 			`SELECT COUNT(*) FROM entity_edges WHERE story_id = '${storyId}' AND relationship = 'co_occurs_with';`,
 		);
 		expect(Number.parseInt(edgeCount, 10)).toBe(0);
@@ -730,7 +707,7 @@ describe('Spec 35 — Graph Step', () => {
 		});
 		expect(result.exitCode).toBe(0);
 
-		const edgeCount = runSql(
+		const edgeCount = db.runSql(
 			`SELECT COUNT(*) FROM entity_edges WHERE story_id = '${storyId}' AND relationship = 'co_occurs_with';`,
 		);
 		expect(Number.parseInt(edgeCount, 10)).toBe(expectedEdges);
@@ -814,7 +791,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-02: --force without story-id or --source gives error ───
 
 	it('SMOKE-02: mulder graph --force (no story-id, no --source) gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['graph', '--force']);
@@ -827,7 +804,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-03: invalid UUID as story-id ───
 
 	it('SMOKE-03: mulder graph with non-UUID story-id gives non-zero exit', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const { exitCode, stdout, stderr } = runCli(['graph', 'not-a-valid-uuid']);
@@ -850,7 +827,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-05: --source with --force is a valid combo ───
 
 	it('SMOKE-05: mulder graph --source <id> --force does not crash (valid combo)', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeSourceId = '00000000-0000-0000-0000-000000000001';
@@ -879,7 +856,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-07: non-existent story-id gives meaningful error ───
 
 	it('SMOKE-07: mulder graph with non-existent UUID gives not-found error', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeId = '00000000-0000-0000-0000-000000000000';
@@ -893,7 +870,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-08: --source with non-existent source-id does not crash ───
 
 	it('SMOKE-08: mulder graph --source <non-existent-id> does not crash', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeSourceId = '00000000-0000-0000-0000-ffffffffffff';
@@ -923,7 +900,7 @@ describe('CLI Smoke Tests: graph', () => {
 	// ─── SMOKE-10: --force alone with story-id does not crash on nonexistent ───
 
 	it('SMOKE-10: mulder graph <nonexistent-id> --force gives error (not crash)', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 
 		const fakeId = '99999999-9999-9999-9999-999999999999';

--- a/tests/specs/35_qa_cascading_reset.test.ts
+++ b/tests/specs/35_qa_cascading_reset.test.ts
@@ -1,14 +1,11 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * QA Gate — Cascading Reset (QA-3)
@@ -52,7 +49,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -61,34 +58,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; ' +
 			'DELETE FROM entities; DELETE FROM chunks; DELETE FROM stories; ' +
 			'DELETE FROM source_steps; DELETE FROM sources;',
@@ -97,7 +68,7 @@ function cleanTestData(): void {
 
 function countRows(table: string, where?: string): number {
 	const sql = where ? `SELECT COUNT(*) FROM ${table} WHERE ${where};` : `SELECT COUNT(*) FROM ${table};`;
-	return Number.parseInt(runSql(sql), 10);
+	return Number.parseInt(db.runSql(sql), 10);
 }
 
 /**
@@ -106,23 +77,23 @@ function countRows(table: string, where?: string): number {
  */
 function seedFullDataChain(): void {
 	// Source
-	runSql(
+	db.runSql(
 		`INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, status)
 		 VALUES ('${SOURCE_ID}', 'qa-test.pdf', 'raw/${SOURCE_ID}/original.pdf', 'hash_qa_test', 10, true, 'segmented');`,
 	);
 
 	// Stories
-	runSql(
+	db.runSql(
 		`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status)
 		 VALUES ('${STORY_ID_1}', '${SOURCE_ID}', 'Story One', 'gs://b/s/${STORY_ID_1}.md', 'gs://b/s/${STORY_ID_1}.meta.json', 'enriched');`,
 	);
-	runSql(
+	db.runSql(
 		`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status)
 		 VALUES ('${STORY_ID_2}', '${SOURCE_ID}', 'Story Two', 'gs://b/s/${STORY_ID_2}.md', 'gs://b/s/${STORY_ID_2}.meta.json', 'enriched');`,
 	);
 
 	// Entities
-	runSql(
+	db.runSql(
 		`INSERT INTO entities (id, name, type) VALUES
 		 ('${ENTITY_ID_1}', 'Entity One', 'person'),
 		 ('${ENTITY_ID_2}', 'Entity Two', 'location'),
@@ -130,10 +101,12 @@ function seedFullDataChain(): void {
 	);
 
 	// Entity aliases
-	runSql(`INSERT INTO entity_aliases (id, entity_id, alias) VALUES ('${ALIAS_ID_1}', '${ENTITY_ID_1}', 'E1 Alias');`);
+	db.runSql(
+		`INSERT INTO entity_aliases (id, entity_id, alias) VALUES ('${ALIAS_ID_1}', '${ENTITY_ID_1}', 'E1 Alias');`,
+	);
 
 	// Story-entity links
-	runSql(
+	db.runSql(
 		`INSERT INTO story_entities (story_id, entity_id, confidence) VALUES
 		 ('${STORY_ID_1}', '${ENTITY_ID_1}', 0.9),
 		 ('${STORY_ID_1}', '${ENTITY_ID_2}', 0.8),
@@ -142,20 +115,20 @@ function seedFullDataChain(): void {
 	// Note: ENTITY_ID_3 has NO story_entities links → will become orphan
 
 	// Entity edges
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, story_id)
 		 VALUES ('${EDGE_ID_1}', '${ENTITY_ID_1}', '${ENTITY_ID_2}', 'mentioned_with', '${STORY_ID_1}');`,
 	);
 
 	// Chunks (with mock embeddings)
-	runSql(
+	db.runSql(
 		`INSERT INTO chunks (id, story_id, content, chunk_index) VALUES
 		 ('${CHUNK_ID_1}', '${STORY_ID_1}', 'Chunk one content for testing', 0),
 		 ('${CHUNK_ID_2}', '${STORY_ID_2}', 'Chunk two content for testing', 0);`,
 	);
 
 	// Source steps
-	runSql(
+	db.runSql(
 		`INSERT INTO source_steps (source_id, step_name, status) VALUES
 		 ('${SOURCE_ID}', 'ingest', 'completed'),
 		 ('${SOURCE_ID}', 'extract', 'completed'),
@@ -174,13 +147,9 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -221,7 +190,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('source_steps', `source_id = '${SOURCE_ID}'`)).toBe(6);
 
 		// Act
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'extract');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'extract');`);
 
 		// Assert: stories deleted (cascades to chunks, story_entities, entity_edges via FK CASCADE)
 		expect(countRows('stories', `source_id = '${SOURCE_ID}'`)).toBe(0);
@@ -231,7 +200,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('entity_edges', `story_id = '${STORY_ID_1}'`)).toBe(0);
 
 		// Source status reset to 'ingested'
-		const status = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 		expect(status).toBe('ingested');
 
 		// ALL source_steps deleted
@@ -246,7 +215,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		if (!pgAvailable) return;
 
 		// Act
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'segment');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'segment');`);
 
 		// Stories deleted (cascades to chunks, story_entities, edges)
 		expect(countRows('stories', `source_id = '${SOURCE_ID}'`)).toBe(0);
@@ -254,11 +223,11 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('story_entities')).toBe(0);
 
 		// Source status reset to 'extracted'
-		const status = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 		expect(status).toBe('extracted');
 
 		// Only ingest and extract steps remain
-		const remainingSteps = runSql(
+		const remainingSteps = db.runSql(
 			`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID}' ORDER BY step_name;`,
 		);
 		const steps = remainingSteps.split('\n').filter(Boolean);
@@ -278,7 +247,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		if (!pgAvailable) return;
 
 		// Act
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'enrich');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'enrich');`);
 
 		// story_entities deleted
 		expect(countRows('story_entities')).toBe(0);
@@ -288,18 +257,18 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 
 		// Stories still exist but status reset to 'segmented'
 		expect(countRows('stories', `source_id = '${SOURCE_ID}'`)).toBe(2);
-		const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
+		const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
 		expect(storyStatuses).toBe('segmented');
 
 		// Source status reset to 'segmented'
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 		expect(sourceStatus).toBe('segmented');
 
 		// Chunks still exist (enrich reset doesn't touch chunks)
 		expect(countRows('chunks')).toBeGreaterThanOrEqual(2);
 
 		// Only ingest, extract, segment steps remain
-		const remainingSteps = runSql(
+		const remainingSteps = db.runSql(
 			`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID}' ORDER BY step_name;`,
 		);
 		const steps = remainingSteps.split('\n').filter(Boolean);
@@ -319,20 +288,20 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		if (!pgAvailable) return;
 
 		// Record initial source status
-		const initialSourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const initialSourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 
 		// Act
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'embed');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'embed');`);
 
 		// Chunks deleted
 		expect(countRows('chunks')).toBe(0);
 
 		// Stories status reset to 'enriched'
-		const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
+		const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
 		expect(storyStatuses).toBe('enriched');
 
 		// Source status UNCHANGED (embed reset does NOT update sources.status per §4.3.1)
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 		expect(sourceStatus).toBe(initialSourceStatus);
 
 		// story_entities and entity_edges still exist
@@ -340,7 +309,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('entity_edges')).toBeGreaterThanOrEqual(1);
 
 		// Only ingest, extract, segment, enrich steps remain
-		const remainingSteps = runSql(
+		const remainingSteps = db.runSql(
 			`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID}' ORDER BY step_name;`,
 		);
 		const steps = remainingSteps.split('\n').filter(Boolean);
@@ -360,20 +329,20 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		if (!pgAvailable) return;
 
 		// Record initial source status
-		const initialSourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const initialSourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 
 		// Act
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'graph');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'graph');`);
 
 		// Entity edges for these stories deleted
 		expect(countRows('entity_edges', `story_id IN ('${STORY_ID_1}', '${STORY_ID_2}')`)).toBe(0);
 
 		// Stories status reset to 'embedded'
-		const storyStatuses = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
+		const storyStatuses = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${SOURCE_ID}';`);
 		expect(storyStatuses).toBe('embedded');
 
 		// Source status UNCHANGED (graph reset does NOT update sources.status per §4.3.1)
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${SOURCE_ID}';`);
 		expect(sourceStatus).toBe(initialSourceStatus);
 
 		// Chunks still exist
@@ -383,7 +352,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('story_entities')).toBeGreaterThanOrEqual(3);
 
 		// Only graph step deleted
-		const remainingSteps = runSql(
+		const remainingSteps = db.runSql(
 			`SELECT step_name FROM source_steps WHERE source_id = '${SOURCE_ID}' ORDER BY step_name;`,
 		);
 		const steps = remainingSteps.split('\n').filter(Boolean);
@@ -410,7 +379,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('story_entities', `entity_id = '${ENTITY_ID_3}'`)).toBe(0);
 
 		// Run enrich reset — this deletes story_entities (making Entity 1 and 2 orphans too)
-		runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'enrich');`);
+		db.runSql(`SELECT reset_pipeline_step('${SOURCE_ID}', 'enrich');`);
 
 		// Verify story_entities are gone
 		expect(countRows('story_entities')).toBe(0);
@@ -419,7 +388,7 @@ describe('Spec 33 — QA-3: Cascading Reset', () => {
 		expect(countRows('entities')).toBe(3);
 
 		// Run GC
-		const deletedCount = Number.parseInt(runSql(`SELECT gc_orphaned_entities();`), 10);
+		const deletedCount = Number.parseInt(db.runSql(`SELECT gc_orphaned_entities();`), 10);
 
 		// Should have deleted all 3 orphaned entities
 		expect(deletedCount).toBe(3);

--- a/tests/specs/36_pipeline_orchestrator.test.ts
+++ b/tests/specs/36_pipeline_orchestrator.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -11,16 +12,12 @@ const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-postgres';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 /**
  * Black-box QA tests for Spec 36: Pipeline Orchestrator
  *
  * Each `it()` maps to one QA condition or CLI condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem (dev-mode storage).
+ * SQL via `the shared env-driven SQL helper`, and filesystem (dev-mode storage).
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
@@ -42,7 +39,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -51,32 +48,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM pipeline_run_sources; DELETE FROM pipeline_runs; ' +
 			'DELETE FROM chunks; DELETE FROM story_entities; DELETE FROM entity_edges; ' +
 			'DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM stories; ' +
@@ -166,7 +139,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
 			console.warn('SKIP: PostgreSQL container not available. Start with:\n  docker compose up -d');
 			return;
@@ -212,7 +185,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(stage1.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 		expect(sourceId).toMatch(/^[0-9a-f-]+$/);
@@ -228,15 +201,15 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		// extracted → segmented. Story-fanout steps (enrich/embed/graph) update
 		// `stories.status`, not `sources.status`. Spec 35's tests follow the
 		// same pattern. Asserting on `stories.status` is the source of truth.
-		const storyStatus = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const storyStatus = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(storyStatus).toBe('graphed');
 
 		// Latest pipeline_runs row for stage2 should be 'completed'
-		const runStatus = runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		const runStatus = db.runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
 		expect(runStatus).toBe('completed');
 
 		// pipeline_run_sources for the latest run shows current_step = graph, status completed
-		const rowState = runSql(
+		const rowState = db.runSql(
 			"SELECT current_step || '|' || status FROM pipeline_run_sources " +
 				'WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1) ' +
 				`AND source_id = '${sourceId}';`,
@@ -258,7 +231,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(stage1.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 		materialisePageImages(sourceId);
@@ -269,15 +242,15 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 
 		// Story should be 'enriched' — not embedded or graphed
 		// (spec says sources.status, but story-fanout steps update stories.status)
-		const storyStatus = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const storyStatus = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(storyStatus).toBe('enriched');
 
 		// Run should be 'completed'
-		const runStatus = runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		const runStatus = db.runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
 		expect(runStatus).toBe('completed');
 
 		// pipeline_run_sources current_step should be 'enrich'
-		const currentStep = runSql(
+		const currentStep = db.runSql(
 			'SELECT current_step FROM pipeline_run_sources ' +
 				'WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1) ' +
 				`AND source_id = '${sourceId}';`,
@@ -299,7 +272,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(stage1.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 		materialisePageImages(sourceId);
@@ -309,7 +282,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		expect(stage2.exitCode).toBe(0);
 
 		// Verify story is 'enriched' (story-level state — see QA-01 note)
-		const preStatus = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const preStatus = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(preStatus).toBe('enriched');
 
 		// Stage 3: --from embed should run embed + graph
@@ -317,11 +290,11 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		expect(stage3.exitCode).toBe(0);
 
 		// Story should now be 'graphed'
-		const postStatus = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const postStatus = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(postStatus).toBe('graphed');
 
 		// pipeline_run_sources current_step should be 'graph' for the latest run
-		const currentStep = runSql(
+		const currentStep = db.runSql(
 			'SELECT current_step FROM pipeline_run_sources ' +
 				'WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1) ' +
 				`AND source_id = '${sourceId}';`,
@@ -355,18 +328,18 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		// Latest run should be 'partial' or 'completed' (if broken file failed pre-flight,
 		// it never produces a pipeline_run_sources row, leaving the run as completed for
 		// the good source). Either way, the orchestrator must NOT have crashed.
-		const runStatus = runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		const runStatus = db.runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
 		expect(['completed', 'partial', 'failed']).toContain(runStatus);
 
 		// At least one source row exists in the run (the good one, or both)
-		const numRows = runSql(
+		const numRows = db.runSql(
 			'SELECT COUNT(*) FROM pipeline_run_sources ' +
 				'WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1);',
 		);
 		expect(Number.parseInt(numRows, 10)).toBeGreaterThanOrEqual(1);
 
 		// The good PDF should have been ingested
-		const goodSource = runSql("SELECT COUNT(*) FROM sources WHERE filename = 'native-text-sample.pdf';");
+		const goodSource = db.runSql("SELECT COUNT(*) FROM sources WHERE filename = 'native-text-sample.pdf';");
 		expect(Number.parseInt(goodSource, 10)).toBeGreaterThanOrEqual(1);
 	}, 600000);
 
@@ -380,8 +353,8 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 
 		const workDir = makeWorkDir('qa05', [NATIVE_TEXT_PDF]);
 
-		const beforeRuns = runSql('SELECT COUNT(*) FROM pipeline_runs;');
-		const beforeSources = runSql('SELECT COUNT(*) FROM sources;');
+		const beforeRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		const beforeSources = db.runSql('SELECT COUNT(*) FROM sources;');
 
 		const result = runCli(['pipeline', 'run', workDir, '--dry-run'], { timeout: 60000 });
 		expect(result.exitCode).toBe(0);
@@ -390,11 +363,11 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		expect(combined).toMatch(/dry run|planned|plan/i);
 
 		// No new pipeline_runs row created
-		const afterRuns = runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		const afterRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
 		expect(afterRuns).toBe(beforeRuns);
 
 		// No new sources row created (dry-run should not ingest)
-		const afterSources = runSql('SELECT COUNT(*) FROM sources;');
+		const afterSources = db.runSql('SELECT COUNT(*) FROM sources;');
 		expect(afterSources).toBe(beforeSources);
 	}, 120000);
 
@@ -415,7 +388,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		});
 		expect(result.exitCode).toBe(0);
 
-		const persistedTag = runSql('SELECT tag FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		const persistedTag = db.runSql('SELECT tag FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
 		expect(persistedTag).toBe(tag);
 	}, 600000);
 
@@ -455,7 +428,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const runResult = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(runResult.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 
@@ -534,34 +507,34 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(stage1.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 
 		// Synthesise a "failed at extract" pipeline_run_sources row by inserting one
 		// directly (alongside the existing successful one). The retry path looks at
 		// the latest row for that source.
-		runSql(
+		db.runSql(
 			`INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at) ` +
 				`VALUES ('99999999-9999-9999-9999-999999999999', 'qa10-failed', '{}', 'failed', ` +
 				`now() + interval '1 second', now() + interval '1 second');`,
 		);
-		runSql(
+		db.runSql(
 			`INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status, error_message, updated_at) ` +
 				`VALUES ('99999999-9999-9999-9999-999999999999', '${sourceId}', 'extract', 'failed', ` +
 				`'simulated extract failure', now() + interval '1 second');`,
 		);
 
 		// Reset source status so retry can re-extract from a clean state.
-		runSql(`UPDATE sources SET status = 'ingested' WHERE id = '${sourceId}';`);
+		db.runSql(`UPDATE sources SET status = 'ingested' WHERE id = '${sourceId}';`);
 
 		const retryResult = runCli(['pipeline', 'retry', sourceId], { timeout: 600000 });
 		// Retry must produce a new run row
-		const numRuns = runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		const numRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
 		expect(Number.parseInt(numRuns, 10)).toBeGreaterThanOrEqual(2);
 
 		// Most recent run should reference this source
-		const latestRunSourceId = runSql(
+		const latestRunSourceId = db.runSql(
 			'SELECT source_id FROM pipeline_run_sources ' +
 				'WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1) ' +
 				'LIMIT 1;',
@@ -578,7 +551,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 	it('QA-11: --up-to with unknown step exits 1 and creates no pipeline_runs row', () => {
 		if (!pgAvailable) return;
 
-		const beforeRuns = runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		const beforeRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
 
 		const result = runCli(['pipeline', 'run', FIXTURE_DIR, '--up-to', 'analyze'], { timeout: 30000 });
 
@@ -587,7 +560,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		// Error should mention unknown / valid steps
 		expect(combined).toMatch(/unknown|invalid|valid/i);
 
-		const afterRuns = runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		const afterRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
 		expect(afterRuns).toBe(beforeRuns);
 	});
 
@@ -629,7 +602,7 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], { timeout: 240000 });
 		expect(stage1.exitCode).toBe(0);
 
-		const sourceId = runSql(
+		const sourceId = db.runSql(
 			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 		);
 		materialisePageImages(sourceId);
@@ -638,26 +611,26 @@ describe('Spec 36 — Pipeline Orchestrator', () => {
 		expect(stage2.exitCode).toBe(0);
 
 		// Story should be graphed (per-story state — see QA-01 note)
-		const status = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const status = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(status).toBe('graphed');
 
 		// Snapshot edge count
-		const edgeCountBefore = runSql('SELECT COUNT(*) FROM entity_edges;');
+		const edgeCountBefore = db.runSql('SELECT COUNT(*) FROM entity_edges;');
 
 		// Re-run on the same dir — ingest should dedupe via file_hash, no changes
 		const rerun = runCli(['pipeline', 'run', workDir], { timeout: 600000 });
 		expect(rerun.exitCode).toBe(0);
 
 		// Still graphed
-		const statusAfter = runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
+		const statusAfter = db.runSql(`SELECT DISTINCT status FROM stories WHERE source_id = '${sourceId}';`);
 		expect(statusAfter).toBe('graphed');
 
 		// No additional edges created
-		const edgeCountAfter = runSql('SELECT COUNT(*) FROM entity_edges;');
+		const edgeCountAfter = db.runSql('SELECT COUNT(*) FROM entity_edges;');
 		expect(edgeCountAfter).toBe(edgeCountBefore);
 
 		// Latest pipeline_runs row status should be 'completed' (no failures)
-		const latestRunStatus = runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		const latestRunStatus = db.runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
 		expect(latestRunStatus).toBe('completed');
 	}, 1200000);
 });
@@ -746,7 +719,7 @@ describe('CLI Test Matrix: pipeline', () => {
 	// ─── CLI-09: pipeline retry bogus uuid ───
 
 	it('CLI-09: mulder pipeline retry <bogus-uuid> errors with source not found', () => {
-		if (!isPgAvailable()) {
+		if (!db.isPgAvailable()) {
 			console.warn('SKIP CLI-09: PostgreSQL not available');
 			return;
 		}
@@ -760,7 +733,7 @@ describe('CLI Test Matrix: pipeline', () => {
 	// ─── CLI-10: pipeline status --run bogus uuid ───
 
 	it('CLI-10: mulder pipeline status --run <bogus-uuid> errors with run not found', () => {
-		if (!isPgAvailable()) {
+		if (!db.isPgAvailable()) {
 			console.warn('SKIP CLI-10: PostgreSQL not available');
 			return;
 		}
@@ -779,7 +752,7 @@ describe('Smoke: pipeline flag combinations', () => {
 	let pgAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 	});
 
 	// ─── SMOKE-01: --tag + --dry-run together ───
@@ -799,7 +772,7 @@ describe('Smoke: pipeline flag combinations', () => {
 		if (!pgAvailable) return;
 
 		// Wipe runs
-		runSql('DELETE FROM pipeline_run_sources; DELETE FROM pipeline_runs;');
+		db.runSql('DELETE FROM pipeline_run_sources; DELETE FROM pipeline_runs;');
 
 		const result = runCli(['pipeline', 'status', '--json'], { timeout: 30000 });
 		// Either non-zero (no run found) or zero with empty payload — both are acceptable

--- a/tests/specs/36_qa_pipeline_integration.test.ts
+++ b/tests/specs/36_qa_pipeline_integration.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
@@ -10,10 +11,6 @@ const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
 const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * QA Gate — Cross-Step Pipeline Integration (QA-4)
@@ -39,7 +36,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -48,34 +45,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM chunks; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -121,13 +92,9 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 	let sourceId: string;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -147,7 +114,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 			throw new Error(`Ingest failed: ${ingestResult.stdout} ${ingestResult.stderr}`);
 		}
 
-		sourceId = runSql(
+		sourceId = db.runSql(
 			`SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;`,
 		);
 		if (!sourceId) throw new Error('No source found after ingest');
@@ -171,10 +138,10 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Insert synthetic chunks to simulate embed step (D4 not built yet).
 		// This enables the join-path test without requiring an actual embed step.
-		const storyIds = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`).split('\n').filter(Boolean);
+		const storyIds = db.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`).split('\n').filter(Boolean);
 
 		for (const sid of storyIds) {
-			runSql(
+			db.runSql(
 				`INSERT INTO chunks (story_id, content, chunk_index)
 				 VALUES ('${sid}', 'Synthetic chunk for integration test', 0)
 				 ON CONFLICT DO NOTHING;`,
@@ -201,7 +168,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Every chunk has a valid story_id
 		const orphanedChunks = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM chunks c
 				 LEFT JOIN stories s ON c.story_id = s.id
 				 WHERE s.id IS NULL;`,
@@ -212,7 +179,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Every story_entity links to valid story AND entity
 		const orphanedSE = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM story_entities se
 				 LEFT JOIN stories s ON se.story_id = s.id
 				 LEFT JOIN entities e ON se.entity_id = e.id
@@ -224,7 +191,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Every entity_edge with a story_id links to a valid story
 		const orphanedEdges = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM entity_edges ee
 				 LEFT JOIN stories s ON ee.story_id = s.id
 				 WHERE ee.story_id IS NOT NULL AND s.id IS NULL;`,
@@ -234,7 +201,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 		expect(orphanedEdges, 'No orphaned entity_edges').toBe(0);
 
 		// Verify stories actually belong to this source
-		const storyCount = Number.parseInt(runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
+		const storyCount = Number.parseInt(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = '${sourceId}';`), 10);
 		expect(storyCount).toBeGreaterThanOrEqual(1);
 	}, 30000);
 
@@ -246,7 +213,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 		if (!pgAvailable || !sourceId) return;
 
 		// This is the exact join path D4+ retrieval will use
-		const result = runSql(
+		const result = db.runSql(
 			`SELECT c.id, c.content, s.title, e.name
 			 FROM chunks c
 			 JOIN stories s ON c.story_id = s.id
@@ -282,7 +249,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Count entities before re-enrich
 		const entityCountBefore = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(DISTINCT e.id) FROM entities e
 				 JOIN story_entities se ON e.id = se.entity_id
 				 JOIN stories s ON se.story_id = s.id
@@ -294,7 +261,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Count total story_entities before
 		const seBefore = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM story_entities se
 				 JOIN stories s ON se.story_id = s.id
 				 WHERE s.source_id = '${sourceId}';`,
@@ -310,7 +277,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// Count entities after re-enrich
 		const entityCountAfter = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(DISTINCT e.id) FROM entities e
 				 JOIN story_entities se ON e.id = se.entity_id
 				 JOIN stories s ON se.story_id = s.id
@@ -324,7 +291,7 @@ describe('Spec 33 — QA-4: Cross-Step Pipeline Integration', () => {
 
 		// story_entities count should also be same or very close
 		const seAfter = Number.parseInt(
-			runSql(
+			db.runSql(
 				`SELECT COUNT(*) FROM story_entities se
 				 JOIN stories s ON se.story_id = s.id
 				 WHERE s.source_id = '${sourceId}';`,

--- a/tests/specs/37_vector_search_retrieval.test.ts
+++ b/tests/specs/37_vector_search_retrieval.test.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import {
 	type EmbeddingResult,
@@ -12,17 +11,17 @@ import {
 import { vectorSearch } from '@mulder/retrieval';
 import pg from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-const PG_DATABASE = 'mulder';
-const PG_HOST = 'localhost';
-const PG_PORT = 5432;
+const PG_USER = db.TEST_PG_USER;
+const PG_PASSWORD = db.TEST_PG_PASSWORD;
+const PG_DATABASE = db.TEST_PG_DATABASE;
+const PG_HOST = db.TEST_PG_HOST;
+const PG_PORT = db.TEST_PG_PORT;
 
 /**
  * Black-box QA tests for Spec 37: Vector Search Retrieval (M4-E1).
@@ -34,7 +33,7 @@ const PG_PORT = 5432;
  * Each `it()` maps to one QA condition (QA-01..QA-12) from the spec's QA Contract.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built dist artifacts for `@mulder/core` and `@mulder/retrieval`
  */
 
@@ -43,27 +42,11 @@ const PG_PORT = 5432;
 // ---------------------------------------------------------------------------
 
 function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
+	return db.isPgAvailable();
 }
 
 function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DATABASE, '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
+	return db.runSql(sql);
 }
 
 /**
@@ -226,11 +209,7 @@ describe('Spec 37 — Vector Search Retrieval', () => {
 
 	beforeAll(async () => {
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 

--- a/tests/specs/38_fulltext_search_retrieval.test.ts
+++ b/tests/specs/38_fulltext_search_retrieval.test.ts
@@ -1,20 +1,19 @@
-import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { loadConfig, type MulderConfig, mulderConfigSchema, RetrievalError, searchByFts } from '@mulder/core';
 import { fulltextSearch } from '@mulder/retrieval';
 import pg from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-const PG_DATABASE = 'mulder';
-const PG_HOST = 'localhost';
-const PG_PORT = 5432;
+const PG_USER = db.TEST_PG_USER;
+const PG_PASSWORD = db.TEST_PG_PASSWORD;
+const PG_DATABASE = db.TEST_PG_DATABASE;
+const PG_HOST = db.TEST_PG_HOST;
+const PG_PORT = db.TEST_PG_PORT;
 
 /**
  * Black-box QA tests for Spec 38: Full-Text Search Retrieval (M4-E2).
@@ -26,7 +25,7 @@ const PG_PORT = 5432;
  * Contract. Section 5b is N/A (library-only).
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built dist artifacts for `@mulder/core` and `@mulder/retrieval`
  */
 
@@ -35,27 +34,11 @@ const PG_PORT = 5432;
 // ---------------------------------------------------------------------------
 
 function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
+	return db.isPgAvailable();
 }
 
 function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DATABASE, '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
+	return db.runSql(sql);
 }
 
 function runSqlReturning(sql: string): string {
@@ -221,11 +204,7 @@ describe('Spec 38 — Full-Text Search Retrieval', () => {
 
 	beforeAll(async () => {
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 

--- a/tests/specs/39_graph_traversal_retrieval.test.ts
+++ b/tests/specs/39_graph_traversal_retrieval.test.ts
@@ -1,20 +1,19 @@
-import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { loadConfig, type MulderConfig, mulderConfigSchema, RetrievalError, traverseGraph } from '@mulder/core';
 import { graphSearch } from '@mulder/retrieval';
 import pg from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-const PG_DATABASE = 'mulder';
-const PG_HOST = 'localhost';
-const PG_PORT = 5432;
+const PG_USER = db.TEST_PG_USER;
+const PG_PASSWORD = db.TEST_PG_PASSWORD;
+const PG_DATABASE = db.TEST_PG_DATABASE;
+const PG_HOST = db.TEST_PG_HOST;
+const PG_PORT = db.TEST_PG_PORT;
 
 /**
  * Black-box QA tests for Spec 39: Graph Traversal Retrieval (M4-E3).
@@ -27,7 +26,7 @@ const PG_PORT = 5432;
  * Contract. Section 5b is N/A (no CLI commands).
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built dist artifacts for `@mulder/core` and `@mulder/retrieval`
  */
 
@@ -36,27 +35,11 @@ const PG_PORT = 5432;
 // ---------------------------------------------------------------------------
 
 function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
+	return db.isPgAvailable();
 }
 
 function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DATABASE, '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
+	return db.runSql(sql);
 }
 
 function runSqlReturning(sql: string): string {
@@ -457,11 +440,7 @@ describe('Spec 39 — Graph Traversal Retrieval', () => {
 
 	beforeAll(async () => {
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 

--- a/tests/specs/42_hybrid_retrieval_orchestrator.test.ts
+++ b/tests/specs/42_hybrid_retrieval_orchestrator.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@mulder/retrieval';
 import pg from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 /**
  * Black-box QA tests for Spec 42: Hybrid Retrieval Orchestrator (M4-E6).
@@ -30,12 +31,12 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
  *
  * Interaction is through system boundaries only:
  * - `@mulder/retrieval` + `@mulder/core` public entrypoints for library tests
- * - `spawnSync` CLI subprocess + `docker exec psql` for integration tests
+ * - `spawnSync` CLI subprocess + `the shared env-driven SQL helper` for integration tests
  *
  * Never imports from packages/src, apps/src, or any internal module.
  *
  * Requires:
- *   - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ *   - PostgreSQL reachable through the standard PG env vars with migrations applied
  *   - Built CLI at apps/cli/dist/index.js
  *   - Test fixtures in fixtures/raw/
  */
@@ -52,10 +53,6 @@ const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 // ---------------------------------------------------------------------------
 // CLI + SQL helpers
 // ---------------------------------------------------------------------------
@@ -69,7 +66,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -117,32 +114,8 @@ function parseCliJson<T>(stdout: string): T {
 	throw new Error(`Unterminated JSON object in CLI output: ${stdout.slice(start, start + 200)}`);
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM chunks; DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM stories; DELETE FROM source_steps; DELETE FROM sources;',
 	);
 }
@@ -186,7 +159,7 @@ function ingestPdf(pdfPath: string): string {
 		throw new Error(`Ingest failed (exit ${exitCode}): ${stdout} ${stderr}`);
 	}
 	const filename = pdfPath.split('/').pop() ?? '';
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) throw new Error(`No source record for ${filename}`);
 	return sourceId;
 }
@@ -204,7 +177,8 @@ function runFullPipeline(pdfPath: string): string {
 	const enr = runCli(['enrich', '--source', sourceId], { timeout: 120000 });
 	if (enr.exitCode !== 0) throw new Error(`Enrich failed: ${enr.stdout} ${enr.stderr}`);
 
-	const storyIds = runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`)
+	const storyIds = db
+		.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`)
 		.split('\n')
 		.filter((s) => s.length > 0);
 
@@ -315,9 +289,9 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 	let corpusSourceId: string | null = null;
 
 	beforeAll(async () => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn('SKIP: PostgreSQL container mulder-pg-test not available');
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT');
 			return;
 		}
 
@@ -471,14 +445,14 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 		// Ensure there is at least one queryable alias. Dev-mode enrich may produce
 		// entities without aliases, so we insert a synthetic alias pointing at an
 		// existing entity if one isn't already present.
-		let alias = runSql('SELECT alias FROM entity_aliases LIMIT 1;');
+		let alias = db.runSql('SELECT alias FROM entity_aliases LIMIT 1;');
 		if (!alias) {
-			const entityId = runSql('SELECT id FROM entities LIMIT 1;');
+			const entityId = db.runSql('SELECT id FROM entities LIMIT 1;');
 			if (!entityId) {
 				console.warn('SKIP QA-09: no entities in corpus');
 				return;
 			}
-			runSql(`INSERT INTO entity_aliases (entity_id, alias, source) VALUES ('${entityId}', 'ZorkTest', 'manual');`);
+			db.runSql(`INSERT INTO entity_aliases (entity_id, alias, source) VALUES ('${entityId}', 'ZorkTest', 'manual');`);
 			alias = 'ZorkTest';
 		}
 		const { exitCode, stdout, stderr } = runCli(['query', alias, '--strategy', 'graph', '--explain', '--json'], {
@@ -550,7 +524,7 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 	// ─── QA-13: confidence.corpus_size matches SQL truth ───
 	it('QA-13: confidence.corpus_size matches SELECT COUNT(*) FROM sources WHERE status != ingested', () => {
 		if (!pgAvailable || !corpusSourceId) return;
-		const sqlCount = Number.parseInt(runSql("SELECT COUNT(*) FROM sources WHERE status != 'ingested';"), 10);
+		const sqlCount = Number.parseInt(db.runSql("SELECT COUNT(*) FROM sources WHERE status != 'ingested';"), 10);
 		const { exitCode, stdout } = runCli(['query', 'ufo', '--strategy', 'fulltext', '--json'], { timeout: 60000 });
 		expect(exitCode).toBe(0);
 		const parsed = parseCliJson<HybridRetrievalResult>(stdout);
@@ -566,7 +540,7 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 
 		// We cannot easily guarantee an exact corpus of 3 without disturbing the shared fixture,
 		// but the existing populated corpus has a small number of sources (< 25). Verify classification.
-		const sqlCount = Number.parseInt(runSql("SELECT COUNT(*) FROM sources WHERE status != 'ingested';"), 10);
+		const sqlCount = Number.parseInt(db.runSql("SELECT COUNT(*) FROM sources WHERE status != 'ingested';"), 10);
 		if (sqlCount === 0 || sqlCount >= 25) {
 			console.warn(`SKIP QA-14: corpus size ${sqlCount} is not in bootstrapping range (1..24)`);
 			return;
@@ -580,7 +554,7 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 	it('QA-15: graph_density === 0 when entities table is empty', async () => {
 		if (!pgAvailable || !pool) return;
 		// This test needs isolation — snapshot then restore to avoid trashing the shared corpus
-		const savedEntitiesCount = Number.parseInt(runSql('SELECT COUNT(*) FROM entities;'), 10);
+		const savedEntitiesCount = Number.parseInt(db.runSql('SELECT COUNT(*) FROM entities;'), 10);
 		if (savedEntitiesCount === 0) {
 			// Already empty — just run the test
 			const confidence = await computeQueryConfidence(pool, makeConfig(), { graphHitCount: 0 });
@@ -588,7 +562,7 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 			return;
 		}
 		// Non-destructive: verify the formula on its own using raw SQL
-		const edgeCount = Number.parseInt(runSql('SELECT COUNT(*) FROM entity_edges;'), 10);
+		const edgeCount = Number.parseInt(db.runSql('SELECT COUNT(*) FROM entity_edges;'), 10);
 		const expectedDensity = edgeCount / savedEntitiesCount;
 		const confidence = await computeQueryConfidence(pool, makeConfig(), { graphHitCount: 1 });
 		expect(confidence.graph_density).toBeCloseTo(expectedDensity, 6);
@@ -640,14 +614,14 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 		if (!pgAvailable || !pool || !corpusSourceId) return;
 		// Ensure a queryable alias exists. Dev-mode enrich may not create aliases,
 		// so we insert one pointing at an existing entity if needed.
-		let alias = runSql('SELECT alias FROM entity_aliases LIMIT 1;');
+		let alias = db.runSql('SELECT alias FROM entity_aliases LIMIT 1;');
 		if (!alias) {
-			const entityId = runSql('SELECT id FROM entities LIMIT 1;');
+			const entityId = db.runSql('SELECT id FROM entities LIMIT 1;');
 			if (!entityId) {
 				console.warn('SKIP QA-18: no entities in corpus');
 				return;
 			}
-			runSql(
+			db.runSql(
 				`INSERT INTO entity_aliases (entity_id, alias, source) VALUES ('${entityId}', 'QuibbleWord', 'manual') ON CONFLICT DO NOTHING;`,
 			);
 			alias = 'QuibbleWord';
@@ -731,17 +705,17 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 		const storyId = '24242424-2424-2424-2424-242424240001';
 		const chunkId = '24242424-2424-2424-2424-242424240002';
 
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, file_hash, storage_path, page_count, status) VALUES ` +
 				`('${sourceId}', 'qa24-gating.pdf', 'qa24-${Date.now()}', 'raw/qa24.pdf', 1, 'graphed');`,
 		);
-		runSql(
+		db.runSql(
 			`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) VALUES ` +
 				`('${storyId}', '${sourceId}', 'qa24-story', 's/qa24.md', 's/qa24.meta.json', 'graphed');`,
 		);
 		// Generate a deterministic 768-dim embedding (all zeros + first dim 0.5).
 		const vec = `[0.5${',0'.repeat(767)}]`;
-		runSql(
+		db.runSql(
 			`INSERT INTO chunks (id, story_id, content, chunk_index, embedding) VALUES ` +
 				`('${chunkId}', '${storyId}', 'A passage containing the unique token ${queryWord}.', 0, '${vec}');`,
 		);
@@ -770,7 +744,7 @@ describe('Spec 42 — Hybrid Retrieval Orchestrator', () => {
 			expect(result.results).toEqual([]);
 			expect(result.confidence.message).toBe('no_meaningful_matches');
 		} finally {
-			runSql(
+			db.runSql(
 				`DELETE FROM chunks WHERE id = '${chunkId}';` +
 					` DELETE FROM stories WHERE id = '${storyId}';` +
 					` DELETE FROM sources WHERE id = '${sourceId}';`,
@@ -805,7 +779,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-03: Empty-string question ───
 	it('CLI-03: empty-string <question> errors cleanly with no stack trace', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout, stderr } = runCli(['query', '']);
 		expect(exitCode).not.toBe(0);
@@ -815,7 +789,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-04: Invalid --strategy ───
 	it('CLI-04: invalid --strategy value errors cleanly', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout, stderr } = runCli(['query', 'test', '--strategy', 'bogus']);
 		expect(exitCode).not.toBe(0);
@@ -826,7 +800,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-05: --json is parseable ───
 	it('CLI-05: --json output is parseable JSON with expected shape', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout } = runCli(['query', 'test', '--json'], { timeout: 60000 });
 		expect(exitCode).toBe(0);
@@ -841,7 +815,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-06: Text mode renders ───
 	it('CLI-06: text mode prints query + results header', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout } = runCli(['query', 'test'], { timeout: 60000 });
 		expect(exitCode).toBe(0);
@@ -851,7 +825,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-07: --explain text mode ───
 	it('CLI-07: --explain text mode prints per-result strategy breakdowns when hits exist', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout } = runCli(['query', 'ufo', '--explain'], { timeout: 60000 });
 		expect(exitCode).toBe(0);
@@ -862,7 +836,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-08: Empty-result query does not crash ───
 	it('CLI-08: query with guaranteed-no-match does not crash', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout } = runCli(['query', 'xyznonsense12345', '--json'], { timeout: 60000 });
 		expect(exitCode).toBe(0);
@@ -873,7 +847,7 @@ describe('CLI Test Matrix: query', () => {
 
 	// ─── CLI-09: --top-k 1 --strategy vector ───
 	it('CLI-09: --top-k 1 --strategy vector returns at most 1 vector-only result', () => {
-		const pgAvailable = isPgAvailable();
+		const pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) return;
 		const { exitCode, stdout } = runCli(['query', 'test', '--top-k', '1', '--strategy', 'vector', '--json'], {
 			timeout: 60000,

--- a/tests/specs/44_e2e_pipeline_integration.test.ts
+++ b/tests/specs/44_e2e_pipeline_integration.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 /**
  * Black-box end-to-end integration test for the full M1–M4 MVP pipeline.
@@ -23,11 +24,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
  * is covered by spec 42 and by the Phase 3 golden retrieval set).
  *
  * System boundary: `node apps/cli/dist/index.js` subprocess + `docker exec
- * mulder-pg-test psql` for DB state introspection. No internal source
+ * the shared env-driven SQL helper for DB state introspection. No internal source
  * imports.
  *
  * Requires:
- *   - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ *   - PostgreSQL reachable through the standard PG env vars with migrations applied
  *   - Built CLI at apps/cli/dist/index.js
  *   - Test fixtures in fixtures/raw/
  */
@@ -44,10 +45,6 @@ const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -61,39 +58,13 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 60000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
 		stderr: result.stderr ?? '',
 		exitCode: result.status ?? 1,
 	};
-}
-
-function runSql(sql: string): string {
-	try {
-		const result = execFileSync(
-			'docker',
-			['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-			{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-		);
-		return (result ?? '').trim();
-	} catch (error: unknown) {
-		const err = error as { stderr?: string; status?: number };
-		throw new Error(`psql failed (exit ${err.status}): ${err.stderr}`);
-	}
-}
-
-function isPgAvailable(): boolean {
-	try {
-		execFileSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
 }
 
 /**
@@ -110,7 +81,7 @@ function ensureSchema(): void {
 }
 
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		[
 			'DELETE FROM chunks',
 			'DELETE FROM story_entities',
@@ -147,7 +118,7 @@ function stageIngest(pdfPath: string): string {
 		throw new Error(`Ingest failed (exit ${exitCode}): ${stdout} ${stderr}`);
 	}
 	const filename = pdfPath.split('/').pop() ?? '';
-	const sourceId = runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
+	const sourceId = db.runSql(`SELECT id FROM sources WHERE filename = '${filename}' ORDER BY created_at DESC LIMIT 1;`);
 	if (!sourceId) throw new Error(`No source row created for ${filename}`);
 	return sourceId;
 }
@@ -182,7 +153,8 @@ function stageGraph(storyIds: string[]): void {
 }
 
 function listStoryIds(sourceId: string): string[] {
-	return runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`)
+	return db
+		.runSql(`SELECT id FROM stories WHERE source_id = '${sourceId}';`)
 		.split('\n')
 		.filter((s) => s.length > 0);
 }
@@ -196,9 +168,9 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 	let sourceId: string | null = null;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn('SKIP: PostgreSQL container mulder-pg-test not available');
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT');
 			return;
 		}
 
@@ -226,7 +198,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 	// ─── QA-01: Ingest writes a source row with status 'ingested' ───
 	it('QA-01: ingest creates sources row with status=ingested and file hash', () => {
 		if (!pgAvailable || !sourceId) return;
-		const row = runSql(`SELECT status, file_hash, filename FROM sources WHERE id = '${sourceId}';`);
+		const row = db.runSql(`SELECT status, file_hash, filename FROM sources WHERE id = '${sourceId}';`);
 		expect(row).toContain('ingested');
 		expect(row).toContain('native-text-sample.pdf');
 		// File hash should be a 64-char hex SHA-256
@@ -238,7 +210,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		if (!pgAvailable || !sourceId) return;
 		stageExtract(sourceId);
 
-		const status = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const status = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(status).toBe('extracted');
 
 		// Layout artifact should exist in local storage
@@ -246,7 +218,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		expect(existsSync(layoutPath)).toBe(true);
 
 		// source_steps row for extract should exist and be completed
-		const stepRow = runSql(
+		const stepRow = db.runSql(
 			`SELECT step_name, status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 		);
 		expect(stepRow).toContain('extract');
@@ -258,17 +230,17 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		if (!pgAvailable || !sourceId) return;
 		stageSegment(sourceId);
 
-		const storyCount = Number(runSql(`SELECT count(*) FROM stories WHERE source_id = '${sourceId}';`));
+		const storyCount = Number(db.runSql(`SELECT count(*) FROM stories WHERE source_id = '${sourceId}';`));
 		expect(storyCount).toBeGreaterThan(0);
 
 		// Every story should be in the 'segmented' state right after segment ran.
-		const anyNotSegmented = runSql(
+		const anyNotSegmented = db.runSql(
 			`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status != 'segmented';`,
 		);
 		expect(Number(anyNotSegmented)).toBe(0);
 
 		// Source status should advance to segmented
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(sourceStatus).toBe('segmented');
 	});
 
@@ -283,20 +255,20 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 
 		const storyIdClause = `story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}')`;
 		const entityCount = Number(
-			runSql(
+			db.runSql(
 				`SELECT count(*) FROM entities WHERE id IN (SELECT entity_id FROM story_entities WHERE ${storyIdClause});`,
 			),
 		);
 		expect(entityCount).toBeGreaterThan(0);
 
 		// story_entities should be populated
-		const linkCount = Number(runSql(`SELECT count(*) FROM story_entities WHERE ${storyIdClause};`));
+		const linkCount = Number(db.runSql(`SELECT count(*) FROM story_entities WHERE ${storyIdClause};`));
 		expect(linkCount).toBeGreaterThan(0);
 
 		// Per spec §2.4, enrich advances story status but NOT source status —
 		// that is the orchestrator's job. See docs/reviews/qa-gate-triage.md
 		// Issue 3 for the BY-DESIGN rationale.
-		const storiesEnriched = runSql(
+		const storiesEnriched = db.runSql(
 			`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'enriched';`,
 		);
 		expect(Number(storiesEnriched)).toBe(storyIds.length);
@@ -309,24 +281,24 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		stageEmbed(storyIds);
 
 		const storyIdClause = `story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}')`;
-		const chunkCount = Number(runSql(`SELECT count(*) FROM chunks WHERE ${storyIdClause};`));
+		const chunkCount = Number(db.runSql(`SELECT count(*) FROM chunks WHERE ${storyIdClause};`));
 		expect(chunkCount).toBeGreaterThan(0);
 
 		// Dimensionality check — CLAUDE.md is emphatic that vectors must NEVER
 		// be manually truncated. This query asserts that pgvector stores the
 		// full 768 dimensions as produced by text-embedding-004 via the
 		// Matryoshka outputDimensionality API parameter.
-		const dimRow = runSql(`SELECT vector_dims(embedding) FROM chunks WHERE ${storyIdClause} LIMIT 1;`);
+		const dimRow = db.runSql(`SELECT vector_dims(embedding) FROM chunks WHERE ${storyIdClause} LIMIT 1;`);
 		expect(Number(dimRow)).toBe(768);
 
 		// fts_vector (the generated tsvector column) should be non-null on
 		// every chunk — verifies the D7/E2 "single-table vector + BM25"
 		// invariant from CLAUDE.md.
-		const nullFts = runSql(`SELECT count(*) FROM chunks WHERE ${storyIdClause} AND fts_vector IS NULL;`);
+		const nullFts = db.runSql(`SELECT count(*) FROM chunks WHERE ${storyIdClause} AND fts_vector IS NULL;`);
 		expect(Number(nullFts)).toBe(0);
 
 		// Stories should advance to 'embedded'
-		const storiesEmbedded = runSql(
+		const storiesEmbedded = db.runSql(
 			`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'embedded';`,
 		);
 		expect(Number(storiesEmbedded)).toBe(storyIds.length);
@@ -339,7 +311,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		stageGraph(storyIds);
 
 		// Stories should be in 'graphed' state
-		const storiesGraphed = runSql(
+		const storiesGraphed = db.runSql(
 			`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'graphed';`,
 		);
 		expect(Number(storiesGraphed)).toBe(storyIds.length);
@@ -347,7 +319,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		// At least one entity_edge row should exist touching our entities.
 		// We scope via story_entities to avoid interference from fixtures.
 		const edgeCount = Number(
-			runSql(
+			db.runSql(
 				`SELECT count(*) FROM entity_edges ee WHERE EXISTS (
 					SELECT 1 FROM story_entities se
 					WHERE se.entity_id IN (ee.source_entity_id, ee.target_entity_id)
@@ -370,7 +342,8 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		// Per migration 002_sources.sql there is no story_id column — step
 		// tracking is source-scoped. Every completed pipeline run should
 		// therefore leave a single row per step for this source.
-		const steps = runSql(`SELECT step_name FROM source_steps WHERE source_id = '${sourceId}' ORDER BY step_name;`)
+		const steps = db
+			.runSql(`SELECT step_name FROM source_steps WHERE source_id = '${sourceId}' ORDER BY step_name;`)
 			.split('\n')
 			.filter(Boolean);
 
@@ -381,7 +354,7 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		// All tracked steps should be status=completed (no partial/failed
 		// rows lingering after a clean run).
 		const badRows = Number(
-			runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${sourceId}' AND status NOT IN ('completed');`),
+			db.runSql(`SELECT count(*) FROM source_steps WHERE source_id = '${sourceId}' AND status NOT IN ('completed');`),
 		);
 		expect(badRows).toBe(0);
 	});
@@ -392,7 +365,9 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 
 		// Sanity: we currently have chunks + edges + stories for this source
 		const before = Number(
-			runSql(`SELECT count(*) FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`),
+			db.runSql(
+				`SELECT count(*) FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`,
+			),
 		);
 		expect(before).toBeGreaterThan(0);
 
@@ -410,14 +385,16 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		// gone. The source itself remains (we only reset the extract step
 		// and below).
 		const afterChunks = Number(
-			runSql(`SELECT count(*) FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`),
+			db.runSql(
+				`SELECT count(*) FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id = '${sourceId}');`,
+			),
 		);
 		expect(afterChunks).toBe(0);
 
 		// Source should still exist, status rolled back to at most 'extracted'
 		// (extract just re-ran, so 'extracted' is the expected terminal value
 		// after the force rerun).
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(['extracted', 'ingested']).toContain(sourceStatus);
 	});
 
@@ -434,7 +411,9 @@ describe('Spec 44 — End-to-end pipeline integration (QA-Gate Phase 3, D6)', ()
 		stageEmbed(storyIds);
 		stageGraph(storyIds);
 
-		const finalStatus = runSql(`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'graphed';`);
+		const finalStatus = db.runSql(
+			`SELECT count(*) FROM stories WHERE source_id = '${sourceId}' AND status = 'graphed';`,
+		);
 		expect(Number(finalStatus)).toBe(storyIds.length);
 	});
 

--- a/tests/specs/46_taxonomy_bootstrap.test.ts
+++ b/tests/specs/46_taxonomy_bootstrap.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 /**
@@ -9,20 +10,16 @@ import { ensureSchema } from '../lib/schema.js';
  *
  * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  */
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,37 +34,13 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
 		stderr: result.stderr ?? '',
 		exitCode: result.status ?? 1,
 	};
-}
-
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
 }
 
 /**
@@ -118,7 +91,7 @@ function seedSources(count: number): string[] {
 	for (let i = 0; i < count; i++) {
 		const id = randomUUID();
 		const hash = randomUUID(); // unique file_hash
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, storage_path, file_hash, page_count, status) ` +
 				`VALUES ('${id}', 'test-${id.slice(0, 8)}.pdf', 'raw/test-${id.slice(0, 8)}.pdf', '${hash}', 5, 'enriched') ` +
 				`ON CONFLICT (id) DO NOTHING;`,
@@ -136,7 +109,7 @@ function seedEntities(entities: Array<{ name: string; type: string }>): string[]
 	const ids: string[] = [];
 	for (const ent of entities) {
 		const id = randomUUID();
-		runSql(
+		db.runSql(
 			`INSERT INTO entities (id, name, type) ` +
 				`VALUES ('${id}', '${ent.name.replace(/'/g, "''")}', '${ent.type}') ` +
 				`ON CONFLICT (name, type) WHERE canonical_id IS NULL DO UPDATE SET updated_at = now() RETURNING id;`,
@@ -156,7 +129,7 @@ function seedTaxonomy(
 		const aliasArray = entry.aliases?.length
 			? `ARRAY[${entry.aliases.map((a) => `'${a.replace(/'/g, "''")}'`).join(',')}]`
 			: `ARRAY['${entry.canonical_name.replace(/'/g, "''")}']`;
-		runSql(
+		db.runSql(
 			`INSERT INTO taxonomy (canonical_name, entity_type, status, aliases) ` +
 				`VALUES ('${entry.canonical_name.replace(/'/g, "''")}', '${entry.entity_type}', '${entry.status}', ${aliasArray}) ` +
 				`ON CONFLICT (canonical_name, entity_type) DO UPDATE SET status = '${entry.status}', aliases = ${aliasArray};`,
@@ -165,7 +138,7 @@ function seedTaxonomy(
 }
 
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'DELETE FROM taxonomy; ' +
 			'DELETE FROM chunks; DELETE FROM story_entities; DELETE FROM entity_edges; DELETE FROM entity_aliases; ' +
 			'DELETE FROM entities; DELETE FROM stories; DELETE FROM source_steps; ' +
@@ -178,7 +151,7 @@ function cleanTestData(): void {
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (!pgAvailable) return;
 	ensureSchema();
 	cleanTestData();
@@ -260,11 +233,11 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 		}
 
 		// Verify taxonomy entries were created with status 'auto'
-		const autoCount = runSql("SELECT COUNT(*) FROM taxonomy WHERE status = 'auto';");
+		const autoCount = db.runSql("SELECT COUNT(*) FROM taxonomy WHERE status = 'auto';");
 		expect(Number(autoCount)).toBeGreaterThan(0);
 
 		// Verify they have canonical_name and aliases
-		const entries = runSql("SELECT canonical_name, aliases FROM taxonomy WHERE status = 'auto' LIMIT 5;");
+		const entries = db.runSql("SELECT canonical_name, aliases FROM taxonomy WHERE status = 'auto' LIMIT 5;");
 		expect(entries.length).toBeGreaterThan(0);
 	});
 
@@ -296,7 +269,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 		// typesProcessed should include the entity types we seeded
 		if (result.typesProcessed && result.typesProcessed.length > 0) {
 			// Check each taxonomy entry has an entity_type matching one of our seeded types
-			const types = runSql("SELECT DISTINCT entity_type FROM taxonomy WHERE status = 'auto';");
+			const types = db.runSql("SELECT DISTINCT entity_type FROM taxonomy WHERE status = 'auto';");
 			const typeList = types.split('\n').filter(Boolean);
 			for (const t of typeList) {
 				expect(['person', 'organization', 'location']).toContain(t);
@@ -317,7 +290,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 		// Insert a confirmed taxonomy entry
 		seedTaxonomy([{ canonical_name: 'Confirmed Person', entity_type: 'person', status: 'confirmed', aliases: ['CP'] }]);
 
-		const confirmedBefore = runSql(
+		const confirmedBefore = db.runSql(
 			"SELECT canonical_name, aliases FROM taxonomy WHERE status = 'confirmed' AND canonical_name = 'Confirmed Person';",
 		);
 
@@ -333,7 +306,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 		}
 
 		// Confirmed entry must still exist and be unchanged
-		const confirmedAfter = runSql(
+		const confirmedAfter = db.runSql(
 			"SELECT canonical_name, aliases FROM taxonomy WHERE status = 'confirmed' AND canonical_name = 'Confirmed Person';",
 		);
 		expect(confirmedAfter).toBe(confirmedBefore);
@@ -352,7 +325,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 			{ canonical_name: 'Confirmed Entry', entity_type: 'person', status: 'confirmed' },
 		]);
 
-		const confirmedBefore = runSql("SELECT id, canonical_name FROM taxonomy WHERE status = 'confirmed';");
+		const confirmedBefore = db.runSql("SELECT id, canonical_name FROM taxonomy WHERE status = 'confirmed';");
 
 		runCli(['taxonomy', 're-bootstrap', '--json'], { timeout: 60000 });
 
@@ -360,11 +333,13 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 		// If bootstrap fails due to threshold (corpus < 25 and no override),
 		// that's expected — but auto entries should already be deleted.
 		// Check that confirmed entries are preserved regardless.
-		const confirmedAfter = runSql("SELECT id, canonical_name FROM taxonomy WHERE status = 'confirmed';");
+		const confirmedAfter = db.runSql("SELECT id, canonical_name FROM taxonomy WHERE status = 'confirmed';");
 		expect(confirmedAfter).toBe(confirmedBefore);
 
 		// Auto entries should be deleted (re-bootstrap deletes them before calling bootstrap)
-		const autoAfter = runSql("SELECT COUNT(*) FROM taxonomy WHERE status = 'auto' AND canonical_name = 'Auto Entry';");
+		const autoAfter = db.runSql(
+			"SELECT COUNT(*) FROM taxonomy WHERE status = 'auto' AND canonical_name = 'Auto Entry';",
+		);
 		expect(Number(autoAfter)).toBe(0);
 	});
 
@@ -454,7 +429,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 			expect.fail(`First bootstrap failed: ${combined}`);
 		}
 
-		const countAfterFirst = Number(runSql('SELECT COUNT(*) FROM taxonomy;'));
+		const countAfterFirst = Number(db.runSql('SELECT COUNT(*) FROM taxonomy;'));
 
 		// Second run
 		const second = runCli(['taxonomy', 'bootstrap', '--min-docs', '1']);
@@ -467,7 +442,7 @@ describe('Spec 46 — Taxonomy Bootstrap (QA Contract)', () => {
 			expect.fail(`Second bootstrap failed: ${combined}`);
 		}
 
-		const countAfterSecond = Number(runSql('SELECT COUNT(*) FROM taxonomy;'));
+		const countAfterSecond = Number(db.runSql('SELECT COUNT(*) FROM taxonomy;'));
 
 		// Entry count should not grow unboundedly (upsert semantics)
 		expect(countAfterSecond).toBeLessThanOrEqual(countAfterFirst * 2);

--- a/tests/specs/47_document_ai_extraction.test.ts
+++ b/tests/specs/47_document_ai_extraction.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -9,10 +10,6 @@ const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
 const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
 const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 /**
  * Black-box end-to-end test for the Document AI extraction path.
@@ -46,7 +43,7 @@ const PG_PASSWORD = 'mulder';
  *   - `gcp.document_ai.processor_id` set to a real Layout Parser processor
  *   - `gcp.document_ai.location` set to the matching multi-region (`eu` or `us`)
  * - Built CLI at `apps/cli/dist/index.js`
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  *
  * Also acts as the regression test for #93: if the Document AI processor
  * name is constructed with the wrong location segment, the extract step
@@ -68,7 +65,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 180_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -77,32 +74,8 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5_000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function cleanSourceData(filename: string): void {
-	runSql(
+	db.runSql(
 		`DELETE FROM chunks WHERE story_id IN (SELECT id FROM stories WHERE source_id IN (SELECT id FROM sources WHERE filename = '${filename}'));` +
 			` DELETE FROM stories WHERE source_id IN (SELECT id FROM sources WHERE filename = '${filename}');` +
 			` DELETE FROM source_steps WHERE source_id IN (SELECT id FROM sources WHERE filename = '${filename}');` +
@@ -115,7 +88,7 @@ function cleanSourceData(filename: string): void {
 // ---------------------------------------------------------------------------
 
 describe('Spec 47 — Document AI Extraction (E2E, real GCP)', () => {
-	const pgAvailable = isPgAvailable();
+	const pgAvailable = db.isPgAvailable();
 	let sourceId: string | null = null;
 
 	beforeAll(() => {
@@ -123,7 +96,7 @@ describe('Spec 47 — Document AI Extraction (E2E, real GCP)', () => {
 			return;
 		}
 		if (!pgAvailable) {
-			throw new Error('mulder-pg-test container is required for the E2E test');
+			throw new Error('PostgreSQL reachable through PGHOST/PGPORT is required for the E2E test');
 		}
 		ensureSchema();
 		cleanSourceData('scanned-sample.pdf');
@@ -143,10 +116,10 @@ describe('Spec 47 — Document AI Extraction (E2E, real GCP)', () => {
 		const { exitCode, stdout, stderr } = runCli(['ingest', SCANNED_PDF]);
 		expect(exitCode, `ingest failed: ${stdout}\n${stderr}`).toBe(0);
 
-		sourceId = runSql("SELECT id FROM sources WHERE filename = 'scanned-sample.pdf';");
+		sourceId = db.runSql("SELECT id FROM sources WHERE filename = 'scanned-sample.pdf';");
 		expect(sourceId).toMatch(/^[a-f0-9-]{36}$/);
 
-		const hasNative = runSql(`SELECT has_native_text FROM sources WHERE id = '${sourceId}';`);
+		const hasNative = db.runSql(`SELECT has_native_text FROM sources WHERE id = '${sourceId}';`);
 		// has_native_text is a boolean column; psql returns 'f' or 't'.
 		expect(hasNative).toBe('f');
 	});
@@ -160,12 +133,12 @@ describe('Spec 47 — Document AI Extraction (E2E, real GCP)', () => {
 
 		// source_steps should record `extract` completed, with method='document_ai'
 		// in the metadata if the step records the routing decision.
-		const stepStatus = runSql(
+		const stepStatus = db.runSql(
 			`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'extract';`,
 		);
 		expect(stepStatus).toBe('completed');
 
-		const sourceStatus = runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
+		const sourceStatus = db.runSql(`SELECT status FROM sources WHERE id = '${sourceId}';`);
 		expect(sourceStatus).toBe('extracted');
 	});
 

--- a/tests/specs/48_layout_to_markdown.test.ts
+++ b/tests/specs/48_layout_to_markdown.test.ts
@@ -14,7 +14,7 @@
  * No imports from packages/*|/src, apps/*|/src, or src/. Dist-barrel only.
  *
  * Infra dependencies:
- *   - A running `mulder-pg-test` PostgreSQL container (same as spec 19).
+ *   - A running PostgreSQL reachable through the standard PG env vars (same as spec 19).
  *     QA conditions that need the DB are gated on `pgAvailable`; when the
  *     container is down they are skipped with a clear message instead of
  *     failing the whole suite.
@@ -23,10 +23,10 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -57,34 +57,6 @@ const FIXTURE_NAMES = [
 // Docker / PG helpers (shared with spec 19 container)
 // ---------------------------------------------------------------------------
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
 function runCli(
 	args: string[],
 	opts?: { env?: Record<string, string>; timeout?: number },
@@ -94,7 +66,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 90_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -104,7 +76,7 @@ function runCli(
 }
 
 function cleanTestData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 function cleanExtractedStorage(): void {
@@ -121,7 +93,7 @@ function ingestNativeTextPdf(): string {
 	if (exitCode !== 0) {
 		throw new Error(`Ingest failed (exit ${exitCode}): ${stdout} ${stderr}`);
 	}
-	const sourceId = runSql(
+	const sourceId = db.runSql(
 		"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 	);
 	if (!sourceId) {
@@ -201,13 +173,9 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		expect(typeof layoutToMarkdown).toBe('function');
 		expect(typeof executeExtract).toBe('function');
 
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: mulder-pg-test container not running — QA-10, QA-11, QA-12 and CLI-01..06 will be skipped.\n' +
-					'  Start with: docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 		} else {
 			// Ensure schema is migrated (idempotent — matches spec 19 pattern).
 			const migrate = runCli(['db', 'migrate', resolve(ROOT, 'mulder.config.example.yaml')]);
@@ -270,7 +238,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		// Find the heading line index and confirm the very next line is
 		// blank (i.e., a blank line separates the heading from the next
 		// content line).
-		const headingIdx = lines.findIndex((l) => l === '# Test Heading');
+		const headingIdx = lines.indexOf('# Test Heading');
 		expect(headingIdx).toBeGreaterThanOrEqual(0);
 		expect(lines[headingIdx + 1] ?? '').toBe('');
 
@@ -437,7 +405,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 	});
 
 	// ─── QA-10: Extract step writes layout.md alongside layout.json ───
-	it.skipIf(!isPgAvailable())('QA-10: executeExtract writes both layout.json and layout.md to storage', async () => {
+	it.skipIf(!db.isPgAvailable())('QA-10: executeExtract writes both layout.json and layout.md to storage', async () => {
 		if (!pgAvailable) return;
 
 		cleanTestData();
@@ -479,7 +447,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 	// We wrap the dev services such that storage.upload() throws on any
 	// path ending in `.md`. The spec guarantees this must not fail the
 	// overall extract result.
-	it.skipIf(!isPgAvailable())('QA-11: a failing layout.md upload does not fail the extract step', async () => {
+	it.skipIf(!db.isPgAvailable())('QA-11: a failing layout.md upload does not fail the extract step', async () => {
 		if (!pgAvailable) return;
 
 		cleanTestData();
@@ -527,7 +495,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 	});
 
 	// ─── QA-12: Extract idempotency preserves layout.md deterministically ───
-	it.skipIf(!isPgAvailable())('QA-12: re-running extract with --force produces byte-identical layout.md', () => {
+	it.skipIf(!db.isPgAvailable())('QA-12: re-running extract with --force produces byte-identical layout.md', () => {
 		if (!pgAvailable) return;
 
 		cleanTestData();
@@ -594,7 +562,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		}
 
 		// ─── CLI-01: plain extract writes layout.md in storage, no local file ───
-		it.skipIf(!isPgAvailable())('CLI-01: mulder extract <id> → exit 0, layout.md in storage, no local file', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-01: mulder extract <id> → exit 0, layout.md in storage, no local file', () => {
 			if (!pgAvailable) return;
 			const id = ensureSource();
 
@@ -610,22 +578,25 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		});
 
 		// ─── CLI-02: --markdown-to writes a local file matching storage ───
-		it.skipIf(!isPgAvailable())('CLI-02: --markdown-to writes a local file byte-identical to storage layout.md', () => {
-			if (!pgAvailable) return;
-			const id = ensureSource();
+		it.skipIf(!db.isPgAvailable())(
+			'CLI-02: --markdown-to writes a local file byte-identical to storage layout.md',
+			() => {
+				if (!pgAvailable) return;
+				const id = ensureSource();
 
-			const localPath = join(TMP_DIR, 'out.md');
-			const result = runCli(['extract', id, '--markdown-to', localPath]);
-			expect(result.exitCode).toBe(0);
-			expect(existsSync(localPath)).toBe(true);
+				const localPath = join(TMP_DIR, 'out.md');
+				const result = runCli(['extract', id, '--markdown-to', localPath]);
+				expect(result.exitCode).toBe(0);
+				expect(existsSync(localPath)).toBe(true);
 
-			const local = readFileSync(localPath);
-			const storage = readFileSync(join(EXTRACTED_STORAGE_DIR, id, 'layout.md'));
-			expect(local.equals(storage)).toBe(true);
-		});
+				const local = readFileSync(localPath);
+				const storage = readFileSync(join(EXTRACTED_STORAGE_DIR, id, 'layout.md'));
+				expect(local.equals(storage)).toBe(true);
+			},
+		);
 
 		// ─── CLI-03: --force + --markdown-to produces same content as CLI-02 ───
-		it.skipIf(!isPgAvailable())('CLI-03: --force --markdown-to matches CLI-02 output (deterministic)', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-03: --force --markdown-to matches CLI-02 output (deterministic)', () => {
 			if (!pgAvailable) return;
 			const id = ensureSource();
 
@@ -647,7 +618,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		});
 
 		// ─── CLI-04: --all and --markdown-to are mutually exclusive ───
-		it.skipIf(!isPgAvailable())('CLI-04: --all --markdown-to exits non-zero with a mutual-exclusion error', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-04: --all --markdown-to exits non-zero with a mutual-exclusion error', () => {
 			if (!pgAvailable) return;
 
 			const manyPath = join(TMP_DIR, 'many.md');
@@ -665,7 +636,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		});
 
 		// ─── CLI-05: non-existent parent directory fails cleanly ───
-		it.skipIf(!isPgAvailable())('CLI-05: --markdown-to with a nonexistent parent dir exits non-zero', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-05: --markdown-to with a nonexistent parent dir exits non-zero', () => {
 			if (!pgAvailable) return;
 			const id = ensureSource();
 
@@ -680,25 +651,28 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 		});
 
 		// ─── CLI-06: running CLI-02 twice yields byte-identical output ───
-		it.skipIf(!isPgAvailable())('CLI-06: running the same --markdown-to command twice yields identical bytes', () => {
-			if (!pgAvailable) return;
-			const id = ensureSource();
+		it.skipIf(!db.isPgAvailable())(
+			'CLI-06: running the same --markdown-to command twice yields identical bytes',
+			() => {
+				if (!pgAvailable) return;
+				const id = ensureSource();
 
-			const p = join(TMP_DIR, 'idem.md');
-			if (existsSync(p)) rmSync(p);
+				const p = join(TMP_DIR, 'idem.md');
+				if (existsSync(p)) rmSync(p);
 
-			const first = runCli(['extract', id, '--markdown-to', p]);
-			expect(first.exitCode).toBe(0);
-			expect(existsSync(p)).toBe(true);
-			const bytes1 = readFileSync(p);
+				const first = runCli(['extract', id, '--markdown-to', p]);
+				expect(first.exitCode).toBe(0);
+				expect(existsSync(p)).toBe(true);
+				const bytes1 = readFileSync(p);
 
-			// Second run needs --force because the source is already extracted.
-			const second = runCli(['extract', id, '--force', '--markdown-to', p]);
-			expect(second.exitCode).toBe(0);
-			expect(existsSync(p)).toBe(true);
-			const bytes2 = readFileSync(p);
+				// Second run needs --force because the source is already extracted.
+				const second = runCli(['extract', id, '--force', '--markdown-to', p]);
+				expect(second.exitCode).toBe(0);
+				expect(existsSync(p)).toBe(true);
+				const bytes2 = readFileSync(p);
 
-			expect(bytes2.equals(bytes1)).toBe(true);
-		});
+				expect(bytes2.equals(bytes1)).toBe(true);
+			},
+		);
 	});
 });

--- a/tests/specs/49_mulder_show_command.test.ts
+++ b/tests/specs/49_mulder_show_command.test.ts
@@ -16,7 +16,7 @@
  * CLI binary only.
  *
  * Infra dependencies:
- *   - A running `mulder-pg-test` PostgreSQL container (same as spec 19, 48).
+ *   - A running PostgreSQL reachable through the standard PG env vars (same as spec 19, 48).
  *   - Built `apps/cli/dist/index.js`.
  */
 
@@ -25,6 +25,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -41,34 +42,6 @@ const RAW_STORAGE_DIR = resolve(ROOT, '.local/storage/raw');
 // Docker / PG helpers (shared with spec 19, 48 container)
 // ---------------------------------------------------------------------------
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
 function runCli(
 	args: string[],
 	opts?: { env?: Record<string, string>; timeout?: number; forceColor?: boolean },
@@ -76,7 +49,7 @@ function runCli(
 	// Chalk disables ANSI escapes by default when stdout is not a TTY (which
 	// it isn't under spawnSync). Tests that assert on ANSI output set
 	// `forceColor: true` to propagate FORCE_COLOR=1 into the child process.
-	const baseEnv: Record<string, string> = { ...process.env, PGPASSWORD: PG_PASSWORD };
+	const baseEnv: Record<string, string> = { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD };
 	if (opts?.forceColor) {
 		baseEnv.FORCE_COLOR = '1';
 	}
@@ -102,7 +75,7 @@ function runCli(
 const NATIVE_TEXT_BODY_MARKER = 'This is the first page of the native text sample document';
 
 function cleanTestData(): void {
-	runSql('DELETE FROM source_steps; DELETE FROM sources;');
+	db.runSql('DELETE FROM source_steps; DELETE FROM sources;');
 }
 
 function cleanExtractedStorage(): void {
@@ -131,7 +104,7 @@ function ingestNativeTextPdf(): string {
 	if (exitCode !== 0) {
 		throw new Error(`Ingest failed (exit ${exitCode}): ${stdout} ${stderr}`);
 	}
-	const sourceId = runSql(
+	const sourceId = db.runSql(
 		"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
 	);
 	if (!sourceId) {
@@ -166,7 +139,7 @@ function seedSyntheticSource(filename: string): string {
 	const id = randomUUID();
 	const storagePath = `raw/${id}/${filename}`;
 	const fileHash = `qa-49-${id}`;
-	runSql(
+	db.runSql(
 		`INSERT INTO sources (id, filename, storage_path, file_hash, status, page_count)
 		 VALUES (${sqlQuote(id)}, ${sqlQuote(filename)}, ${sqlQuote(storagePath)}, ${sqlQuote(fileHash)}, 'extracted', 1);`,
 	);
@@ -216,13 +189,9 @@ describe('Spec 49 — `mulder show` command', () => {
 	beforeAll(async () => {
 		expect(existsSync(CLI), `CLI not built: ${CLI}`).toBe(true);
 
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: mulder-pg-test container not running — all spec 49 tests will be skipped.\n' +
-					'  Start with: docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -247,7 +216,7 @@ describe('Spec 49 — `mulder show` command', () => {
 		// seed a synthetic row directly. The row is marked status='ingested'
 		// to match the spec's precondition for QA-05 / CLI-08.
 		unextractedId = randomUUID();
-		runSql(
+		db.runSql(
 			`INSERT INTO sources (id, filename, storage_path, file_hash, status, page_count)
 			 VALUES (${sqlQuote(unextractedId)}, 'qa49-unextracted.pdf',
 			         ${sqlQuote(`raw/${unextractedId}/qa49-unextracted.pdf`)},
@@ -278,7 +247,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	// ═══════════════════════════════════════════════════════════════════════
 
 	// ─── QA-01: Happy path with ANSI formatting ───
-	it.skipIf(!isPgAvailable())('QA-01: show <id> → exit 0, body text present, contains ANSI escape', () => {
+	it.skipIf(!db.isPgAvailable())('QA-01: show <id> → exit 0, body text present, contains ANSI escape', () => {
 		// FORCE_COLOR=1 propagates through to chalk so ANSI is emitted
 		// even though stdout is a pipe, not a TTY.
 		const result = runCli(['show', srcId], { forceColor: true });
@@ -291,7 +260,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	});
 
 	// ─── QA-02: --raw produces byte-identical markdown, zero ANSI ───
-	it.skipIf(!isPgAvailable())('QA-02: show <id> --raw → byte-identical to stored layout.md, no ANSI', () => {
+	it.skipIf(!db.isPgAvailable())('QA-02: show <id> --raw → byte-identical to stored layout.md, no ANSI', () => {
 		const rawFile = readFileSync(join(EXTRACTED_STORAGE_DIR, srcId, 'layout.md'), 'utf-8');
 		const result = runCli(['show', srcId, '--raw']);
 		expect(result.exitCode).toBe(0);
@@ -317,7 +286,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	});
 
 	// ─── QA-04: Nonexistent source ID → exit 1, clear error ───
-	it.skipIf(!isPgAvailable())('QA-04: show <nonexistent-uuid> → exit 1, stderr "Source not found" + UUID', () => {
+	it.skipIf(!db.isPgAvailable())('QA-04: show <nonexistent-uuid> → exit 1, stderr "Source not found" + UUID', () => {
 		const result = runCli(['show', NONEXISTENT_UUID]);
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain('Source not found');
@@ -325,7 +294,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	});
 
 	// ─── QA-05: Source exists but layout.md missing → exit 1, clear error ───
-	it.skipIf(!isPgAvailable())(
+	it.skipIf(!db.isPgAvailable())(
 		'QA-05: show <ingested-only-id> → exit 1, stderr "layout.md not found" + "mulder extract"',
 		() => {
 			const result = runCli(['show', unextractedId]);
@@ -336,7 +305,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	);
 
 	// ─── QA-06: Formatter is deterministic (idempotency) ───
-	it.skipIf(!isPgAvailable())('QA-06: show <id> twice → byte-identical stdouts', () => {
+	it.skipIf(!db.isPgAvailable())('QA-06: show <id> twice → byte-identical stdouts', () => {
 		const first = runCli(['show', srcId]);
 		const second = runCli(['show', srcId]);
 		expect(first.exitCode).toBe(0);
@@ -345,7 +314,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	});
 
 	// ─── QA-07: --pager with PAGER=cat does not crash, produces output ───
-	it.skipIf(!isPgAvailable())('QA-07: show <id> --pager (PAGER=cat) → exit 0, body text passed through', () => {
+	it.skipIf(!db.isPgAvailable())('QA-07: show <id> --pager (PAGER=cat) → exit 0, body text passed through', () => {
 		const result = runCli(['show', srcId, '--pager'], { env: { PAGER: 'cat' } });
 		expect(result.exitCode).toBe(0);
 		// The cat pager passes formatted output through, so the body text
@@ -354,7 +323,7 @@ describe('Spec 49 — `mulder show` command', () => {
 	});
 
 	// ─── QA-08: GFM table separator row is dimmed ───
-	it.skipIf(!isPgAvailable())(
+	it.skipIf(!db.isPgAvailable())(
 		'QA-08: show <id> → GFM table separator row gets chalk.dim, data rows pass through',
 		() => {
 			const result = runCli(['show', syntheticTableId], { forceColor: true });
@@ -404,7 +373,7 @@ describe('Spec 49 — `mulder show` command', () => {
 
 	describe('CLI matrix (§5b)', () => {
 		// ─── CLI-01: plain show → exit 0, ANSI present ───
-		it.skipIf(!isPgAvailable())('CLI-01: show $SRC_ID → exit 0, ANSI present', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-01: show $SRC_ID → exit 0, ANSI present', () => {
 			const result = runCli(['show', srcId], { forceColor: true });
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout.length).toBeGreaterThan(0);
@@ -413,7 +382,7 @@ describe('Spec 49 — `mulder show` command', () => {
 		});
 
 		// ─── CLI-02: --raw → byte-identical, no ANSI ───
-		it.skipIf(!isPgAvailable())('CLI-02: show $SRC_ID --raw → byte-identical to stored layout.md, no ANSI', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-02: show $SRC_ID --raw → byte-identical to stored layout.md, no ANSI', () => {
 			const rawFile = readFileSync(join(EXTRACTED_STORAGE_DIR, srcId, 'layout.md'), 'utf-8');
 			const result = runCli(['show', srcId, '--raw']);
 			expect(result.exitCode).toBe(0);
@@ -424,14 +393,14 @@ describe('Spec 49 — `mulder show` command', () => {
 		});
 
 		// ─── CLI-03: --pager (PAGER=cat) → exit 0, body in stdout ───
-		it.skipIf(!isPgAvailable())('CLI-03: show $SRC_ID --pager (PAGER=cat) → exit 0, body text present', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-03: show $SRC_ID --pager (PAGER=cat) → exit 0, body text present', () => {
 			const result = runCli(['show', srcId, '--pager'], { env: { PAGER: 'cat' } });
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout).toContain(NATIVE_TEXT_BODY_MARKER);
 		});
 
 		// ─── CLI-04: --raw --pager (PAGER=cat) → raw markdown, no ANSI ───
-		it.skipIf(!isPgAvailable())('CLI-04: show $SRC_ID --raw --pager (PAGER=cat) → raw markdown, no ANSI', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-04: show $SRC_ID --raw --pager (PAGER=cat) → raw markdown, no ANSI', () => {
 			const rawFile = readFileSync(join(EXTRACTED_STORAGE_DIR, srcId, 'layout.md'), 'utf-8');
 			const result = runCli(['show', srcId, '--raw', '--pager'], {
 				env: { PAGER: 'cat' },
@@ -467,7 +436,7 @@ describe('Spec 49 — `mulder show` command', () => {
 		});
 
 		// ─── CLI-07: nonexistent UUID → exit 1, Source not found + UUID ───
-		it.skipIf(!isPgAvailable())('CLI-07: show <nonexistent-uuid> → exit 1, stderr "Source not found" + UUID', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-07: show <nonexistent-uuid> → exit 1, stderr "Source not found" + UUID', () => {
 			const result = runCli(['show', NONEXISTENT_UUID]);
 			expect(result.exitCode).toBe(1);
 			expect(result.stderr).toContain('Source not found');
@@ -475,7 +444,7 @@ describe('Spec 49 — `mulder show` command', () => {
 		});
 
 		// ─── CLI-08: ingested-but-not-extracted → exit 1, layout.md not found ───
-		it.skipIf(!isPgAvailable())(
+		it.skipIf(!db.isPgAvailable())(
 			'CLI-08: show $UNEXTRACTED_ID → exit 1, stderr "layout.md not found" + "mulder extract"',
 			() => {
 				const result = runCli(['show', unextractedId]);
@@ -486,7 +455,7 @@ describe('Spec 49 — `mulder show` command', () => {
 		);
 
 		// ─── CLI-09: run twice → byte-identical stdouts ───
-		it.skipIf(!isPgAvailable())('CLI-09: show $SRC_ID twice → both exit 0, byte-identical stdouts', () => {
+		it.skipIf(!db.isPgAvailable())('CLI-09: show $SRC_ID twice → both exit 0, byte-identical stdouts', () => {
 			const first = runCli(['show', srcId]);
 			const second = runCli(['show', srcId]);
 			expect(first.exitCode).toBe(0);

--- a/tests/specs/50_taxonomy_export_curate_merge.test.ts
+++ b/tests/specs/50_taxonomy_export_curate_merge.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 /**
@@ -10,20 +11,16 @@ import { ensureSchema } from '../lib/schema.js';
  *
  * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  */
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // Temporary file paths for test artifacts
 const TMP_DIR = resolve(ROOT, 'tmp-test-50');
@@ -42,37 +39,13 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
 		stderr: result.stderr ?? '',
 		exitCode: result.status ?? 1,
 	};
-}
-
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
 }
 
 /**
@@ -95,7 +68,7 @@ function seedTaxonomy(
 			? `ARRAY[${entry.aliases.map((a) => `'${a.replace(/'/g, "''")}'`).join(',')}]`
 			: 'ARRAY[]::text[]';
 		const categoryValue = entry.category ? `'${entry.category.replace(/'/g, "''")}'` : 'NULL';
-		runSql(
+		db.runSql(
 			`INSERT INTO taxonomy (id, canonical_name, entity_type, status, category, aliases) ` +
 				`VALUES ('${id}', '${entry.canonical_name.replace(/'/g, "''")}', '${entry.entity_type}', '${entry.status}', ${categoryValue}, ${aliasArray}) ` +
 				`ON CONFLICT (canonical_name, entity_type) DO UPDATE SET status = '${entry.status}', aliases = ${aliasArray}, category = ${categoryValue};`,
@@ -108,7 +81,7 @@ function seedTaxonomy(
 function cleanTestData(): void {
 	// Use TRUNCATE CASCADE for robustness against foreign key ordering issues
 	// when the database has leftover data from other test suites
-	runSql(
+	db.runSql(
 		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
 			'taxonomy, entities, stories, source_steps, ' +
 			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
@@ -136,7 +109,7 @@ function cleanupTmpFiles(): void {
  */
 function countTaxonomy(entityType?: string): number {
 	const where = entityType ? ` WHERE entity_type = '${entityType}'` : '';
-	return Number(runSql(`SELECT COUNT(*) FROM taxonomy${where};`));
+	return Number(db.runSql(`SELECT COUNT(*) FROM taxonomy${where};`));
 }
 
 /**
@@ -145,7 +118,7 @@ function countTaxonomy(entityType?: string): number {
 function getTaxonomyById(
 	id: string,
 ): { canonical_name: string; status: string; aliases: string; category: string | null } | null {
-	const row = runSql(`SELECT canonical_name, status, aliases, category FROM taxonomy WHERE id = '${id}';`);
+	const row = db.runSql(`SELECT canonical_name, status, aliases, category FROM taxonomy WHERE id = '${id}';`);
 	if (!row) return null;
 	const parts = row.split('|');
 	return {
@@ -167,7 +140,7 @@ let pgAvailable = false;
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (!pgAvailable) return;
 	ensureSchema();
 	cleanTestData();
@@ -339,7 +312,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 
 		// Create a YAML with the existing entry plus a new one (no id)
 		const yamlContent = `person:
-  - id: "${runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Existing Person';")}"
+  - id: "${db.runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Existing Person';")}"
     canonical: "Existing Person"
     status: auto
     aliases: []
@@ -357,7 +330,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		expect(exitCode, `Merge failed: ${stdout}\n${stderr}`).toBe(0);
 
 		// A new entry should be created
-		const newEntry = runSql(
+		const newEntry = db.runSql(
 			"SELECT canonical_name, status, aliases FROM taxonomy WHERE canonical_name = 'Brand New Person';",
 		);
 		expect(newEntry).toContain('Brand New Person');
@@ -520,7 +493,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 			{ canonical_name: 'Org Not In YAML', entity_type: 'organization', status: 'confirmed' },
 		]);
 
-		const personId = runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Person In YAML';");
+		const personId = db.runSql("SELECT id FROM taxonomy WHERE canonical_name = 'Person In YAML';");
 
 		// Create YAML that only contains person type
 		const yamlContent = `person:
@@ -563,7 +536,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		const inputPath = resolve(TMP_DIR, 'merge-dryrun.yaml');
 		writeFileSync(inputPath, yamlContent, 'utf-8');
 
-		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
 		expect(exitCode, `Dry-run failed: ${stderr}`).toBe(0);
 
 		const combined = stdout + stderr;
@@ -763,7 +736,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (CLI Test Matrix)', () => {
 		const inputPath = resolve(TMP_DIR, 'cli-dryrun.yaml');
 		writeFileSync(inputPath, yamlContent, 'utf-8');
 
-		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
+		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
 		expect(exitCode, `Dry-run failed: ${stderr}`).toBe(0);
 
 		// Database should not be modified

--- a/tests/specs/50_taxonomy_export_curate_merge.test.ts
+++ b/tests/specs/50_taxonomy_export_curate_merge.test.ts
@@ -536,7 +536,7 @@ describe('Spec 50 — Taxonomy Export/Curate/Merge (QA Contract)', () => {
 		const inputPath = resolve(TMP_DIR, 'merge-dryrun.yaml');
 		writeFileSync(inputPath, yamlContent, 'utf-8');
 
-		const { exitCode, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
+		const { exitCode, stdout, stderr } = runCli(['taxonomy', 'merge', '--input', inputPath, '--dry-run']);
 		expect(exitCode, `Dry-run failed: ${stderr}`).toBe(0);
 
 		const combined = stdout + stderr;

--- a/tests/specs/51_entity_management_cli.test.ts
+++ b/tests/specs/51_entity_management_cli.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 /**
@@ -9,20 +10,16 @@ import { ensureSchema } from '../lib/schema.js';
  *
  * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls and SQL
- * via `docker exec psql`.
+ * via `the shared env-driven SQL helper`.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  */
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,7 +34,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -46,35 +43,11 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 /**
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
 			'taxonomy, entities, stories, source_steps, ' +
 			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
@@ -101,7 +74,7 @@ function seedEntity(opts: {
 		opts.corroboration_score !== undefined && opts.corroboration_score !== null
 			? `${opts.corroboration_score}`
 			: 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, source_count, corroboration_score) ` +
 			`VALUES ('${id}', '${opts.name.replace(/'/g, "''")}', '${opts.type}', ${canonicalId}, '${taxonomyStatus}', ${sourceCount}, ${corroborationScore}) ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -115,7 +88,7 @@ function seedEntity(opts: {
 function seedAlias(opts: { id?: string; entity_id: string; alias: string; source?: string }): string {
 	const id = opts.id ?? randomUUID();
 	const source = opts.source ?? 'extraction';
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_aliases (id, entity_id, alias, source) ` +
 			`VALUES ('${id}', '${opts.entity_id}', '${opts.alias.replace(/'/g, "''")}', '${source}') ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -130,7 +103,7 @@ function seedSource(opts?: { id?: string; filename?: string }): string {
 	const id = opts?.id ?? randomUUID();
 	const filename = opts?.filename ?? 'test.pdf';
 	const fileHash = randomUUID(); // unique hash
-	runSql(
+	db.runSql(
 		`INSERT INTO sources (id, filename, storage_path, file_hash, status) ` +
 			`VALUES ('${id}', '${filename}', 'raw/${filename}', '${fileHash}', 'ingested') ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -144,7 +117,7 @@ function seedSource(opts?: { id?: string; filename?: string }): string {
 function seedStory(opts: { id?: string; source_id: string; title?: string }): string {
 	const id = opts.id ?? randomUUID();
 	const title = opts.title ?? 'Test Story';
-	runSql(
+	db.runSql(
 		`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri) ` +
 			`VALUES ('${id}', '${opts.source_id}', '${title.replace(/'/g, "''")}', 'gs://test/${id}.md', 'gs://test/${id}.meta.json') ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -156,7 +129,7 @@ function seedStory(opts: { id?: string; source_id: string; title?: string }): st
  * Link an entity to a story.
  */
 function seedStoryEntity(storyId: string, entityId: string): void {
-	runSql(
+	db.runSql(
 		`INSERT INTO story_entities (story_id, entity_id) ` +
 			`VALUES ('${storyId}', '${entityId}') ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -175,7 +148,7 @@ function seedEdge(opts: {
 }): string {
 	const id = opts.id ?? randomUUID();
 	const storyId = opts.story_id ? `'${opts.story_id}'` : 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, story_id) ` +
 			`VALUES ('${id}', '${opts.source_entity_id}', '${opts.target_entity_id}', '${opts.relationship}', ${storyId}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -213,7 +186,7 @@ let mergeJsonSourceId: string;
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (!pgAvailable) return;
 	ensureSchema();
 	cleanTestData();
@@ -392,25 +365,25 @@ describe('QA Contract: Entity Management CLI', () => {
 		expect(exitCode).toBe(0);
 
 		// Verify source entity now has canonical_id = target
-		const canonicalId = runSql(`SELECT canonical_id FROM entities WHERE id = '${mergeSourceId}';`);
+		const canonicalId = db.runSql(`SELECT canonical_id FROM entities WHERE id = '${mergeSourceId}';`);
 		expect(canonicalId).toBe(mergeTargetId);
 
 		// Verify source entity has taxonomy_status = 'merged'
-		const taxonomyStatus = runSql(`SELECT taxonomy_status FROM entities WHERE id = '${mergeSourceId}';`);
+		const taxonomyStatus = db.runSql(`SELECT taxonomy_status FROM entities WHERE id = '${mergeSourceId}';`);
 		expect(taxonomyStatus).toBe('merged');
 
 		// Verify story_entities were reassigned to target
-		const storyEntityCount = runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${mergeTargetId}';`);
+		const storyEntityCount = db.runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = '${mergeTargetId}';`);
 		expect(Number(storyEntityCount)).toBeGreaterThanOrEqual(1);
 
 		// Verify source name is now an alias on target
-		const mergeAlias = runSql(
+		const mergeAlias = db.runSql(
 			`SELECT COUNT(*) FROM entity_aliases WHERE entity_id = '${mergeTargetId}' AND alias = 'Source Entity';`,
 		);
 		expect(Number(mergeAlias)).toBe(1);
 
 		// Verify edges were reassigned (source's edges now point to/from target)
-		const targetEdges = runSql(
+		const targetEdges = db.runSql(
 			`SELECT COUNT(*) FROM entity_edges WHERE source_entity_id = '${mergeTargetId}' OR target_entity_id = '${mergeTargetId}';`,
 		);
 		expect(Number(targetEdges)).toBeGreaterThanOrEqual(1);
@@ -463,7 +436,7 @@ describe('QA Contract: Entity Management CLI', () => {
 		expect(exitCode).toBe(0);
 
 		// Verify alias was created with source 'manual'
-		const aliasSource = runSql(
+		const aliasSource = db.runSql(
 			`SELECT source FROM entity_aliases WHERE entity_id = '${aliasEntityId}' AND alias = 'New Test Alias';`,
 		);
 		expect(aliasSource).toBe('manual');
@@ -476,7 +449,7 @@ describe('QA Contract: Entity Management CLI', () => {
 		expect(exitCode).toBe(0);
 
 		// Verify alias was deleted
-		const count = runSql(`SELECT COUNT(*) FROM entity_aliases WHERE id = '${aliasId2}';`);
+		const count = db.runSql(`SELECT COUNT(*) FROM entity_aliases WHERE id = '${aliasId2}';`);
 		expect(Number(count)).toBe(0);
 	});
 

--- a/tests/specs/52_status_overview.test.ts
+++ b/tests/specs/52_status_overview.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 /**
@@ -9,20 +10,16 @@ import { ensureSchema } from '../lib/schema.js';
  *
  * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls and SQL
- * via `docker exec psql`.
+ * via `the shared env-driven SQL helper`.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  */
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,7 +34,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -46,35 +43,11 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 /**
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
 			'taxonomy, entities, stories, source_steps, ' +
 			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
@@ -90,7 +63,7 @@ function seedSource(opts?: { id?: string; filename?: string; status?: string }):
 	const filename = opts?.filename ?? 'test.pdf';
 	const fileHash = randomUUID();
 	const status = opts?.status ?? 'ingested';
-	runSql(
+	db.runSql(
 		`INSERT INTO sources (id, filename, storage_path, file_hash, status) ` +
 			`VALUES ('${id}', '${filename}', 'raw/${filename}', '${fileHash}', '${status}') ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -102,7 +75,7 @@ function seedStory(opts: { id?: string; source_id: string; title?: string; statu
 	const id = opts.id ?? randomUUID();
 	const title = opts.title ?? 'Test Story';
 	const status = opts.status ?? 'segmented';
-	runSql(
+	db.runSql(
 		`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status) ` +
 			`VALUES ('${id}', '${opts.source_id}', '${title.replace(/'/g, "''")}', 'gs://test/${id}.md', 'gs://test/${id}.meta.json', '${status}') ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -122,7 +95,7 @@ function seedEntity(opts: {
 	const canonicalId = opts.canonical_id !== undefined && opts.canonical_id !== null ? `'${opts.canonical_id}'` : 'NULL';
 	const taxonomyStatus = opts.taxonomy_status ?? 'auto';
 	const sourceCount = opts.source_count ?? 0;
-	runSql(
+	db.runSql(
 		`INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, source_count) ` +
 			`VALUES ('${id}', '${opts.name.replace(/'/g, "''")}', '${opts.type}', ${canonicalId}, '${taxonomyStatus}', ${sourceCount}) ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -139,7 +112,7 @@ function seedEdge(opts: {
 }): string {
 	const id = opts.id ?? randomUUID();
 	const storyId = opts.story_id ? `'${opts.story_id}'` : 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, story_id) ` +
 			`VALUES ('${id}', '${opts.source_entity_id}', '${opts.target_entity_id}', '${opts.relationship}', ${storyId}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -149,7 +122,7 @@ function seedEdge(opts: {
 
 function seedChunk(opts: { id?: string; story_id: string; content: string; chunk_index: number }): string {
 	const id = opts.id ?? randomUUID();
-	runSql(
+	db.runSql(
 		`INSERT INTO chunks (id, story_id, content, chunk_index) ` +
 			`VALUES ('${id}', '${opts.story_id}', '${opts.content.replace(/'/g, "''")}', ${opts.chunk_index}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -160,7 +133,7 @@ function seedChunk(opts: { id?: string; story_id: string; content: string; chunk
 function seedTaxonomy(opts: { id?: string; canonical_name: string; entity_type: string; status?: string }): string {
 	const id = opts.id ?? randomUUID();
 	const status = opts.status ?? 'auto';
-	runSql(
+	db.runSql(
 		`INSERT INTO taxonomy (id, canonical_name, entity_type, status) ` +
 			`VALUES ('${id}', '${opts.canonical_name.replace(/'/g, "''")}', '${opts.entity_type}', '${status}') ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -178,7 +151,7 @@ function seedSourceStep(opts: {
 		opts.error_message !== undefined && opts.error_message !== null
 			? `'${opts.error_message.replace(/'/g, "''")}'`
 			: 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO source_steps (source_id, step_name, status, error_message) ` +
 			`VALUES ('${opts.source_id}', '${opts.step_name}', '${opts.status}', ${errorMsg}) ` +
 			`ON CONFLICT (source_id, step_name) DO UPDATE SET status = '${opts.status}', error_message = ${errorMsg};`,
@@ -194,7 +167,7 @@ function seedPipelineRun(opts?: { id?: string; status?: string; finished_at?: st
 			: status === 'completed'
 				? 'now()'
 				: 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO pipeline_runs (id, status, finished_at) ` +
 			`VALUES ('${id}', '${status}', ${finishedAt}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -229,7 +202,7 @@ let pipelineRunId: string;
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (!pgAvailable) return;
 	ensureSchema();
 	cleanTestData();
@@ -366,7 +339,7 @@ describe('QA Contract: Status Overview CLI', () => {
 	it('QA-06: --failed with no failures', () => {
 		if (!pgAvailable) return;
 		// Remove failed source_steps
-		runSql(`DELETE FROM source_steps WHERE status = 'failed';`);
+		db.runSql(`DELETE FROM source_steps WHERE status = 'failed';`);
 		try {
 			const { stdout, exitCode } = runCli(['status', '--failed']);
 			expect(exitCode).toBe(0);

--- a/tests/specs/53_export_commands.test.ts
+++ b/tests/specs/53_export_commands.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 /**
@@ -9,20 +10,16 @@ import { ensureSchema } from '../lib/schema.js';
  *
  * Each `it()` maps to one QA-NN or CLI-NN condition from Section 5/5b of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls and SQL
- * via `docker exec psql`.
+ * via `the shared env-driven SQL helper`.
  * Never imports from packages/ or src/ or apps/.
  *
  * Requires:
- * - Running PostgreSQL container `mulder-pg-test` with migrations applied
+ * - PostgreSQL reachable through the standard PG env vars with migrations applied
  * - Built CLI at apps/cli/dist/index.js
  */
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,7 +34,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, MULDER_LOG_LEVEL: 'silent', ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -46,35 +43,11 @@ function runCli(
 	};
 }
 
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 /**
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	runSql(
+	db.runSql(
 		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
 			'taxonomy, entities, stories, source_steps, ' +
 			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
@@ -90,7 +63,7 @@ function seedSource(opts?: { id?: string; filename?: string; status?: string }):
 	const filename = opts?.filename ?? 'test.pdf';
 	const fileHash = randomUUID();
 	const status = opts?.status ?? 'ingested';
-	runSql(
+	db.runSql(
 		`INSERT INTO sources (id, filename, storage_path, file_hash, status) ` +
 			`VALUES ('${id}', '${filename}', 'raw/${filename}', '${fileHash}', '${status}') ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -120,7 +93,7 @@ function seedStory(opts: {
 		opts.extraction_confidence !== undefined && opts.extraction_confidence !== null
 			? opts.extraction_confidence
 			: 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status, language, category, page_start, page_end, extraction_confidence) ` +
 			`VALUES ('${id}', '${opts.source_id}', '${title.replace(/'/g, "''")}', 'gs://test/${id}.md', 'gs://test/${id}.meta.json', '${status}', ${language}, ${category}, ${pageStart}, ${pageEnd}, ${extractionConfidence}) ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -143,7 +116,7 @@ function seedEntity(opts: {
 	const sourceCount = opts.source_count ?? 0;
 	const corroborationScore =
 		opts.corroboration_score !== undefined && opts.corroboration_score !== null ? opts.corroboration_score : 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, source_count, corroboration_score) ` +
 			`VALUES ('${id}', '${opts.name.replace(/'/g, "''")}', '${opts.type}', ${canonicalId}, '${taxonomyStatus}', ${sourceCount}, ${corroborationScore}) ` +
 			`ON CONFLICT (id) DO NOTHING;`,
@@ -164,7 +137,7 @@ function seedEdge(opts: {
 	const storyId = opts.story_id ? `'${opts.story_id}'` : 'NULL';
 	const edgeType = opts.edge_type ?? 'RELATIONSHIP';
 	const confidence = opts.confidence !== undefined && opts.confidence !== null ? opts.confidence : 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, story_id, edge_type, confidence) ` +
 			`VALUES ('${id}', '${opts.source_entity_id}', '${opts.target_entity_id}', '${opts.relationship}', ${storyId}, '${edgeType}', ${confidence}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -174,7 +147,7 @@ function seedEdge(opts: {
 
 function seedChunk(opts: { id?: string; story_id: string; content: string; chunk_index: number }): string {
 	const id = opts.id ?? randomUUID();
-	runSql(
+	db.runSql(
 		`INSERT INTO chunks (id, story_id, content, chunk_index) ` +
 			`VALUES ('${id}', '${opts.story_id}', '${opts.content.replace(/'/g, "''")}', ${opts.chunk_index}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -185,7 +158,7 @@ function seedChunk(opts: { id?: string; story_id: string; content: string; chunk
 function seedAlias(opts: { id?: string; entity_id: string; alias: string; source?: string }): string {
 	const id = opts.id ?? randomUUID();
 	const source = opts.source ? `'${opts.source}'` : 'NULL';
-	runSql(
+	db.runSql(
 		`INSERT INTO entity_aliases (id, entity_id, alias, source) ` +
 			`VALUES ('${id}', '${opts.entity_id}', '${opts.alias.replace(/'/g, "''")}', ${source}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -195,7 +168,7 @@ function seedAlias(opts: { id?: string; entity_id: string; alias: string; source
 
 function seedStoryEntity(opts: { story_id: string; entity_id: string; mention_count?: number }): void {
 	const mentionCount = opts.mention_count ?? 1;
-	runSql(
+	db.runSql(
 		`INSERT INTO story_entities (story_id, entity_id, mention_count) ` +
 			`VALUES ('${opts.story_id}', '${opts.entity_id}', ${mentionCount}) ` +
 			`ON CONFLICT DO NOTHING;`,
@@ -227,7 +200,7 @@ let edgeContradiction: string;
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-	pgAvailable = isPgAvailable();
+	pgAvailable = db.isPgAvailable();
 	if (!pgAvailable) return;
 	ensureSchema();
 	cleanTestData();

--- a/tests/specs/54_v2_schema_migrations.test.ts
+++ b/tests/specs/54_v2_schema_migrations.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
 import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -12,16 +13,13 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
  *
  * Each `it()` maps to one QA condition from Section 5 of the spec.
  * Tests interact through system boundaries only: CLI subprocess calls,
- * SQL via `docker exec psql`, and filesystem.
+ * SQL via `the shared env-driven SQL helper`, and filesystem.
  * Never import from packages/ or src/ or apps/.
  *
- * Requires a running PostgreSQL instance (Docker container `mulder-pg-test`)
+ * Requires a running PostgreSQL instance (the standard PG env vars)
  * with pgvector, PostGIS, and pg_trgm extensions available.
  */
 
-const PG_CONTAINER = 'mulder-pg-test';
-const PG_USER = 'mulder';
-const PG_PASSWORD = 'mulder';
 const MIGRATIONS_009_011 = ['009_entity_grounding.sql', '010_evidence_chains.sql', '011_spatio_temporal_clusters.sql'];
 
 /**
@@ -36,7 +34,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 30_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -46,35 +44,13 @@ function runCli(
 }
 
 /**
- * Helper: run SQL via docker exec psql. Returns query output.
+ * Helper: run SQL via the shared env-driven SQL helper. Returns query output.
  */
-function runSql(sql: string): string {
-	const result = spawnSync(
-		'docker',
-		['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-t', '-A', '-c', sql],
-		{ encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] },
-	);
-	if (result.status !== 0) {
-		throw new Error(`psql failed (exit ${result.status}): ${result.stderr}`);
-	}
-	return (result.stdout ?? '').trim();
-}
-
-function isPgAvailable(): boolean {
-	try {
-		const result = spawnSync('docker', ['exec', PG_CONTAINER, 'pg_isready', '-U', PG_USER], {
-			encoding: 'utf-8',
-			timeout: 5_000,
-		});
-		return result.status === 0;
-	} catch {
-		return false;
-	}
-}
-
 function hasRequiredExtensions(): boolean {
 	try {
-		const out = runSql("SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');");
+		const out = db.runSql(
+			"SELECT count(*) FROM pg_available_extensions WHERE name IN ('vector', 'postgis', 'pg_trgm');",
+		);
 		return Number.parseInt(out, 10) >= 3;
 	} catch {
 		return false;
@@ -108,19 +84,16 @@ function resetDatabase(): void {
 		'DROP EXTENSION IF EXISTS pg_trgm CASCADE',
 	].join('; ');
 
-	spawnSync('docker', ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', 'mulder', '-c', dropSql], {
-		encoding: 'utf-8',
-		timeout: 15_000,
-	});
+	db.runSql(dropSql);
 }
 
 function migrationFilenames(): string[] {
-	const rows = runSql('SELECT filename FROM mulder_migrations ORDER BY filename;');
+	const rows = db.runSql('SELECT filename FROM mulder_migrations ORDER BY filename;');
 	return rows.split('\n').filter(Boolean);
 }
 
 function migrationCount(): number {
-	return Number.parseInt(runSql('SELECT count(*) FROM mulder_migrations;'), 10);
+	return Number.parseInt(db.runSql('SELECT count(*) FROM mulder_migrations;'), 10);
 }
 
 function parseMigrationSummary(output: string): { applied?: number; skipped?: number; total?: number } | null {
@@ -145,7 +118,7 @@ function prepareBackfilledDatabase(): void {
 		'DROP INDEX IF EXISTS idx_entities_geom',
 	].join('; ');
 
-	runSql(cleanupSql);
+	db.runSql(cleanupSql);
 }
 
 describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
@@ -153,14 +126,9 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 	let extensionsAvailable: boolean;
 
 	beforeAll(() => {
-		pgAvailable = isPgAvailable();
+		pgAvailable = db.isPgAvailable();
 		if (!pgAvailable) {
-			console.warn(
-				'SKIP: PostgreSQL container not available. Start with:\n' +
-					'  docker run -d --name mulder-pg-test -e POSTGRES_USER=mulder ' +
-					'-e POSTGRES_PASSWORD=mulder -e POSTGRES_DB=mulder -p 5432:5432 pgvector/pgvector:pg17\n' +
-					'  docker exec mulder-pg-test apt-get update && docker exec mulder-pg-test apt-get install -y postgresql-17-postgis-3',
-			);
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 			return;
 		}
 
@@ -251,7 +219,7 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 		it('entity_grounding has the expected columns and cascades on entity deletion', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'entity_grounding' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -261,7 +229,7 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 				expect(colList, `Missing column: ${col}`).toContain(col);
 			}
 
-			const fkDeleteRule = runSql(
+			const fkDeleteRule = db.runSql(
 				"SELECT rc.delete_rule FROM information_schema.table_constraints tc JOIN information_schema.referential_constraints rc ON tc.constraint_name = rc.constraint_name AND tc.constraint_schema = rc.constraint_schema WHERE tc.table_name = 'entity_grounding' AND tc.constraint_type = 'FOREIGN KEY';",
 			);
 			expect(fkDeleteRule).toContain('CASCADE');
@@ -269,16 +237,16 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 			const entityId = '00000000-0000-0000-0000-000000540301';
 			const groundingId = '00000000-0000-0000-0000-000000540302';
 
-			runSql(
+			db.runSql(
 				[
 					`INSERT INTO entities (id, name, type) VALUES ('${entityId}', 'QA Grounding Entity', 'person')`,
 					`INSERT INTO entity_grounding (id, entity_id, grounding_data, source_urls, expires_at) VALUES ('${groundingId}', '${entityId}', '{"title":"Grounded"}'::jsonb, ARRAY['https://example.com/a'], now() + interval '1 day')`,
 				].join('; '),
 			);
 
-			expect(runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('1');
-			runSql(`DELETE FROM entities WHERE id = '${entityId}';`);
-			expect(runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('0');
+			expect(db.runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('1');
+			db.runSql(`DELETE FROM entities WHERE id = '${entityId}';`);
+			expect(db.runSql(`SELECT count(*) FROM entity_grounding WHERE id = '${groundingId}';`)).toBe('0');
 		});
 	});
 
@@ -286,7 +254,7 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 		it('evidence_chains matches the expected types and defaults', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'evidence_chains' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -295,27 +263,27 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 				expect(colList, `Missing column: ${col}`).toContain(col);
 			}
 
-			const thesisType = runSql(
+			const thesisType = db.runSql(
 				"SELECT data_type FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'thesis';",
 			);
 			expect(thesisType).toBe('text');
 
-			const pathType = runSql(
+			const pathType = db.runSql(
 				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'evidence_chains'::regclass AND a.attname = 'path';",
 			);
 			expect(pathType).toBe('uuid[]');
 
-			const strengthType = runSql(
+			const strengthType = db.runSql(
 				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'evidence_chains'::regclass AND a.attname = 'strength';",
 			);
 			expect(strengthType).toBe('double precision');
 
-			const supportsType = runSql(
+			const supportsType = db.runSql(
 				"SELECT data_type FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'supports';",
 			);
 			expect(supportsType).toBe('boolean');
 
-			const computedDefault = runSql(
+			const computedDefault = db.runSql(
 				"SELECT column_default FROM information_schema.columns WHERE table_name = 'evidence_chains' AND column_name = 'computed_at';",
 			);
 			expect(computedDefault.toLowerCase()).toMatch(/now\(\)|current_timestamp/);
@@ -326,7 +294,7 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 		it('spatio_temporal_clusters, entities.geom, and idx_entities_geom match the contract', () => {
 			if (skipIfUnavailable()) return;
 
-			const columns = runSql(
+			const columns = db.runSql(
 				"SELECT column_name FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND table_schema = 'public' ORDER BY ordinal_position;",
 			);
 			const colList = columns.split('\n').filter(Boolean);
@@ -345,27 +313,29 @@ describe('Spec 54: v2.0 Schema Migrations (009-011)', () => {
 				expect(colList, `Missing column: ${col}`).toContain(col);
 			}
 
-			const eventCountType = runSql(
+			const eventCountType = db.runSql(
 				"SELECT data_type FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND column_name = 'event_count';",
 			);
 			expect(eventCountType).toBe('integer');
 
-			const eventIdsType = runSql(
+			const eventIdsType = db.runSql(
 				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'spatio_temporal_clusters'::regclass AND a.attname = 'event_ids';",
 			);
 			expect(eventIdsType).toBe('uuid[]');
 
-			const computedDefault = runSql(
+			const computedDefault = db.runSql(
 				"SELECT column_default FROM information_schema.columns WHERE table_name = 'spatio_temporal_clusters' AND column_name = 'computed_at';",
 			);
 			expect(computedDefault.toLowerCase()).toMatch(/now\(\)|current_timestamp/);
 
-			const geomType = runSql(
-				"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'entities'::regclass AND a.attname = 'geom';",
-			).replace(/\s+/g, '');
+			const geomType = db
+				.runSql(
+					"SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a WHERE a.attrelid = 'entities'::regclass AND a.attname = 'geom';",
+				)
+				.replace(/\s+/g, '');
 			expect(geomType).toBe('geometry(Point,4326)');
 
-			const geomIndex = runSql(
+			const geomIndex = db.runSql(
 				"SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_entities_geom';",
 			);
 			expect(geomIndex.toLowerCase()).toContain('using gist');


### PR DESCRIPTION
## Summary

Replace the DB test harness used by Mulder's black-box spec suites with a shared env-driven PostgreSQL path. The test files no longer depend on `docker exec` or the hardcoded `mulder-pg-test` container name, so local runs and CI now exercise the same database access path.

Closes #141
Implements:
- `docs/specs/55_portable_db_test_harness_foundation.spec.md`
- `docs/specs/56_portable_db_harness_core_pipeline_suites.spec.md`
- `docs/specs/57_portable_db_harness_retrieval_cli_suites.spec.md`

Follow-up:
- #144 — spec 33 schema/type mismatch (`entities.geom`) newly surfaced once the harness stopped skipping

## Changes

- add `tests/lib/db.ts` and `tests/lib/db-runner.mjs` as the shared env-driven SQL/readiness harness
- align `tests/lib/schema.ts` with the same PG env contract
- migrate DB-backed spec suites and `tests/cli-smoke.test.ts` off suite-local `docker exec` helpers
- update the migration-heavy reset helpers so they can reset the current schema set before rerunning `db migrate`
- normalize suite messaging around `PGHOST` / `PGPORT` instead of a fixed Docker container name

## Verification

- `pnpm exec biome check tests/cli-smoke.test.ts tests/lib tests/specs docs/specs/55_portable_db_test_harness_foundation.spec.md docs/specs/56_portable_db_harness_core_pipeline_suites.spec.md docs/specs/57_portable_db_harness_retrieval_cli_suites.spec.md`
- `pnpm exec vitest tests/cli-smoke.test.ts tests/specs/07_database_client_migration_runner.test.ts tests/specs/22_story_repository.test.ts tests/specs/37_vector_search_retrieval.test.ts tests/specs/54_v2_schema_migrations.test.ts --run`
- `pnpm exec vitest tests/specs/33_qa_schema_conformance.test.ts --run` (fails on existing `entities.geom` schema/type mismatch; tracked in #144)