### PR TITLE
[Test Infra] Hermetic DB state, GCP lane, and E2E health signal

### DIFF
--- a/.github/workflows/gcp-tests.yml
+++ b/.github/workflows/gcp-tests.yml
@@ -1,53 +1,14 @@
-name: CI
+name: GCP Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 0"
 
 jobs:
-  lint:
+  gcp-black-box:
+    if: ${{ secrets.GCP_CREDENTIALS_JSON != '' && secrets.MULDER_GCP_CONFIG_YAML != '' }}
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Biome lint
-        run: pnpm lint
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -73,6 +34,12 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
       - run: pnpm install --frozen-lockfile
 
       - name: Build packages
@@ -89,44 +56,19 @@ jobs:
           PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
           PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
-      - name: Setup test config
-        run: cp mulder.config.example.yaml mulder.config.yaml
+      - name: Write GCP test config
+        run: |
+          cat <<'EOF' > mulder.config.yaml
+          ${{ secrets.MULDER_GCP_CONFIG_YAML }}
+          EOF
 
-      - name: Run E2E health check (Spec 44)
-        run: pnpm test:health
+      - name: Run GCP black-box lane
+        run: pnpm test:gcp
         env:
           NODE_ENV: test
+          MULDER_TEST_GCP: "true"
           PGHOST: localhost
           PGPORT: "5432"
           PGUSER: mulder
           PGPASSWORD: mulder
           PGDATABASE: mulder
-
-      - name: Run tests
-        run: pnpm test
-        env:
-          NODE_ENV: test
-          PGHOST: localhost
-          PGPORT: "5432"
-          PGUSER: mulder
-          PGPASSWORD: mulder
-          PGDATABASE: mulder
-
-  demo:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: demo/package-lock.json
-
-      - run: npm ci
-
-      - name: Build demo
-        run: npm run build

