### PR TITLE
[Evidence] Add contradiction analysis step

### DIFF
--- a/apps/cli/src/commands/analyze.ts
+++ b/apps/cli/src/commands/analyze.ts
@@ -1,0 +1,135 @@
+/**
+ * CLI command: `mulder analyze --contradictions`.
+ *
+ * Thin wrapper that validates selectors, loads config and services, runs the
+ * graph-wide Analyze step, and formats the result.
+ *
+ * @see docs/specs/61_contradiction_resolution.spec.md §4.5
+ * @see docs/functional-spec.md §2.8
+ */
+
+import { closeAllPools, createLogger, createServiceRegistry, getWorkerPool, loadConfig } from '@mulder/core';
+import type { AnalyzeResult } from '@mulder/pipeline';
+import { executeAnalyze } from '@mulder/pipeline';
+import type { Command } from 'commander';
+import { withErrorHandler } from '../lib/errors.js';
+import { printError, printSuccess } from '../lib/output.js';
+
+interface AnalyzeOptions {
+	contradictions?: boolean;
+	reliability?: boolean;
+	evidenceChains?: boolean;
+	spatioTemporal?: boolean;
+	full?: boolean;
+}
+
+function hasUnsupportedSelector(options: AnalyzeOptions): boolean {
+	return Boolean(options.full || options.reliability || options.evidenceChains || options.spatioTemporal);
+}
+
+function printUnsupportedSelectorMessage(options: AnalyzeOptions): void {
+	if (options.full) {
+		printError('--full is not implemented yet — it belongs to M6-G7');
+		return;
+	}
+	if (options.reliability) {
+		printError('--reliability is not implemented yet — it belongs to M6-G4');
+		return;
+	}
+	if (options.evidenceChains) {
+		printError('--evidence-chains is not implemented yet — it belongs to M6-G5');
+		return;
+	}
+	if (options.spatioTemporal) {
+		printError('--spatio-temporal is not implemented yet — it belongs to M6-G6');
+	}
+}
+
+function printOutcomeTable(result: AnalyzeResult): void {
+	if (result.data.outcomes.length === 0) {
+		return;
+	}
+
+	const header = `${'Edge ID'.padEnd(36)}  ${'Attribute'.padEnd(16)}  ${'Verdict'.padEnd(10)}  ${'Winner'.padEnd(7)}  Confidence`;
+	const separator = '-'.repeat(header.length);
+	process.stdout.write(`${header}\n`);
+	process.stdout.write(`${separator}\n`);
+
+	for (const outcome of result.data.outcomes) {
+		process.stdout.write(
+			`${outcome.edgeId.padEnd(36)}  ${outcome.attribute.padEnd(16)}  ${outcome.verdict.padEnd(10)}  ${outcome.winningClaim.padEnd(7)}  ${outcome.confidence.toFixed(2)}\n`,
+		);
+	}
+}
+
+export function registerAnalyzeCommands(program: Command): void {
+	program
+		.command('analyze')
+		.description('Run graph-wide analysis passes')
+		.option('--contradictions', 'resolve pending contradiction edges')
+		.option('--reliability', 'score source reliability (not yet implemented)')
+		.option('--evidence-chains', 'compute evidence chains (not yet implemented)')
+		.option('--spatio-temporal', 'compute spatio-temporal clusters (not yet implemented)')
+		.option('--full', 'run the full analyze orchestrator (not yet implemented)')
+		.action(
+			withErrorHandler(async (options: AnalyzeOptions) => {
+				if (!options.contradictions && !hasUnsupportedSelector(options)) {
+					printError('Provide an analysis selector such as --contradictions');
+					process.exit(1);
+					return;
+				}
+
+				if (hasUnsupportedSelector(options)) {
+					printUnsupportedSelectorMessage(options);
+					process.exit(1);
+					return;
+				}
+
+				const config = loadConfig();
+				const logger = createLogger();
+				const services = createServiceRegistry(config, logger);
+
+				if (!config.gcp && !config.dev_mode) {
+					printError('GCP configuration is required for analyze (or enable dev_mode)');
+					process.exit(1);
+					return;
+				}
+
+				if (!config.gcp) {
+					printError('GCP configuration with cloud_sql is required for analyze');
+					process.exit(1);
+					return;
+				}
+
+				const pool = getWorkerPool(config.gcp.cloud_sql);
+
+				try {
+					const result = await executeAnalyze({ contradictions: true }, config, services, pool, logger);
+
+					printOutcomeTable(result);
+
+					for (const error of result.errors) {
+						printError(`[${error.code}] ${error.message}`);
+					}
+
+					if (result.data.pendingCount === 0) {
+						printSuccess(`Analyze complete: no pending contradiction edges found (${result.metadata.duration_ms}ms)`);
+						return;
+					}
+
+					const summary = `${result.data.processedCount} processed, ${result.data.confirmedCount} confirmed, ${result.data.dismissedCount} dismissed, ${result.data.failedCount} failed (${result.metadata.duration_ms}ms)`;
+
+					if (result.status === 'failed') {
+						printError(`Analyze failed: ${summary}`);
+						process.exit(1);
+					} else if (result.status === 'partial') {
+						process.stderr.write(`Analyze partial: ${summary}\n`);
+					} else {
+						printSuccess(`Analyze complete: ${summary}`);
+					}
+				} finally {
+					await closeAllPools();
+				}
+			}),
+		);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { Command } from 'commander';
+import { registerAnalyzeCommands } from './commands/analyze.js';
 import { registerCacheCommands } from './commands/cache.js';
 import { registerConfigCommands } from './commands/config.js';
 import { registerDbCommands } from './commands/db.js';
@@ -35,6 +36,7 @@ const program = new Command()
 	.version('0.0.0');
 
 registerCacheCommands(program);
+registerAnalyzeCommands(program);
 registerConfigCommands(program);
 registerDbCommands(program);
 registerEmbedCommands(program);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -165,7 +165,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 |--------|------|------|------|
 | 🟢 | G1 | v2.0 schema migrations (009-011) | §4.3 (grounding, evidence_chains, clusters tables) |
 | 🟢 | G2 | Ground step — `mulder ground <entity-id>` | §2.5, §1 (ground cmd) |
-| ⚪ | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
+| 🟡 | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
 | ⚪ | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
 | ⚪ | G5 | Evidence chains — `mulder analyze --evidence-chains` | §2.8, §4.3 (evidence_chains table) |
 | ⚪ | G6 | Spatio-temporal clustering | §2.8, §4.3 (clusters table) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -165,7 +165,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 |--------|------|------|------|
 | 🟢 | G1 | v2.0 schema migrations (009-011) | §4.3 (grounding, evidence_chains, clusters tables) |
 | 🟢 | G2 | Ground step — `mulder ground <entity-id>` | §2.5, §1 (ground cmd) |
-| 🟡 | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
+| 🟢 | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
 | ⚪ | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
 | ⚪ | G5 | Evidence chains — `mulder analyze --evidence-chains` | §2.8, §4.3 (evidence_chains table) |
 | ⚪ | G6 | Spatio-temporal clustering | §2.8, §4.3 (clusters table) |

--- a/docs/specs/61_contradiction_resolution.spec.md
+++ b/docs/specs/61_contradiction_resolution.spec.md
@@ -1,0 +1,140 @@
+---
+spec: "61"
+title: "Contradiction Resolution"
+roadmap_step: M6-G3
+functional_spec: ["§2.8"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/150"
+created: 2026-04-12
+---
+
+# Spec 61: Contradiction Resolution
+
+## 1. Objective
+
+Implement Mulder's first Analyze sub-step so `mulder analyze --contradictions` resolves previously flagged `POTENTIAL_CONTRADICTION` edges with Gemini, updates each edge to `CONFIRMED_CONTRADICTION` or `DISMISSED_CONTRADICTION`, and stores the model's explanation on the edge record for downstream evidence and review workflows. Per `§2.8`, the step runs against the full graph rather than a single story, builds a comparison prompt from both conflicting claims plus source context, and treats contradiction resolution as a modular analysis pass that can be rerun after new documents or manual entity curation.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M6-G3` — Contradiction resolution — `mulder analyze --contradictions`
+- **Target:** `packages/core/src/shared/errors.ts`, `packages/core/src/shared/services.dev.ts`, `packages/core/src/prompts/templates/resolve-contradiction.jinja2`, `packages/core/src/index.ts`, `packages/pipeline/src/analyze/types.ts`, `packages/pipeline/src/analyze/index.ts`, `packages/pipeline/src/index.ts`, `apps/cli/src/commands/analyze.ts`, `apps/cli/src/index.ts`
+- **In scope:** loading unresolved contradiction edges, hydrating the prompt with both sides of the conflict and supporting story/source context, calling Gemini structured output through the shared LLM service, persisting per-edge verdicts and explanations, adding a standalone Analyze pipeline entry point for contradictions, and exposing the CLI command surface for `mulder analyze --contradictions`
+- **Out of scope:** source reliability scoring (`M6-G4`), evidence chains (`M6-G5`), spatio-temporal clustering (`M6-G6`), the `--full` orchestrator (`M6-G7`), schema migrations beyond the existing `entity_edges.analysis` support, UI/API exposure, and any new contradiction-detection logic in the Graph step
+- **Constraints:** keep the step global rather than story-scoped per `§2.8`; use the existing service abstraction and prompt engine instead of direct SDK calls or inline prompts; preserve idempotency by only processing unresolved `POTENTIAL_CONTRADICTION` edges unless a future step explicitly adds refresh semantics; and store enough structured analysis on each edge to support later evidence, export, and review flows
+
+## 3. Dependencies
+
+- **Requires:** Spec 11 (`M1-A10`) service abstraction, Spec 18 (`M2-B6`) prompt template engine, Spec 25 (`M3-C4`) edge repository CRUD, Spec 35 (`M4-D5`) graph contradiction flagging, and Spec 54 (`M6-G1`) v2.0 schema migrations
+- **Blocks:** `M6-G7` analyze orchestrator and any downstream workflow that expects contradiction edges to carry confirmed or dismissed verdicts instead of only raw `POTENTIAL_CONTRADICTION` flags
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/core/src/shared/errors.ts`** — defines Analyze-step error codes and a dedicated error class for disabled analysis, malformed contradiction context, and persistence/LLM failures
+2. **`packages/core/src/shared/services.dev.ts`** — returns deterministic contradiction-resolution fixtures through `generateStructured()` so black-box verification can exercise the step without live Gemini calls
+3. **`packages/core/src/prompts/templates/resolve-contradiction.jinja2`** — upgrades the placeholder template to the real comparison contract, including both claims, source snippets, and JSON-only verdict instructions
+4. **`packages/core/src/index.ts`** — re-exports the new Analyze error surface for pipeline and CLI consumers
+5. **`packages/pipeline/src/analyze/types.ts`** — defines contradiction-resolution input, structured LLM response, per-edge outcome, and aggregate Analyze result types
+6. **`packages/pipeline/src/analyze/index.ts`** — implements the contradiction-resolution step: load unresolved contradiction edges, gather story/source context, render the prompt, call Gemini structured output, map the verdict to a final edge type, persist the explanation/metadata, and return an aggregate result
+7. **`packages/pipeline/src/index.ts`** — exports the Analyze step from the pipeline package barrel
+8. **`apps/cli/src/commands/analyze.ts`** — thin Commander wrapper for `mulder analyze --contradictions`, including flag validation, step execution, tabular output, and exit-code handling
+9. **`apps/cli/src/index.ts`** — registers the new `analyze` command
+
+### 4.2 Database Changes
+
+None. This step uses the existing `entity_edges` schema introduced earlier:
+
+- `edge_type` transitions from `POTENTIAL_CONTRADICTION` to either `CONFIRMED_CONTRADICTION` or `DISMISSED_CONTRADICTION`
+- `analysis` stores the structured Gemini verdict, explanation, and any supporting metadata needed for later export/review
+
+### 4.3 Config Changes
+
+None. The step uses the existing `analysis` config block:
+
+- `analysis.enabled`
+- `analysis.contradictions`
+
+Implementation should fail fast with a clear Analyze-step error when contradiction analysis is disabled by config.
+
+### 4.4 Integration Points
+
+- The step must use `renderPrompt('resolve-contradiction', ...)` so prompt content stays template-driven
+- Gemini calls must go through `services.llm.generateStructured()` with both server-side schema enforcement and client-side validation
+- Edge persistence should reuse the existing repository APIs to update `edge_type` and `analysis` in place rather than creating new edges
+- CLI wiring should follow the existing `ground` and `graph` command pattern: validate flags, load config, create services, run the pipeline step, print a concise results table and summary, then close pools
+- The pipeline barrel export should make the new Analyze executor available to the CLI now and to the future orchestrator in `M6-G7`
+
+### 4.5 Implementation Phases
+
+**Phase 1: Contracts + prompt**
+- Files: `packages/core/src/shared/errors.ts`, `packages/core/src/shared/services.dev.ts`, `packages/core/src/prompts/templates/resolve-contradiction.jinja2`, `packages/core/src/index.ts`, `packages/pipeline/src/analyze/types.ts`
+- Deliverable: the Analyze step has a stable typed contract, dev/test fixture behavior, and a concrete prompt/schema for contradiction verdicts
+
+**Phase 2: Resolution engine**
+- Files: `packages/pipeline/src/analyze/index.ts`, `packages/pipeline/src/index.ts`
+- Deliverable: unresolved contradiction edges can be resolved and persisted with confirmed/dismissed verdicts plus stored explanations
+
+**Phase 3: CLI surface**
+- Files: `apps/cli/src/commands/analyze.ts`, `apps/cli/src/index.ts`
+- Deliverable: `mulder analyze --contradictions` runs end to end with clear summaries and non-zero exits for invalid invocations or total failure
+
+## 5. QA Contract
+
+1. **QA-01: Contradiction analysis resolves pending edges into final verdicts**
+   - Given: the database contains at least one `POTENTIAL_CONTRADICTION` edge whose related stories and sources exist, and `analysis.enabled=true` with `analysis.contradictions=true`
+   - When: `mulder analyze --contradictions` runs successfully
+   - Then: the command exits `0`, the targeted edge no longer has `edge_type='POTENTIAL_CONTRADICTION'`, its new `edge_type` is either `CONFIRMED_CONTRADICTION` or `DISMISSED_CONTRADICTION`, and its `analysis` column contains a non-empty explanation payload
+
+2. **QA-02: Re-running the step is idempotent after all pending contradictions are resolved**
+   - Given: the same contradiction edges have already been resolved once
+   - When: `mulder analyze --contradictions` is run again without adding new `POTENTIAL_CONTRADICTION` edges
+   - Then: the command exits `0`, reports that zero pending contradictions were processed, and previously resolved edge verdicts remain unchanged
+
+3. **QA-03: No-op runs succeed cleanly when there is nothing to resolve**
+   - Given: the database contains no `POTENTIAL_CONTRADICTION` edges
+   - When: `mulder analyze --contradictions` runs
+   - Then: the command exits `0`, prints a clear “nothing to analyze” style summary, and makes no database changes
+
+4. **QA-04: Disabled contradiction analysis fails before any LLM work**
+   - Given: `analysis.enabled=false` or `analysis.contradictions=false`
+   - When: `mulder analyze --contradictions` runs
+   - Then: the command exits non-zero with an Analyze-step error code/message explaining that contradiction analysis is disabled, and no `entity_edges` rows are modified
+
+5. **QA-05: Missing contradiction context fails without partial updates**
+   - Given: a `POTENTIAL_CONTRADICTION` edge exists but one of its referenced stories or sources is missing
+   - When: `mulder analyze --contradictions` runs
+   - Then: the command exits non-zero with an Analyze-step error code for missing context, and the affected edge remains `POTENTIAL_CONTRADICTION` with no partial verdict written
+
+6. **QA-06: Mixed batches preserve successful verdicts and report partial failure**
+   - Given: one pending contradiction edge has valid context and another pending contradiction edge has invalid or missing context
+   - When: `mulder analyze --contradictions` runs
+   - Then: the valid edge is resolved and persisted, the invalid edge remains pending, and the command reports partial failure rather than rolling back the successful resolution
+
+## 5b. CLI Test Matrix
+
+### `mulder analyze --contradictions`
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-01 | `--contradictions` | Exit `0`, resolves all pending contradiction edges and prints a summary table |
+| CLI-02 | `--contradictions` *(run twice)* | Exit `0`, second run reports zero processed contradictions and preserves the first run’s verdicts |
+| CLI-03 | `--contradictions --json` | Exit non-zero, because JSON output is not part of this step’s CLI surface |
+| CLI-04 | `--contradictions --full` | Exit non-zero, because `--full` belongs to `M6-G7`, not `M6-G3` |
+
+### Selector validation
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-05 | *(no args)* | Exit non-zero, usage/help indicates that an analysis selector such as `--contradictions` is required |
+| CLI-06 | `--full` | Exit non-zero, because the full Analyze orchestrator is not implemented yet |
+| CLI-07 | `--reliability` | Exit non-zero, because source reliability scoring belongs to `M6-G4` |
+| CLI-08 | `--evidence-chains` | Exit non-zero, because evidence chains belong to `M6-G5` |
+| CLI-09 | `--spatio-temporal` | Exit non-zero, because clustering belongs to `M6-G6` |
+
+## 6. Cost Considerations
+
+- **Services called:** Gemini via Vertex AI structured generation
+- **Estimated cost per contradiction edge:** low but non-zero; each unresolved contradiction requires one Gemini comparison call
+- **Dev mode alternative:** yes — deterministic contradiction fixtures in `services.dev.ts` allow end-to-end verification without live Vertex spend
+- **Safety flags:** respect `analysis.enabled` and `analysis.contradictions` so the step does not make paid calls when contradiction analysis is disabled

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,7 @@ export {
 	findChunksByStoryId,
 	findEdgesByEntityId,
 	findEdgesByStoryId,
+	findEdgesByType,
 	findEntitiesByCanonicalId,
 	findEntitiesByStoryId,
 	findEntitiesByType,
@@ -184,6 +185,7 @@ export {
 	traverseGraph,
 	unlinkStoryEntity,
 	updateChunkEmbedding,
+	updateEdge,
 	updateEntity,
 	updateEntityEmbedding,
 	updateSource,
@@ -209,6 +211,7 @@ export { clearPromptCaches, listTemplates, renderPrompt } from './prompts/index.
 export type { CacheKeyParams } from './shared/cache-hash.js';
 export { computeCacheKey } from './shared/cache-hash.js';
 export type {
+	AnalyzeErrorCode,
 	ConfigErrorCode,
 	DatabaseErrorCode,
 	EmbedErrorCode,
@@ -226,6 +229,8 @@ export type {
 	TaxonomyErrorCode,
 } from './shared/errors.js';
 export {
+	ANALYZE_ERROR_CODES,
+	AnalyzeError,
 	CONFIG_ERROR_CODES,
 	ConfigError,
 	DATABASE_ERROR_CODES,

--- a/packages/core/src/prompts/templates/resolve-contradiction.jinja2
+++ b/packages/core/src/prompts/templates/resolve-contradiction.jinja2
@@ -1,10 +1,30 @@
-{# Contradiction resolution prompt — real content added when Analyze step is implemented (M6-G3) #}
 {{ i18n.contradiction.system_role }}
 
-## Conflicting Claims
-{{ claims }}
+## Entity
+- Name: {{ entity.name }}
+- Type: {{ entity.type }}
+- Attribute in dispute: {{ contradiction.attribute }}
+- Edge ID: {{ contradiction.edge_id }}
+
+## Claim A
+- Value: {{ claim_a.value }}
+- Story: {{ claim_a.story_title }}
+- Source: {{ claim_a.source_filename }}
+- Pages: {{ claim_a.page_range }}
+
+## Claim B
+- Value: {{ claim_b.value }}
+- Story: {{ claim_b.story_title }}
+- Source: {{ claim_b.source_filename }}
+- Pages: {{ claim_b.page_range }}
 
 ## Task
 {{ i18n.contradiction.task_description }}
+
+Return a JSON object with:
+- `verdict`: `"confirmed"` or `"dismissed"`
+- `winning_claim`: `"A"`, `"B"`, or `"neither"`
+- `confidence`: number between 0 and 1
+- `explanation`: concise evidence-based reasoning
 
 {{ i18n.common.json_instruction }}

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -159,6 +159,17 @@ export const GRAPH_ERROR_CODES = {
 
 export type GraphErrorCode = (typeof GRAPH_ERROR_CODES)[keyof typeof GRAPH_ERROR_CODES];
 
+/** Analyze step error codes. */
+export const ANALYZE_ERROR_CODES = {
+	ANALYZE_DISABLED: 'ANALYZE_DISABLED',
+	ANALYZE_CONTEXT_MISSING: 'ANALYZE_CONTEXT_MISSING',
+	ANALYZE_LLM_FAILED: 'ANALYZE_LLM_FAILED',
+	ANALYZE_VALIDATION_FAILED: 'ANALYZE_VALIDATION_FAILED',
+	ANALYZE_WRITE_FAILED: 'ANALYZE_WRITE_FAILED',
+} as const;
+
+export type AnalyzeErrorCode = (typeof ANALYZE_ERROR_CODES)[keyof typeof ANALYZE_ERROR_CODES];
+
 /** Retrieval domain error codes (vector/fulltext/graph search wrappers + fusion + re-ranking + orchestrator). */
 export const RETRIEVAL_ERROR_CODES = {
 	RETRIEVAL_INVALID_INPUT: 'RETRIEVAL_INVALID_INPUT',
@@ -198,6 +209,7 @@ export type MulderErrorCode =
 	| EmbedErrorCode
 	| GroundErrorCode
 	| GraphErrorCode
+	| AnalyzeErrorCode
 	| RetrievalErrorCode
 	| PromptErrorCode;
 
@@ -391,6 +403,21 @@ export class GraphError extends MulderError {
 	) {
 		super(message, code, options);
 		this.name = 'GraphError';
+	}
+}
+
+/** Analyze step errors (contradiction resolution and later analysis passes). */
+export class AnalyzeError extends MulderError {
+	constructor(
+		message: string,
+		code: AnalyzeErrorCode,
+		options?: {
+			context?: Record<string, unknown>;
+			cause?: unknown;
+		},
+	) {
+		super(message, code, options);
+		this.name = 'AnalyzeError';
 	}
 }
 

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -361,8 +361,21 @@ class DevLlmService implements LlmService {
 			this.logger.debug('DevLlmService: generateStructured — returning rerank fixture (empty rankings)');
 			result = JSON.parse(JSON.stringify({ rankings: [] }));
 		} else {
-			this.logger.debug('DevLlmService: generateStructured called (returning empty object)');
-			result = emptyStubResponse<T>();
+			if (hasProperty('verdict')) {
+				this.logger.debug('DevLlmService: generateStructured — returning contradiction resolution fixture');
+				result = JSON.parse(
+					JSON.stringify({
+						verdict: 'confirmed',
+						winning_claim: 'A',
+						confidence: 0.84,
+						explanation:
+							'Dev mode fixture selected claim A based on stronger source context and a more specific attribute statement.',
+					}),
+				);
+			} else {
+				this.logger.debug('DevLlmService: generateStructured called (returning empty object)');
+				result = emptyStubResponse<T>();
+			}
 		}
 
 		// Call responseValidator if provided, matching production behavior

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -123,14 +123,9 @@ function formatPageRange(story: Story): string {
 	return 'unknown';
 }
 
-function resolveLocale(config: MulderConfig, storyA: Story, storyB: Story): string {
-	const candidateLocales = [storyA.language, storyB.language, config.project.supported_locales[0], 'en'];
-	for (const locale of candidateLocales) {
-		if (typeof locale === 'string' && locale.trim().length > 0) {
-			return locale;
-		}
-	}
-	return 'en';
+function resolveLocale(config: MulderConfig): string {
+	const locale = config.project.supported_locales[0];
+	return typeof locale === 'string' && locale.trim().length > 0 ? locale : 'en';
 }
 
 function toStepError(error: AnalyzeError, edgeId: string): StepError {
@@ -225,7 +220,7 @@ async function resolveEdge(
 	services: Services,
 	pool: pg.Pool,
 ): Promise<ContradictionResolutionOutcome> {
-	const locale = resolveLocale(config, context.storyA, context.storyB);
+	const locale = resolveLocale(config);
 	const prompt = buildPrompt(context, locale);
 
 	let resolution: ContradictionResolutionResponse;

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -1,0 +1,381 @@
+/**
+ * Analyze pipeline step — currently resolves contradiction edges across the
+ * full graph using Gemini structured output.
+ *
+ * @see docs/specs/61_contradiction_resolution.spec.md
+ * @see docs/functional-spec.md §2.8
+ */
+
+import { performance } from 'node:perf_hooks';
+import type { Entity, EntityEdge, Logger, MulderConfig, Services, Source, StepError, Story } from '@mulder/core';
+import {
+	ANALYZE_ERROR_CODES,
+	AnalyzeError,
+	createChildLogger,
+	findEdgesByType,
+	findEntityById,
+	findSourceById,
+	findStoryById,
+	renderPrompt,
+	updateEdge,
+} from '@mulder/core';
+import type pg from 'pg';
+import { z } from 'zod';
+import { z as z3 } from 'zod/v3';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type {
+	AnalyzeData,
+	AnalyzeInput,
+	AnalyzeResult,
+	ContradictionResolutionOutcome,
+	ContradictionResolutionResponse,
+} from './types.js';
+
+export type {
+	AnalyzeData,
+	AnalyzeInput,
+	AnalyzeResult,
+	ContradictionResolutionOutcome,
+	ContradictionResolutionResponse,
+	ContradictionVerdict,
+	WinningClaim,
+} from './types.js';
+
+const STEP_NAME = 'analyze';
+
+const contradictionResolutionSchema = z.object({
+	verdict: z.enum(['confirmed', 'dismissed']),
+	winning_claim: z.enum(['A', 'B', 'neither']),
+	confidence: z.number().min(0).max(1),
+	explanation: z.string().min(1),
+});
+
+const contradictionResolutionSchemaV3 = z3.object({
+	verdict: z3.enum(['confirmed', 'dismissed']),
+	winning_claim: z3.enum(['A', 'B', 'neither']),
+	confidence: z3.number().min(0).max(1),
+	explanation: z3.string().min(1),
+});
+
+const contradictionResolutionJsonSchema: Record<string, unknown> = zodToJsonSchema(contradictionResolutionSchemaV3, {
+	name: 'ContradictionResolutionResponse',
+	$refStrategy: 'none',
+});
+
+interface ContradictionAttributes {
+	attribute: string;
+	valueA: string;
+	valueB: string;
+	storyIdA: string;
+	storyIdB: string;
+}
+
+interface HydratedContradictionContext extends ContradictionAttributes {
+	edge: EntityEdge;
+	entity: Entity;
+	storyA: Story;
+	storyB: Story;
+	sourceA: Source;
+	sourceB: Source;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getStringAttribute(record: Record<string, unknown>, key: string): string {
+	const value = record[key];
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new AnalyzeError(`Contradiction edge is missing "${key}"`, ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING, {
+			context: { key },
+		});
+	}
+	return value.trim();
+}
+
+function parseContradictionAttributes(edge: EntityEdge): ContradictionAttributes {
+	if (!isRecord(edge.attributes)) {
+		throw new AnalyzeError(
+			`Contradiction edge ${edge.id} has invalid attribute payload`,
+			ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING,
+			{ context: { edgeId: edge.id } },
+		);
+	}
+
+	return {
+		attribute: getStringAttribute(edge.attributes, 'attribute'),
+		valueA: getStringAttribute(edge.attributes, 'valueA'),
+		valueB: getStringAttribute(edge.attributes, 'valueB'),
+		storyIdA: getStringAttribute(edge.attributes, 'storyIdA'),
+		storyIdB: getStringAttribute(edge.attributes, 'storyIdB'),
+	};
+}
+
+function formatPageRange(story: Story): string {
+	if (typeof story.pageStart === 'number' && typeof story.pageEnd === 'number') {
+		return story.pageStart === story.pageEnd ? String(story.pageStart) : `${story.pageStart}-${story.pageEnd}`;
+	}
+	if (typeof story.pageStart === 'number') {
+		return String(story.pageStart);
+	}
+	if (typeof story.pageEnd === 'number') {
+		return String(story.pageEnd);
+	}
+	return 'unknown';
+}
+
+function resolveLocale(config: MulderConfig, storyA: Story, storyB: Story): string {
+	const candidateLocales = [storyA.language, storyB.language, config.project.supported_locales[0], 'en'];
+	for (const locale of candidateLocales) {
+		if (typeof locale === 'string' && locale.trim().length > 0) {
+			return locale;
+		}
+	}
+	return 'en';
+}
+
+function toStepError(error: AnalyzeError, edgeId: string): StepError {
+	return {
+		code: error.code,
+		message: `${edgeId}: ${error.message}`,
+	};
+}
+
+async function hydrateContext(pool: pg.Pool, edge: EntityEdge): Promise<HydratedContradictionContext> {
+	const attributes = parseContradictionAttributes(edge);
+
+	const entity = await findEntityById(pool, edge.sourceEntityId);
+	if (!entity) {
+		throw new AnalyzeError(
+			`Entity not found for contradiction edge ${edge.id}`,
+			ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING,
+			{
+				context: { edgeId: edge.id, entityId: edge.sourceEntityId },
+			},
+		);
+	}
+
+	const storyA = await findStoryById(pool, attributes.storyIdA);
+	if (!storyA) {
+		throw new AnalyzeError(`Story not found: ${attributes.storyIdA}`, ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING, {
+			context: { edgeId: edge.id, storyId: attributes.storyIdA },
+		});
+	}
+
+	const storyB = await findStoryById(pool, attributes.storyIdB);
+	if (!storyB) {
+		throw new AnalyzeError(`Story not found: ${attributes.storyIdB}`, ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING, {
+			context: { edgeId: edge.id, storyId: attributes.storyIdB },
+		});
+	}
+
+	const sourceA = await findSourceById(pool, storyA.sourceId);
+	if (!sourceA) {
+		throw new AnalyzeError(`Source not found: ${storyA.sourceId}`, ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING, {
+			context: { edgeId: edge.id, sourceId: storyA.sourceId },
+		});
+	}
+
+	const sourceB = await findSourceById(pool, storyB.sourceId);
+	if (!sourceB) {
+		throw new AnalyzeError(`Source not found: ${storyB.sourceId}`, ANALYZE_ERROR_CODES.ANALYZE_CONTEXT_MISSING, {
+			context: { edgeId: edge.id, sourceId: storyB.sourceId },
+		});
+	}
+
+	return {
+		edge,
+		entity,
+		storyA,
+		storyB,
+		sourceA,
+		sourceB,
+		...attributes,
+	};
+}
+
+function buildPrompt(context: HydratedContradictionContext, locale: string): string {
+	return renderPrompt('resolve-contradiction', {
+		locale,
+		entity: {
+			name: context.entity.name,
+			type: context.entity.type,
+		},
+		contradiction: {
+			attribute: context.attribute,
+			edge_id: context.edge.id,
+		},
+		claim_a: {
+			value: context.valueA,
+			story_title: context.storyA.title,
+			source_filename: context.sourceA.filename,
+			page_range: formatPageRange(context.storyA),
+		},
+		claim_b: {
+			value: context.valueB,
+			story_title: context.storyB.title,
+			source_filename: context.sourceB.filename,
+			page_range: formatPageRange(context.storyB),
+		},
+	});
+}
+
+async function resolveEdge(
+	context: HydratedContradictionContext,
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool,
+): Promise<ContradictionResolutionOutcome> {
+	const locale = resolveLocale(config, context.storyA, context.storyB);
+	const prompt = buildPrompt(context, locale);
+
+	let resolution: ContradictionResolutionResponse;
+	try {
+		resolution = await services.llm.generateStructured<ContradictionResolutionResponse>({
+			prompt,
+			schema: contradictionResolutionJsonSchema,
+			responseValidator: (data) => contradictionResolutionSchema.parse(data),
+		});
+	} catch (cause: unknown) {
+		const code =
+			cause instanceof z.ZodError
+				? ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED
+				: ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED;
+		throw new AnalyzeError(`Failed to resolve contradiction edge ${context.edge.id}`, code, {
+			cause,
+			context: { edgeId: context.edge.id },
+		});
+	}
+
+	const nextEdgeType = resolution.verdict === 'confirmed' ? 'CONFIRMED_CONTRADICTION' : 'DISMISSED_CONTRADICTION';
+	try {
+		await updateEdge(pool, context.edge.id, {
+			edgeType: nextEdgeType,
+			confidence: resolution.confidence,
+			analysis: {
+				verdict: resolution.verdict,
+				winning_claim: resolution.winning_claim,
+				confidence: resolution.confidence,
+				explanation: resolution.explanation,
+				attribute: context.attribute,
+				valueA: context.valueA,
+				valueB: context.valueB,
+				storyIdA: context.storyA.id,
+				storyIdB: context.storyB.id,
+				sourceIdA: context.sourceA.id,
+				sourceIdB: context.sourceB.id,
+				resolvedAt: new Date().toISOString(),
+			},
+		});
+	} catch (cause: unknown) {
+		throw new AnalyzeError(
+			`Failed to persist contradiction verdict for edge ${context.edge.id}`,
+			ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED,
+			{
+				cause,
+				context: { edgeId: context.edge.id },
+			},
+		);
+	}
+
+	return {
+		edgeId: context.edge.id,
+		entityId: context.entity.id,
+		attribute: context.attribute,
+		verdict: resolution.verdict,
+		winningClaim: resolution.winning_claim,
+		confidence: resolution.confidence,
+	};
+}
+
+function makeData(outcomes: ContradictionResolutionOutcome[], failedCount: number, pendingCount: number): AnalyzeData {
+	const confirmedCount = outcomes.filter((outcome) => outcome.verdict === 'confirmed').length;
+	const dismissedCount = outcomes.filter((outcome) => outcome.verdict === 'dismissed').length;
+
+	return {
+		pendingCount,
+		processedCount: outcomes.length,
+		confirmedCount,
+		dismissedCount,
+		failedCount,
+		outcomes,
+	};
+}
+
+export async function execute(
+	input: AnalyzeInput,
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool | undefined,
+	logger: Logger,
+): Promise<AnalyzeResult> {
+	const log = createChildLogger(logger, { step: STEP_NAME, contradictions: input.contradictions });
+	const startTime = performance.now();
+
+	if (!pool) {
+		throw new AnalyzeError('Database pool is required for analyze step', ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED);
+	}
+
+	if (!input.contradictions || !config.analysis.enabled || !config.analysis.contradictions) {
+		throw new AnalyzeError(
+			'Contradiction analysis is disabled in the active configuration',
+			ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
+			{
+				context: {
+					enabled: config.analysis.enabled,
+					contradictions: config.analysis.contradictions,
+				},
+			},
+		);
+	}
+
+	const pendingEdges = await findEdgesByType(pool, 'POTENTIAL_CONTRADICTION');
+	const outcomes: ContradictionResolutionOutcome[] = [];
+	const errors: StepError[] = [];
+
+	for (const edge of pendingEdges) {
+		try {
+			const context = await hydrateContext(pool, edge);
+			const outcome = await resolveEdge(context, config, services, pool);
+			outcomes.push(outcome);
+		} catch (cause: unknown) {
+			const analyzeError =
+				cause instanceof AnalyzeError
+					? cause
+					: new AnalyzeError(`Unexpected analyze failure for edge ${edge.id}`, ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED, {
+							cause,
+							context: { edgeId: edge.id },
+						});
+			errors.push(toStepError(analyzeError, edge.id));
+			log.warn({ err: cause, edgeId: edge.id }, 'Analyze failed for contradiction edge — continuing');
+		}
+	}
+
+	const data = makeData(outcomes, errors.length, pendingEdges.length);
+	const status = errors.length === 0 ? 'success' : outcomes.length > 0 ? 'partial' : 'failed';
+	const durationMs = Math.round(performance.now() - startTime);
+
+	log.info(
+		{
+			pendingCount: data.pendingCount,
+			processedCount: data.processedCount,
+			confirmedCount: data.confirmedCount,
+			dismissedCount: data.dismissedCount,
+			failedCount: data.failedCount,
+			duration_ms: durationMs,
+		},
+		'Analyze step completed',
+	);
+
+	return {
+		status,
+		data,
+		errors,
+		metadata: {
+			duration_ms: durationMs,
+			items_processed: data.processedCount,
+			items_skipped: 0,
+			items_cached: 0,
+		},
+	};
+}

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -58,7 +58,6 @@ const contradictionResolutionSchemaV3 = z3.object({
 });
 
 const contradictionResolutionJsonSchema: Record<string, unknown> = zodToJsonSchema(contradictionResolutionSchemaV3, {
-	name: 'ContradictionResolutionResponse',
 	$refStrategy: 'none',
 });
 

--- a/packages/pipeline/src/analyze/types.ts
+++ b/packages/pipeline/src/analyze/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Type definitions for the Analyze pipeline step.
+ *
+ * @see docs/specs/61_contradiction_resolution.spec.md §4.1
+ * @see docs/functional-spec.md §2.8
+ */
+
+import type { StepError } from '@mulder/core';
+
+export interface AnalyzeInput {
+	contradictions: boolean;
+}
+
+export type ContradictionVerdict = 'confirmed' | 'dismissed';
+
+export type WinningClaim = 'A' | 'B' | 'neither';
+
+export interface ContradictionResolutionResponse {
+	verdict: ContradictionVerdict;
+	winning_claim: WinningClaim;
+	confidence: number;
+	explanation: string;
+}
+
+export interface ContradictionResolutionOutcome {
+	edgeId: string;
+	entityId: string;
+	attribute: string;
+	verdict: ContradictionVerdict;
+	winningClaim: WinningClaim;
+	confidence: number;
+}
+
+export interface AnalyzeData {
+	pendingCount: number;
+	processedCount: number;
+	confirmedCount: number;
+	dismissedCount: number;
+	failedCount: number;
+	outcomes: ContradictionResolutionOutcome[];
+}
+
+export interface AnalyzeResult {
+	status: 'success' | 'partial' | 'failed';
+	data: AnalyzeData;
+	errors: StepError[];
+	metadata: {
+		duration_ms: number;
+		items_processed: number;
+		items_skipped: number;
+		items_cached: number;
+	};
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,4 +1,14 @@
 export type {
+	AnalyzeData,
+	AnalyzeInput,
+	AnalyzeResult,
+	ContradictionResolutionOutcome,
+	ContradictionResolutionResponse,
+	ContradictionVerdict,
+	WinningClaim,
+} from './analyze/index.js';
+export { execute as executeAnalyze } from './analyze/index.js';
+export type {
 	ChunkerConfig,
 	EmbedChunkInput,
 	EmbedChunkResult,

--- a/tests/specs/61_contradiction_resolution.test.ts
+++ b/tests/specs/61_contradiction_resolution.test.ts
@@ -1,0 +1,369 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const ENTITY_ID = '00000000-0000-0000-0000-000000610001';
+const VALID_EDGE_ID = '00000000-0000-0000-0000-000000610101';
+const INVALID_EDGE_ID = '00000000-0000-0000-0000-000000610102';
+const SOURCE_A_ID = '00000000-0000-0000-0000-000000610201';
+const SOURCE_B_ID = '00000000-0000-0000-0000-000000610202';
+const STORY_A_ID = '00000000-0000-0000-0000-000000610301';
+const STORY_B_ID = '00000000-0000-0000-0000-000000610302';
+
+let tmpDir: string;
+let pgAvailable = false;
+let enabledConfigPath: string;
+let disabledConfigPath: string;
+let contradictionsDisabledConfigPath: string;
+
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 60_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+			...opts?.env,
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function sqlString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function jsonLiteral(value: Record<string, unknown>): string {
+	return `${sqlString(JSON.stringify(value))}::jsonb`;
+}
+
+function writeAnalyzeConfig(options?: { enabled?: boolean; contradictions?: boolean }): string {
+	const base = readFileSync(EXAMPLE_CONFIG, 'utf-8');
+	const devModeEnabled = base.replace(/^dev_mode:\s*false$/m, 'dev_mode: true');
+	const replacement = [
+		'analysis:',
+		`  enabled: ${options?.enabled ?? true}`,
+		`  contradictions: ${options?.contradictions ?? true}`,
+		'  reliability: true',
+		'  evidence_chains: true',
+		'  spatio_temporal: true',
+		'  cluster_window_days: 30',
+		'',
+		'# --- Sparse Graph Thresholds ---',
+	].join('\n');
+
+	const updated = devModeEnabled.replace(/analysis:\n[\s\S]*?\n# --- Sparse Graph Thresholds ---/, replacement);
+	const configPath = join(tmpDir, `analyze-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
+	writeFileSync(configPath, updated, 'utf-8');
+	return configPath;
+}
+
+function cleanTestData(): void {
+	truncateMulderTables();
+}
+
+function seedSource(args: { id: string; filename: string }): void {
+	db.runSql(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, has_native_text, native_text_ratio, status, metadata)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.filename)}, ${sqlString(`gs://test/raw/${args.filename}`)}, ${sqlString(`${args.id}-hash`)}, true, 1.0, 'graphed', '{}'::jsonb)`,
+		].join(' '),
+	);
+}
+
+function seedStory(args: { id: string; sourceId: string; title: string; pageStart: number; pageEnd: number }): void {
+	db.runSql(
+		[
+			'INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, chunk_count, extraction_confidence, status, metadata)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.sourceId)}, ${sqlString(args.title)}, NULL, 'en', 'article', ${args.pageStart}, ${args.pageEnd}, ${sqlString(`gs://test/segments/${args.id}.md`)}, ${sqlString(`gs://test/segments/${args.id}.json`)}, 0, 0.9, 'graphed', '{}'::jsonb)`,
+		].join(' '),
+	);
+}
+
+function seedEntity(): void {
+	db.runSql(
+		[
+			'INSERT INTO entities (id, canonical_id, name, type, attributes, taxonomy_status)',
+			`VALUES (${sqlString(ENTITY_ID)}, NULL, 'Alice Adler', 'person', '{}'::jsonb, 'auto')`,
+		].join(' '),
+	);
+}
+
+function seedContradictionEdge(args: {
+	edgeId: string;
+	storyIdA: string;
+	storyIdB: string;
+	valueA: string;
+	valueB: string;
+	storyId?: string;
+}): void {
+	db.runSql(
+		[
+			'INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis)',
+			`VALUES (${sqlString(args.edgeId)}, ${sqlString(ENTITY_ID)}, ${sqlString(ENTITY_ID)}, 'contradiction_status', ${jsonLiteral({
+				attribute: 'status',
+				valueA: args.valueA,
+				valueB: args.valueB,
+				storyIdA: args.storyIdA,
+				storyIdB: args.storyIdB,
+			})}, NULL, ${sqlString(args.storyId ?? args.storyIdA)}, 'POTENTIAL_CONTRADICTION', NULL)`,
+		].join(' '),
+	);
+}
+
+function seedValidFixture(edgeId = VALID_EDGE_ID): void {
+	seedSource({ id: SOURCE_A_ID, filename: 'source-a.pdf' });
+	seedSource({ id: SOURCE_B_ID, filename: 'source-b.pdf' });
+	seedStory({ id: STORY_A_ID, sourceId: SOURCE_A_ID, title: 'Claim A Story', pageStart: 1, pageEnd: 1 });
+	seedStory({ id: STORY_B_ID, sourceId: SOURCE_B_ID, title: 'Claim B Story', pageStart: 2, pageEnd: 2 });
+	seedEntity();
+	seedContradictionEdge({
+		edgeId,
+		storyIdA: STORY_A_ID,
+		storyIdB: STORY_B_ID,
+		valueA: 'active',
+		valueB: 'inactive',
+	});
+}
+
+function edgeType(edgeId: string): string {
+	return db.runSql(`SELECT edge_type FROM entity_edges WHERE id = ${sqlString(edgeId)};`);
+}
+
+function edgeAnalysis(edgeId: string): Record<string, unknown> | null {
+	const raw = db.runSqlSafe(`SELECT analysis::text FROM entity_edges WHERE id = ${sqlString(edgeId)};`);
+	if (!raw || raw === 'null') {
+		return null;
+	}
+	return JSON.parse(raw);
+}
+
+describe('Spec 61 — Contradiction Resolution', () => {
+	beforeAll(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-61-'));
+		enabledConfigPath = writeAnalyzeConfig({ enabled: true, contradictions: true });
+		disabledConfigPath = writeAnalyzeConfig({ enabled: false, contradictions: true });
+		contradictionsDisabledConfigPath = writeAnalyzeConfig({ enabled: true, contradictions: false });
+
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
+			return;
+		}
+
+		ensureSchema();
+		cleanTestData();
+	}, 120_000);
+
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanTestData();
+	});
+
+	afterAll(() => {
+		if (pgAvailable) {
+			cleanTestData();
+		}
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('QA-01: contradiction analysis resolves pending edges into final verdicts', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('Analyze complete');
+		expect(edgeType(VALID_EDGE_ID)).toBe('CONFIRMED_CONTRADICTION');
+
+		const analysis = edgeAnalysis(VALID_EDGE_ID);
+		expect(analysis).toBeTruthy();
+		expect(String(analysis?.explanation ?? '')).not.toHaveLength(0);
+	});
+
+	it('QA-02: re-running the step is idempotent after all pending contradictions are resolved', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
+		const first = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(first.exitCode).toBe(0);
+		const firstType = edgeType(VALID_EDGE_ID);
+		const firstAnalysis = edgeAnalysis(VALID_EDGE_ID);
+
+		const second = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(second.exitCode).toBe(0);
+		expect(second.stderr).toContain('no pending contradiction edges');
+		expect(edgeType(VALID_EDGE_ID)).toBe(firstType);
+		expect(edgeAnalysis(VALID_EDGE_ID)).toEqual(firstAnalysis);
+	});
+
+	it('QA-03: no-op runs succeed cleanly when there is nothing to resolve', () => {
+		if (!pgAvailable) return;
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('no pending contradiction edges');
+		expect(db.runSql("SELECT COUNT(*) FROM entity_edges WHERE edge_type = 'POTENTIAL_CONTRADICTION';")).toBe('0');
+	});
+
+	it('QA-04: disabled contradiction analysis fails before any LLM work', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: disabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('ANALYZE_DISABLED');
+		expect(edgeType(VALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
+		expect(edgeAnalysis(VALID_EDGE_ID)).toBeNull();
+
+		const result2 = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: contradictionsDisabledConfigPath } });
+		expect(result2.exitCode).not.toBe(0);
+		expect(result2.stderr).toContain('ANALYZE_DISABLED');
+		expect(edgeType(VALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
+	});
+
+	it('QA-05: missing contradiction context fails without partial updates', () => {
+		if (!pgAvailable) return;
+		seedSource({ id: SOURCE_A_ID, filename: 'missing-context.pdf' });
+		seedStory({ id: STORY_A_ID, sourceId: SOURCE_A_ID, title: 'Only Story', pageStart: 1, pageEnd: 1 });
+		seedEntity();
+		seedContradictionEdge({
+			edgeId: VALID_EDGE_ID,
+			storyIdA: STORY_A_ID,
+			storyIdB: STORY_B_ID,
+			valueA: 'active',
+			valueB: 'inactive',
+		});
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('ANALYZE_CONTEXT_MISSING');
+		expect(edgeType(VALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
+		expect(edgeAnalysis(VALID_EDGE_ID)).toBeNull();
+	});
+
+	it('QA-06: mixed batches preserve successful verdicts and report partial failure', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+		seedContradictionEdge({
+			edgeId: INVALID_EDGE_ID,
+			storyIdA: STORY_A_ID,
+			storyIdB: '00000000-0000-0000-0000-000000619999',
+			valueA: 'onsite',
+			valueB: 'remote',
+			storyId: STORY_B_ID,
+		});
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('Analyze partial');
+		expect(result.stderr).toContain('ANALYZE_CONTEXT_MISSING');
+		expect(edgeType(VALID_EDGE_ID)).toBe('CONFIRMED_CONTRADICTION');
+		expect(edgeType(INVALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
+	});
+
+	it('CLI-01: --contradictions resolves pending contradiction edges and prints a summary table', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Edge ID');
+		expect(result.stdout).toContain('confirmed');
+		expect(result.stderr).toContain('Analyze complete');
+	});
+
+	it('CLI-02: running --contradictions twice reports zero processed contradictions on the second run', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
+		expect(runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } }).exitCode).toBe(0);
+		const result = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('no pending contradiction edges');
+	});
+
+	it('CLI-03: --contradictions --json exits non-zero because JSON output is not supported', () => {
+		const result = runCli(['analyze', '--contradictions', '--json'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(/unknown option|unexpected option/i);
+	});
+
+	it('CLI-04: --contradictions --full exits non-zero because --full belongs to M6-G7', () => {
+		const result = runCli(['analyze', '--contradictions', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G7');
+	});
+
+	it('CLI-05: no args exits non-zero and asks for an analysis selector', () => {
+		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('--contradictions');
+	});
+
+	it('CLI-06: --full exits non-zero because the full Analyze orchestrator is not implemented yet', () => {
+		const result = runCli(['analyze', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G7');
+	});
+
+	it('CLI-07: --reliability exits non-zero because source reliability scoring belongs to M6-G4', () => {
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G4');
+	});
+
+	it('CLI-08: --evidence-chains exits non-zero because evidence chains belong to M6-G5', () => {
+		const result = runCli(['analyze', '--evidence-chains'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G5');
+	});
+
+	it('CLI-09: --spatio-temporal exits non-zero because clustering belongs to M6-G6', () => {
+		const result = runCli(['analyze', '--spatio-temporal'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G6');
+	});
+});
+
+describe('CLI Smoke Tests: analyze', () => {
+	it('SMOKE-01: mulder analyze --help exits 0 and shows the available selectors', () => {
+		const result = runCli(['analyze', '--help'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Usage:');
+		expect(result.stdout).toContain('--contradictions');
+	});
+
+	it('SMOKE-02: mulder analyze --contradictions --reliability exits non-zero without crashing', () => {
+		const result = runCli(['analyze', '--contradictions', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G4');
+	});
+
+	it('SMOKE-03: mulder analyze --contradictions --spatio-temporal exits non-zero without crashing', () => {
+		const result = runCli(['analyze', '--contradictions', '--spatio-temporal'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G6');
+	});
+});


### PR DESCRIPTION
## Summary

Implements Spec 61 for roadmap step `M6-G3` by adding the first Analyze sub-step, wiring a new `mulder analyze --contradictions` CLI command, and resolving pending contradiction edges through Gemini structured output with persisted verdict metadata.

Closes #150
Implements: [docs/specs/61_contradiction_resolution.spec.md](docs/specs/61_contradiction_resolution.spec.md)
Roadmap: M6-G3

## Changes

- add Analyze-step error codes, core exports, and a deterministic dev-mode contradiction fixture
- add the contradiction-resolution prompt and the new `packages/pipeline/src/analyze/` execution flow
- wire the new `analyze` CLI command and pipeline barrel exports

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec turbo run build`
- `pnpm exec biome check .`
- targeted CLI sanity checks for `mulder analyze --help`, missing selector, and `--full`
- `pnpm exec vitest run tests/ --reporter=verbose` is currently blocked by pre-existing suite failures in this worktree because many older CLI specs expect a root `mulder.config.yaml` that is absent here