--- a/docs/specs/59_hermetic_test_infrastructure.spec.md
+++ b/docs/specs/59_hermetic_test_infrastructure.spec.md
@@ -1,0 +1,113 @@
+---
+spec: "59"
+title: "Hermetic Test Infrastructure: DB State, GCP Lane, and E2E Health Signal"
+roadmap_step: ""
+functional_spec: []
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/143"
+created: 2026-04-12
+---
+
+# Spec 59: Hermetic Test Infrastructure: DB State, GCP Lane, and E2E Health Signal
+
+## 1. Objective
+
+Close the remaining test-infrastructure gaps tracked by Issue `#143` after the env-driven DB harness (`#141`) and CLI artifact freshness guard (`#142`) landed. The suite must stop depending on prior spec teardown state, credential-dependent tests must move behind one explicit opt-in switch, and Spec 44 must become a named CI health signal rather than just one test buried inside the full run.
+
+## 2. Boundaries
+
+- **Roadmap Step:** N/A — off-roadmap test-infrastructure follow-up tracked by Issue `#143`
+- **Target:** `tests/lib/schema.ts`, selected DB-backed spec suites, `tests/specs/20_fixture_generator.test.ts`, `tests/specs/44_e2e_pipeline_integration.test.ts`, `tests/specs/47_document_ai_extraction.test.ts`, `package.json`, and GitHub Actions workflows under `.github/workflows/`
+- **In scope:** defensive DB cleanup helpers, the missing per-suite schema bootstrap needed for independent execution, consistent `MULDER_TEST_GCP` opt-in handling for real-GCP tests, and explicit CI wiring for a deterministic default lane plus a manual/scheduled GCP lane
+- **Out of scope:** product runtime behavior under `packages/` or `apps/`, broader test-suite parallelization, or new roadmap work beyond the issue acceptance criteria
+- **Constraints:** keep test coverage black-box, preserve the built CLI boundary, do not silently skip genuine failures behind readiness heuristics, and keep the default CI lane credential-free and deterministic
+
+## 3. Dependencies
+
+- **Requires:** Spec 55 (shared env-driven DB harness), Spec 57 (Spec 44 on the shared harness), and Spec 58 (fresh CLI artifacts before black-box tests)
+- **Blocks:** closure of Issue `#143` and future attempts to parallelize or promote the suite as a trustworthy CI signal
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`tests/lib/schema.ts`** — extend the shared schema helper with defensive cleanup primitives that can truncate only existing Mulder tables and keep DB-backed suites hermetic when run in isolation
+2. **`tests/specs/25_edge_repository.test.ts`** — add the missing schema bootstrap so the suite no longer depends on a prior spec having already migrated the database
+3. **`tests/specs/50_taxonomy_export_curate_merge.test.ts`**, **`51_entity_management_cli.test.ts`**, **`52_status_overview.test.ts`**, **`53_export_commands.test.ts`** — replace raw `TRUNCATE TABLE ...` cleanup with the shared defensive helper so missing-schema runs fail less opaquely
+4. **`tests/specs/44_e2e_pipeline_integration.test.ts`** — reuse the shared schema bootstrap instead of carrying a local duplicate and keep the suite aligned with the named CI health-lane contract
+5. **`tests/specs/20_fixture_generator.test.ts`** — split deterministic fixture-generator checks from real-GCP checks and gate the credential-dependent cases behind `MULDER_TEST_GCP=true`
+6. **`tests/specs/47_document_ai_extraction.test.ts`** — normalize the real-GCP gate to `MULDER_TEST_GCP=true` while preserving compatibility with the legacy env name during transition
+7. **`package.json`** — add dedicated test scripts for the Spec 44 health lane and the opt-in GCP lane
+8. **`.github/workflows/ci.yml`** — run the Spec 44 health check as an explicit CI step before the broader test suite
+9. **`.github/workflows/gcp-tests.yml`** — add a separate manual/scheduled workflow for credentialed GCP black-box tests
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None in repository config files. CI/workflow env changes only:
+
+- `MULDER_TEST_GCP=true` becomes the canonical opt-in for credential-dependent tests
+- Legacy `MULDER_E2E_GCP=true` remains temporarily supported in the spec 47 test to avoid breaking local callers during the transition
+
+### 4.4 Integration Points
+
+- DB-backed suites share one defensive cleanup path from `tests/lib/schema.ts`
+- Spec 44 becomes a named, first-class CI health indicator via a dedicated script and workflow step
+- Credentialed test workflows run separately from the default CI lane and enable the GCP-gated suites with one env variable
+
+### 4.5 Implementation Phases
+
+**Phase 1: Hermetic DB setup and cleanup**
+- extend `tests/lib/schema.ts` with defensive truncation helpers
+- wire the helper into suites that currently assume the schema already exists
+- add the missing schema bootstrap in the edge repository suite
+
+**Phase 2: Credentialed test lane split**
+- gate real-GCP fixture/document-AI tests behind `MULDER_TEST_GCP=true`
+- keep the default lane deterministic and free of credential-absence assertions
+
+**Phase 3: CI health and opt-in workflow wiring**
+- add package scripts for the Spec 44 health lane and GCP lane
+- update `ci.yml` to run Spec 44 explicitly
+- add a separate manual/scheduled workflow for the real-GCP suites
+
+## 5. QA Contract
+
+1. **QA-01: Defensive cleanup works when the schema is missing**
+   - Given: PostgreSQL is reachable but Mulder tables may not exist yet
+   - When: a DB-backed suite uses the shared cleanup helper before or after setup
+   - Then: cleanup succeeds without `relation does not exist` failures and without requiring another suite to have migrated first
+
+2. **QA-02: Edge repository suite is independently runnable**
+   - Given: a clean PostgreSQL database with no Mulder schema
+   - When: `vitest` runs `tests/specs/25_edge_repository.test.ts` by itself
+   - Then: the suite bootstraps the schema, seeds its own fixtures, and does not rely on any prior spec execution order
+
+3. **QA-03: Default black-box lane is credential-free**
+   - Given: `MULDER_TEST_GCP` is unset
+   - When: the fixture-generator and Document AI black-box suites run
+   - Then: only deterministic non-GCP checks execute, credential-dependent checks are explicitly skipped, and no assertion depends on “missing credentials” behavior
+
+4. **QA-04: Real-GCP tests share one opt-in switch**
+   - Given: `MULDER_TEST_GCP=true` plus valid GCP credentials and config
+   - When: the GCP black-box lane runs
+   - Then: the credential-dependent cases in the fixture-generator and Document AI suites execute under the same env gate
+
+5. **QA-05: Spec 44 is a named CI health signal**
+   - Given: the default GitHub Actions CI workflow for pull requests
+   - When: the test job reaches the verification phase
+   - Then: Spec 44 runs as an explicit health-check step before the broader suite, and a separate workflow exists for manual/scheduled GCP tests
+
+## 5b. CLI Test Matrix
+
+N/A — no user-facing CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+- **Services called:** optional real-GCP verification uses Document AI and any fixture-generator GCP calls already covered by existing specs
+- **Estimated cost per run:** unchanged from the existing GCP-gated specs; default CI remains zero-cost
+- **Dev mode alternative:** the default CI lane and local default `pnpm test` path remain credential-free
+- **Safety flags:** real-GCP tests execute only when `MULDER_TEST_GCP=true` inside the dedicated workflow or an intentional local run

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"typecheck": "turbo run typecheck",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
+		"test:health": "vitest run tests/specs/44_e2e_pipeline_integration.test.ts",
+		"test:gcp": "vitest run tests/specs/20_fixture_generator.test.ts tests/specs/47_document_ai_extraction.test.ts",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/tests/lib/schema.ts
+++ b/tests/lib/schema.ts
@@ -19,11 +19,29 @@
 
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { TEST_PG_ENV } from './db.js';
+import { runSql, TEST_PG_ENV } from './db.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+export const MULDER_TEST_TABLES = [
+	'chunks',
+	'story_entities',
+	'entity_edges',
+	'entity_aliases',
+	'taxonomy',
+	'entities',
+	'stories',
+	'entity_grounding',
+	'evidence_chains',
+	'spatio_temporal_clusters',
+	'pipeline_run_sources',
+	'pipeline_runs',
+	'jobs',
+	'source_steps',
+	'sources',
+] as const;
 
 /**
  * Run `mulder db migrate` against the example config and throw if migrations
@@ -44,4 +62,43 @@ export function ensureSchema(): void {
 				`stderr: ${result.stderr ?? ''}`,
 		);
 	}
+}
+
+function quoteSqlLiteral(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quoteSqlIdentifier(identifier: string): string {
+	if (!/^[a-z_][a-z0-9_]*$/i.test(identifier)) {
+		throw new Error(`Unsupported SQL identifier for test cleanup: ${identifier}`);
+	}
+	return `"${identifier}"`;
+}
+
+export function truncateExistingTables(tables: readonly string[]): void {
+	if (tables.length === 0) {
+		return;
+	}
+
+	const requestedTables = [...new Set(tables)];
+	const existingRows = runSql(
+		[
+			'SELECT tablename',
+			'FROM pg_tables',
+			"WHERE schemaname = 'public'",
+			`  AND tablename IN (${requestedTables.map(quoteSqlLiteral).join(', ')})`,
+			'ORDER BY tablename;',
+		].join('\n'),
+	);
+	const existingTables = existingRows.split('\n').filter(Boolean);
+
+	if (existingTables.length === 0) {
+		return;
+	}
+
+	runSql(`TRUNCATE TABLE ${existingTables.map(quoteSqlIdentifier).join(', ')} CASCADE;`);
+}
+
+export function truncateMulderTables(): void {
+	truncateExistingTables(MULDER_TEST_TABLES);
 }

--- a/tests/specs/20_fixture_generator.test.ts
+++ b/tests/specs/20_fixture_generator.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const FIXTURE_RAW_DIR = resolve(ROOT, 'fixtures/raw');
+const GCP_TESTS_ENABLED = process.env.MULDER_TEST_GCP === 'true' || process.env.MULDER_E2E_GCP === 'true';
 
 /**
  * Black-box QA tests for Spec 20: Fixture Generator
@@ -14,9 +15,8 @@ const FIXTURE_RAW_DIR = resolve(ROOT, 'fixtures/raw');
  * Tests interact through system boundaries only: CLI subprocess calls
  * and filesystem inspection. Never imports from packages/ or src/ or apps/.
  *
- * Note: The fixture generator requires real GCP credentials for `generate`.
- * Tests that need GCP are designed to verify orchestration logic
- * (discovery, skip, force, status) without requiring successful Document AI calls.
+ * Default runs stay credential-free. Real-GCP generation checks are gated
+ * behind `MULDER_TEST_GCP=true` so they can run in a separate opt-in lane.
  */
 
 // ---------------------------------------------------------------------------
@@ -141,35 +141,32 @@ describe('Spec 20 — Fixture Generator', () => {
 
 	// ─── QA-02: Generate with defaults ───
 
-	it('QA-02: `mulder fixtures generate` discovers PDFs and attempts processing', () => {
-		// Use a temp directory so pre-existing extracted fixtures (e.g. from eval golden sets)
-		// in the shared fixtures/extracted/ directory don't cause PDFs to be skipped.
-		const { rel, abs } = createTmpFixtureDir('generate');
-		trackTmpDir(abs);
+	it.skipIf(!GCP_TESTS_ENABLED)(
+		'QA-02: `mulder fixtures generate` generates extracted fixtures for discovered PDFs',
+		() => {
+			// Use a temp directory so pre-existing extracted fixtures (e.g. from eval golden sets)
+			// in the shared fixtures/extracted/ directory don't cause PDFs to be skipped.
+			const { rel, abs } = createTmpFixtureDir('generate');
+			trackTmpDir(abs);
 
-		// Add both real test PDFs
-		addTestPdf(abs, 'native-text-sample.pdf');
-		addTestPdf(abs, 'scanned-sample.pdf');
+			// Add both real test PDFs
+			const nativeSlug = addTestPdf(abs, 'native-text-sample.pdf');
+			const scannedSlug = addTestPdf(abs, 'scanned-sample.pdf');
 
-		// Without valid GCP credentials, Document AI calls will fail,
-		// but we can verify the discovery and orchestration logic.
-		const { stdout, stderr, exitCode } = runCli(
-			['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--verbose'],
-			{ timeout: 60000 },
-		);
+			const { stdout, stderr, exitCode } = runCli(
+				['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--verbose'],
+				{ timeout: 120000 },
+			);
 
-		const combined = stdout + stderr;
+			const combined = stdout + stderr;
 
-		// Should discover PDFs
-		expect(combined).toMatch(/discover|pdf.*found|found.*pdf|pdfCount/i);
-
-		// Should attempt to process files (even though GCP calls will fail)
-		expect(combined).toMatch(/process|calling|extract/i);
-
-		// The command may succeed (real GCP configured) or fail (credentials absent),
-		// but in both cases the orchestration path must have run end-to-end.
-		expect([0, 1]).toContain(exitCode);
-	});
+			expect(exitCode, combined).toBe(0);
+			expect(combined).toMatch(/discover|pdf.*found|found.*pdf|pdfCount/i);
+			expect(combined).toMatch(/process|calling|extract/i);
+			expect(existsSync(join(abs, 'extracted', nativeSlug, 'layout.json'))).toBe(true);
+			expect(existsSync(join(abs, 'extracted', scannedSlug, 'layout.json'))).toBe(true);
+		},
+	);
 
 	// ─── QA-03: Skip existing ───
 
@@ -212,7 +209,7 @@ describe('Spec 20 — Fixture Generator', () => {
 
 	// ─── QA-04: Force regenerate ───
 
-	it('QA-04: `--force` causes existing fixture to be overwritten (attempts re-generation)', () => {
+	it.skipIf(!GCP_TESTS_ENABLED)('QA-04: `--force` causes existing fixture to be overwritten', () => {
 		const { rel, abs } = createTmpFixtureDir('force');
 		trackTmpDir(abs);
 
@@ -220,27 +217,20 @@ describe('Spec 20 — Fixture Generator', () => {
 		const slug = addTestPdf(abs, 'native-text-sample.pdf');
 		createExistingFixture(abs, slug);
 
-		const { stdout, stderr } = runCli([
-			'fixtures',
-			'generate',
-			'--input',
-			`${rel}/raw`,
-			'--output',
-			rel,
-			'--force',
-			'--verbose',
-		]);
+		const fixturePath = join(abs, 'extracted', slug, 'layout.json');
+		const originalLayout = readFileSync(fixturePath, 'utf-8');
+
+		const { stdout, stderr, exitCode } = runCli(
+			['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--force', '--verbose'],
+			{ timeout: 120000 },
+		);
 
 		const combined = stdout + stderr;
 
-		// With --force, should NOT report as skipped
+		expect(exitCode, combined).toBe(0);
 		expect(combined).not.toMatch(/already exist.*skip/i);
-
-		// Should attempt to process (call Document AI)
 		expect(combined).toMatch(/Calling Document AI|process/i);
-
-		// Will fail without GCP, but the key behavior is: it attempted re-generation
-		// (as opposed to QA-03 which skips entirely)
+		expect(readFileSync(fixturePath, 'utf-8')).not.toBe(originalLayout);
 	});
 
 	// ─── QA-05: Status display ───
@@ -269,35 +259,24 @@ describe('Spec 20 — Fixture Generator', () => {
 
 	// ─── QA-06: Step filter ───
 
-	it('QA-06: `--step extract` only runs extract step', () => {
+	it.skipIf(!GCP_TESTS_ENABLED)('QA-06: `--step extract` only runs extract step', () => {
 		const { rel, abs } = createTmpFixtureDir('step-filter');
 		trackTmpDir(abs);
 
 		const slug = addTestPdf(abs, 'native-text-sample.pdf');
 
-		const { stdout, stderr } = runCli([
-			'fixtures',
-			'generate',
-			'--input',
-			`${rel}/raw`,
-			'--output',
-			rel,
-			'--step',
-			'extract',
-			'--verbose',
-		]);
+		const { stdout, stderr, exitCode } = runCli(
+			['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--step', 'extract', '--verbose'],
+			{ timeout: 120000 },
+		);
 
 		const combined = stdout + stderr;
 
-		// Should discover the PDF
+		expect(exitCode, combined).toBe(0);
 		expect(combined).toMatch(/discover|pdf|pdfCount/i);
-
-		// Should attempt extract step specifically
-		// Will fail without GCP but the step filter acceptance is verified
 		expect(combined).toMatch(/extract|Document AI/i);
-
-		// The slug should appear in the output (being processed)
 		expect(combined).toContain(slug);
+		expect(existsSync(join(abs, 'extracted', slug, 'layout.json'))).toBe(true);
 	});
 
 	// ─── QA-07: Slug derivation ───
@@ -308,27 +287,31 @@ describe('Spec 20 — Fixture Generator', () => {
 
 		// Copy a real PDF but rename it to complex-magazine.pdf
 		addTestPdf(abs, 'native-text-sample.pdf', 'complex-magazine.pdf');
+		createExistingFixture(abs, 'complex-magazine');
 
-		const { stdout, stderr } = runCli(['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--verbose']);
+		const { stdout, stderr, exitCode } = runCli([
+			'fixtures',
+			'generate',
+			'--input',
+			`${rel}/raw`,
+			'--output',
+			rel,
+			'--verbose',
+		]);
 
 		const combined = stdout + stderr;
 
-		// The slug should be "complex-magazine" (derived from filename minus .pdf)
+		expect(exitCode).toBe(0);
 		expect(combined).toContain('complex-magazine');
-
-		// If GCP were available, output would land in extracted/complex-magazine/
-		// Without GCP, we verify the slug derivation from the logs
-		// The implementation should log slug: "complex-magazine"
+		expect(combined).toMatch(/skip/i);
 		expect(combined).toMatch(/complex-magazine/);
 	});
 
 	// ─── QA-08: Writer creates correct structure ───
 
 	it('QA-08: extract writer creates layout.json + pages/page-NNN.png structure', () => {
-		// This test verifies the expected writer output structure.
-		// Without GCP credentials, we cannot actually run Document AI.
-		// We verify by creating a pre-existing fixture and checking it matches
-		// the spec's expected structure, and that the status command recognizes it.
+		// This test verifies the expected writer output structure with a
+		// synthetic pre-existing fixture, so it stays deterministic and local.
 
 		const { rel, abs } = createTmpFixtureDir('writer');
 		trackTmpDir(abs);
@@ -374,41 +357,39 @@ describe('Spec 20 — Fixture Generator', () => {
 
 	// ─── QA-09: Partial failure handling ───
 
-	it('QA-09: with 2 PDFs where one processing path fails, errors are reported and exit code is 1', () => {
-		const { rel, abs } = createTmpFixtureDir('partial');
-		trackTmpDir(abs);
+	it.skipIf(!GCP_TESTS_ENABLED)(
+		'QA-09: with 2 PDFs where one processing path fails, errors are reported and exit code is 1',
+		() => {
+			const { rel, abs } = createTmpFixtureDir('partial');
+			trackTmpDir(abs);
 
-		// One valid PDF plus one corrupt payload forces at least one per-file error
-		// regardless of whether real GCP credentials are configured.
-		const validSlug = addTestPdf(abs, 'native-text-sample.pdf');
-		const invalidSlug = addInvalidPdf(abs, 'broken-input.pdf');
+			const validSlug = addTestPdf(abs, 'native-text-sample.pdf');
+			const invalidSlug = addInvalidPdf(abs, 'broken-input.pdf');
 
-		const { stdout, stderr, exitCode } = runCli(
-			['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--verbose'],
-			{ timeout: 60000 },
-		);
+			const { stdout, stderr, exitCode } = runCli(
+				['fixtures', 'generate', '--input', `${rel}/raw`, '--output', rel, '--verbose'],
+				{ timeout: 120000 },
+			);
 
-		const combined = stdout + stderr;
+			const combined = stdout + stderr;
 
-		// Both PDFs should be discovered
-		expect(combined).toMatch(/pdfCount.*2|2.*pdf|discover/i);
-		expect(combined).toContain(validSlug);
-		expect(combined).toContain(invalidSlug);
+			// Both PDFs should be discovered
+			expect(combined).toMatch(/pdfCount.*2|2.*pdf|discover/i);
+			expect(combined).toContain(validSlug);
+			expect(combined).toContain(invalidSlug);
 
-		// The corrupt file must produce an error and the overall run must fail.
-		expect(combined).toMatch(/error|fail/i);
-		expect(exitCode).toBe(1);
+			// The corrupt file must produce an error and the overall run must fail.
+			expect(combined).toMatch(/error|fail/i);
+			expect(exitCode).toBe(1);
 
-		// The summary should mention the error count
-		expect(combined).toMatch(/\d+\s*error/i);
+			// The summary should mention the error count
+			expect(combined).toMatch(/\d+\s*error/i);
 
-		// If the valid PDF was processed successfully in this environment, keep
-		// the assertion black-box by checking for the extract fixture directory.
-		const extractedDir = join(abs, 'extracted', validSlug);
-		if (existsSync(extractedDir)) {
+			const extractedDir = join(abs, 'extracted', validSlug);
+			expect(existsSync(extractedDir)).toBe(true);
 			expect(existsSync(join(extractedDir, 'layout.json'))).toBe(true);
-		}
-	});
+		},
+	);
 
 	// ─── QA-10: Build succeeds ───
 

--- a/tests/specs/25_edge_repository.test.ts
+++ b/tests/specs/25_edge_repository.test.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
+import { ensureSchema } from '../lib/schema.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CORE_MODULE = resolve(ROOT, 'packages/core/dist/index.js');
@@ -67,6 +68,7 @@ describe('Spec 25: Edge Repository', () => {
 			return;
 		}
 
+		ensureSchema();
 		pool = new pg.Pool(PG_CONFIG);
 
 		// Dynamically import repository functions from the built database barrel

--- a/tests/specs/44_e2e_pipeline_integration.test.ts
+++ b/tests/specs/44_e2e_pipeline_integration.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
+import { ensureSchema } from '../lib/schema.js';
 
 /**
  * Black-box end-to-end integration test for the full M1–M4 MVP pipeline.
@@ -42,7 +43,6 @@ const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
 const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
 const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
 const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
-const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,19 +64,6 @@ function runCli(
 		stderr: result.stderr ?? '',
 		exitCode: result.status ?? 1,
 	};
-}
-
-/**
- * Ensure the schema exists before the test runs. Phase 1 of the QA Gate
- * identified finding P1-BASELINE-FLAKE-01: spec 08's afterAll drops all
- * tables, so downstream tests that don't re-migrate race against it. We
- * defend against that by running migrations in our own beforeAll.
- */
-function ensureSchema(): void {
-	const mig = runCli(['db', 'migrate', EXAMPLE_CONFIG]);
-	if (mig.exitCode !== 0) {
-		throw new Error(`Migration failed: ${mig.stdout} ${mig.stderr}`);
-	}
 }
 
 function cleanTestData(): void {

--- a/tests/specs/47_document_ai_extraction.test.ts
+++ b/tests/specs/47_document_ai_extraction.test.ts
@@ -31,11 +31,12 @@ const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
  * Cost: ~€0.30 per run (one Document AI Layout Parser call against ~1 page).
  * Within the €3 sprint cap.
  *
- * Skipped by default behind `MULDER_E2E_GCP=true` so no developer machine
- * burns Document AI quota on every `pnpm test`.
+ * Skipped by default behind `MULDER_TEST_GCP=true` so no developer machine
+ * burns Document AI quota on every `pnpm test`. The legacy
+ * `MULDER_E2E_GCP=true` name is still accepted for local compatibility.
  *
  * Requires when running:
- * - `MULDER_E2E_GCP=true` env var
+ * - `MULDER_TEST_GCP=true` env var (or legacy `MULDER_E2E_GCP=true`)
  * - Working `gcloud` ADC for the configured project
  * - A real `mulder.config.yaml` with:
  *   - `dev_mode: false`
@@ -50,7 +51,7 @@ const SCANNED_PDF = resolve(FIXTURE_DIR, 'scanned-sample.pdf');
  * will fail with a 404 from the Document AI endpoint.
  */
 
-const E2E_ENABLED = process.env.MULDER_E2E_GCP === 'true';
+const E2E_ENABLED = process.env.MULDER_TEST_GCP === 'true' || process.env.MULDER_E2E_GCP === 'true';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -178,9 +179,9 @@ describe('Spec 47 — Document AI Extraction (E2E, real GCP)', () => {
 });
 
 describe('Spec 47 — Document AI Extraction (smoke, no GCP)', () => {
-	it('SKIP-NOTICE: real-GCP test is gated behind MULDER_E2E_GCP=true', () => {
+	it('SKIP-NOTICE: real-GCP test is gated behind MULDER_TEST_GCP=true', () => {
 		// This always-running test exists so the suite never reports the spec
-		// as silently empty. When MULDER_E2E_GCP is unset, every E2E `it()`
+		// as silently empty. When the GCP env gate is unset, every E2E `it()`
 		// above is skipped via `it.skipIf` and only this notice runs.
 		if (!E2E_ENABLED) {
 			expect(E2E_ENABLED).toBe(false);

--- a/tests/specs/50_taxonomy_export_curate_merge.test.ts
+++ b/tests/specs/50_taxonomy_export_curate_merge.test.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
-import { ensureSchema } from '../lib/schema.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
 
 /**
  * Black-box QA tests for Spec 50: Taxonomy Export/Curate/Merge
@@ -79,13 +79,7 @@ function seedTaxonomy(
 }
 
 function cleanTestData(): void {
-	// Use TRUNCATE CASCADE for robustness against foreign key ordering issues
-	// when the database has leftover data from other test suites
-	db.runSql(
-		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
-			'taxonomy, entities, stories, source_steps, ' +
-			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
-	);
+	truncateMulderTables();
 }
 
 function cleanupTmpFiles(): void {

--- a/tests/specs/51_entity_management_cli.test.ts
+++ b/tests/specs/51_entity_management_cli.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
-import { ensureSchema } from '../lib/schema.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
 
 /**
  * Black-box QA tests for Spec 51: Entity Management CLI
@@ -47,11 +47,7 @@ function runCli(
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	db.runSql(
-		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
-			'taxonomy, entities, stories, source_steps, ' +
-			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
-	);
+	truncateMulderTables();
 }
 
 /**

--- a/tests/specs/52_status_overview.test.ts
+++ b/tests/specs/52_status_overview.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
-import { ensureSchema } from '../lib/schema.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
 
 /**
  * Black-box QA tests for Spec 52: Status Overview CLI
@@ -47,11 +47,7 @@ function runCli(
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	db.runSql(
-		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
-			'taxonomy, entities, stories, source_steps, ' +
-			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
-	);
+	truncateMulderTables();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/specs/53_export_commands.test.ts
+++ b/tests/specs/53_export_commands.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
-import { ensureSchema } from '../lib/schema.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
 
 /**
  * Black-box QA tests for Spec 53: Export Commands (graph/stories/evidence)
@@ -47,11 +47,7 @@ function runCli(
  * Truncate all relevant tables for a clean test state.
  */
 function cleanTestData(): void {
-	db.runSql(
-		'TRUNCATE TABLE chunks, story_entities, entity_edges, entity_aliases, ' +
-			'taxonomy, entities, stories, source_steps, ' +
-			'pipeline_run_sources, pipeline_runs, sources CASCADE;',
-	);
+	truncateMulderTables();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CI_WORKFLOW = resolve(ROOT, '.github/workflows/ci.yml');
+const GCP_WORKFLOW = resolve(ROOT, '.github/workflows/gcp-tests.yml');
+const PACKAGE_JSON = resolve(ROOT, 'package.json');
+
+function runVitest(args: string[], env?: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('pnpm', ['vitest', 'run', ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: 240_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			NODE_ENV: 'test',
+			PGHOST: db.TEST_PG_HOST,
+			PGPORT: String(db.TEST_PG_PORT),
+			PGUSER: db.TEST_PG_USER,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			PGDATABASE: db.TEST_PG_DATABASE,
+			...env,
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function resetSchemaToMissing(): void {
+	db.runSql(
+		[
+			'DROP FUNCTION IF EXISTS reset_pipeline_step CASCADE',
+			'DROP FUNCTION IF EXISTS gc_orphaned_entities CASCADE',
+			'DROP TABLE IF EXISTS pipeline_run_sources CASCADE',
+			'DROP TABLE IF EXISTS pipeline_runs CASCADE',
+			'DROP TABLE IF EXISTS jobs CASCADE',
+			'DROP TYPE IF EXISTS job_status CASCADE',
+			'DROP TABLE IF EXISTS chunks CASCADE',
+			'DROP TABLE IF EXISTS story_entities CASCADE',
+			'DROP TABLE IF EXISTS entity_edges CASCADE',
+			'DROP TABLE IF EXISTS entity_aliases CASCADE',
+			'DROP TABLE IF EXISTS taxonomy CASCADE',
+			'DROP TABLE IF EXISTS entities CASCADE',
+			'DROP TABLE IF EXISTS stories CASCADE',
+			'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
+			'DROP TABLE IF EXISTS evidence_chains CASCADE',
+			'DROP TABLE IF EXISTS entity_grounding CASCADE',
+			'DROP TABLE IF EXISTS source_steps CASCADE',
+			'DROP TABLE IF EXISTS sources CASCADE',
+			'DROP TABLE IF EXISTS mulder_migrations CASCADE',
+		].join('; '),
+	);
+}
+
+describe('Spec 59 — Hermetic Test Infrastructure', () => {
+	it.skipIf(!db.isPgAvailable())('QA-01: defensive cleanup succeeds even when Mulder tables do not exist', () => {
+		resetSchemaToMissing();
+		expect(() => truncateMulderTables()).not.toThrow();
+		ensureSchema();
+	});
+
+	it.skipIf(!db.isPgAvailable())('QA-02: spec 25 is independently runnable on a fresh database', () => {
+		resetSchemaToMissing();
+
+		const result = runVitest(['tests/specs/25_edge_repository.test.ts']);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+	});
+
+	it('QA-03: default fixture-generator and Document AI suites stay green without GCP opt-in', () => {
+		const result = runVitest(
+			['tests/specs/20_fixture_generator.test.ts', 'tests/specs/47_document_ai_extraction.test.ts'],
+			{
+				MULDER_TEST_GCP: 'false',
+				MULDER_E2E_GCP: 'false',
+			},
+		);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+	});
+
+	it('QA-04: the repo exposes one canonical opt-in GCP lane', () => {
+		const packageJson = readFileSync(PACKAGE_JSON, 'utf-8');
+		const gcpWorkflow = readFileSync(GCP_WORKFLOW, 'utf-8');
+
+		expect(packageJson).toContain('"test:gcp"');
+		expect(gcpWorkflow).toContain('MULDER_TEST_GCP: "true"');
+		expect(gcpWorkflow).toContain('pnpm test:gcp');
+	});
+
+	it('QA-05: CI runs Spec 44 as an explicit health signal before the wider suite', () => {
+		const ciWorkflow = readFileSync(CI_WORKFLOW, 'utf-8');
+		const gcpWorkflow = readFileSync(GCP_WORKFLOW, 'utf-8');
+
+		expect(ciWorkflow).toContain('Run E2E health check (Spec 44)');
+		expect(ciWorkflow).toContain('pnpm test:health');
+		expect(gcpWorkflow).toContain('workflow_dispatch');
+		expect(gcpWorkflow).toContain('schedule:');
+	});
+});


### PR DESCRIPTION
## Summary

Implements Spec 59 for issue #143 by hardening hermetic DB test setup/cleanup, moving credentialed fixture and Document AI checks behind a canonical `MULDER_TEST_GCP` opt-in, and surfacing Spec 44 as an explicit CI health lane.

Closes #143
Implements: [`docs/specs/59_hermetic_test_infrastructure.spec.md`](docs/specs/59_hermetic_test_infrastructure.spec.md)
Roadmap: N/A (off-roadmap test infrastructure)

## Changes

- add Spec 59 plus a dedicated black-box regression suite for the infrastructure contract
- add shared defensive table truncation and the missing schema bootstrap for the edge repository suite
- normalize fixture-generator and Document AI GCP gating, keeping the default test lane deterministic
- add `test:health` and `test:gcp` scripts, an explicit Spec 44 CI step, and a separate manual/scheduled GCP workflow

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run tests/specs/20_fixture_generator.test.ts tests/specs/25_edge_repository.test.ts tests/specs/44_e2e_pipeline_integration.test.ts tests/specs/47_document_ai_extraction.test.ts tests/specs/50_taxonomy_export_curate_merge.test.ts tests/specs/51_entity_management_cli.test.ts tests/specs/52_status_overview.test.ts tests/specs/53_export_commands.test.ts tests/specs/59_hermetic_test_infrastructure.test.ts`
- `pnpm vitest run tests/specs/59_hermetic_test_infrastructure.test.ts`
