### PR TITLE
[Evidence] Source reliability scoring — M6-G4

### DIFF
--- a/.codex/skills/auto-pilot/SKILL.md
+++ b/.codex/skills/auto-pilot/SKILL.md
@@ -41,11 +41,91 @@ Do not use this for small bug fixes or narrow edits that do not need a spec. Rou
 
 - Preserve the workflow and decision gates from the Claude command, but adapt them to Codex tools and policies.
 - Replace Claude-specific plan-mode wording with Codex planning. Use `update_plan` for substantial work and keep it current.
-- If the legacy workflow calls for subagents, you may delegate because the user explicitly asked for the auto-pilot workflow. Use workers for implementation or QA only when delegation materially helps.
+- Treat `auto-pilot` as a thin coordinator. Keep the main thread focused on workflow state, decisions, and summaries rather than detailed implementation or QA context.
+- Architect and finalize stay inline unless a blocking constraint forces a pause.
+- Implement, verify, and review run via fresh sub-agents by default because the user explicitly asked for the auto-pilot workflow and this workflow benefits from bounded phase context.
+- Prefer fresh sub-agents over reusing a long-lived worker across phases. For iteration retries, spawn a new phase agent with the latest structured failure evidence instead of carrying full prior chat history.
+- Do not fork the full parent context into phase agents unless a narrow blocking detail truly cannot be reconstructed from the repo plus the handoff payload.
 - If a referenced model name from the Claude prompt is unavailable, use the default current Codex model instead of inventing compatibility shims.
 - Do not carry over Claude-specific commit trailers or identity strings unless the user explicitly wants them.
 - Keep the state machine from the original command: target step, milestone, scope, spec path, issue, branch, PR, iteration count, verdict, failures.
 - Preserve the Claude command's stop conditions. Only ask the user for approval where the original workflow requires it, such as multi-spec splits or a genuinely blocking fork.
+
+## Coordinator Model
+
+Run `auto-pilot` as an orchestrator with a small explicit ledger:
+
+```text
+TARGET_STEP
+MILESTONE
+SCOPE
+SPEC_PATH
+SPEC_NUMBER
+ISSUE_NUMBER
+ISSUE_URL
+BRANCH_NAME
+PR_URL
+PR_NUMBER
+ITERATION
+MAX_ITERATIONS
+VERDICT
+FAILURES
+```
+
+The main agent should hold only this ledger plus brief phase summaries. Do not keep full implementation, test, or review reasoning in the parent thread once a phase is complete.
+
+## Phase Handoffs
+
+When spawning a phase sub-agent, pass only the minimum state it needs:
+
+- Implement handoff:
+  - `SPEC_PATH`
+  - `SPEC_NUMBER`
+  - `TARGET_STEP`
+  - `ISSUE_NUMBER`
+  - `ISSUE_URL`
+  - `BRANCH_NAME` if resuming
+  - `ITERATION`
+  - `FAILURES` only for iteration 2+
+- Verify handoff:
+  - `SPEC_PATH`
+  - `SPEC_NUMBER`
+  - `TARGET_STEP`
+  - `BRANCH_NAME`
+  - `ITERATION`
+  - any `TEST_MISMATCH` details reported by implementation
+- Review handoff:
+  - `SPEC_PATH`
+  - `SPEC_NUMBER`
+  - `TARGET_STEP`
+  - `BRANCH_NAME`
+  - `PR_NUMBER` or `PR_URL` when available
+
+Each handoff should tell the sub-agent to reconstruct domain context from repository files rather than parent-thread memory.
+
+## Required Sub-Agent Outputs
+
+Sub-agents must return compact, parseable summaries so the coordinator can update its ledger without inheriting the full phase context.
+
+- Implement must return:
+  - `BRANCH_NAME`
+  - `PR_URL`
+  - `PR_NUMBER`
+  - `FILES_CHANGED`
+  - `DEVIATIONS`
+  - `TEST_MISMATCH` when applicable
+- Verify must return:
+  - `TOTAL`
+  - `PASSED`
+  - `FAILED`
+  - `SKIPPED`
+  - `VERDICT`
+  - one failure block per failed condition
+- Review must return:
+  - `REVIEW_VERDICT`
+  - blocking `ISSUE` blocks when present
+
+After each phase, fold the result back into the ledger and continue from the summary only.
 
 ## State Tracking
 
@@ -93,15 +173,18 @@ Create and maintain a task list equivalent to the original workflow:
    - Stop for user approval on `multi-spec`.
    - Create the spec, create or update the GitHub issue, update project metadata if configured, and move roadmap state to in-progress when the workflow calls for it.
 3. Implement:
+   - Spawn a fresh implementation sub-agent.
    - Implement against the spec with roadmap, issue, branch, and PR traceability preserved.
    - Use Codex planning in place of Claude plan mode.
 4. Verify:
+   - Spawn a fresh verification sub-agent.
    - Verification is black-box only.
    - Write or rerun spec tests and run the regression suite as the original workflow specifies.
 5. Iterate:
-   - If verification fails and `ITERATION < MAX_ITERATIONS`, feed the failure evidence back into implementation and rerun verification.
+   - If verification fails and `ITERATION < MAX_ITERATIONS`, feed only the failure evidence back into a new implementation sub-agent and rerun verification with a new verification sub-agent.
    - Preserve the original PASS, FAIL, and PARTIAL handling semantics.
 6. Review:
+   - Spawn a fresh review sub-agent after QA passes.
    - Run the architect review gate before any merge or close-out.
 7. Finalize:
    - Merge, close, and update roadmap or issue state only when the workflow's gates pass.

--- a/.codex/skills/implement/SKILL.md
+++ b/.codex/skills/implement/SKILL.md
@@ -29,6 +29,8 @@ Do not modify `.claude/commands/implement.md`.
 - Do not write tests unless the user explicitly asks or the workflow being executed is `auto-pilot` and verification is being handled separately.
 - Keep the original stop conditions for ambiguous specs, missing dependencies, or oversized scopes.
 - Do not invent Claude-specific attribution trailers during commits.
+- Assume this skill may be run inside a fresh sub-agent with little or no parent-thread context. Reconstruct context from the spec, roadmap, functional spec, and codebase rather than relying on chat history.
+- If invoked from `auto-pilot`, treat the handoff payload as the only workflow memory you need: spec reference, issue or branch identifiers, iteration number, and any failure evidence for retries.
 - Preserve the original planning requirements:
   - file creation order
   - exports and imports per file
@@ -42,4 +44,18 @@ Do not modify `.claude/commands/implement.md`.
 
 ## Output
 
-Report the resolved spec, changed scope, branch name, PR reference if created, and any deviations from the spec.
+Return a compact handoff summary that a coordinator can parse without needing your full reasoning:
+
+```text
+BRANCH_NAME: <branch>
+PR_URL: <full URL or empty>
+PR_NUMBER: <number or empty>
+FILES_CHANGED: <comma-separated list>
+DEVIATIONS: <spec deviations or "none">
+```
+
+If this is a retry and a test assertion appears wrong relative to the spec, also report:
+
+```text
+TEST_MISMATCH: <test file:line> asserts <X>, but spec says <Y>
+```

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -29,7 +29,23 @@ Do not modify `.claude/commands/review.md`.
 - Do not turn the review into a style pass.
 - Preserve the Claude workflow's selective-depth rule: start with spec and diff, then read functional spec only when needed.
 - Preserve the original approval vocabulary: `APPROVED` or `CHANGES_REQUESTED`.
+- Assume this skill may run in a fresh sub-agent with only a spec reference plus branch or PR identifiers. Reconstruct the review context from repo files and the diff instead of relying on the parent thread.
 
 ## Output
 
-Return `APPROVED` or `CHANGES_REQUESTED`, with blocking findings first.
+Return a compact parseable summary first:
+
+```text
+REVIEW_VERDICT: APPROVED | CHANGES_REQUESTED
+```
+
+If changes are requested, include one block per issue:
+
+```text
+ISSUE: <short title>
+SEVERITY: blocking | warning
+FILE: <path:line>
+PROBLEM: <what's wrong>
+FIX: <specific fix needed>
+SPEC_REF: <violated spec section or CLAUDE.md rule>
+```

--- a/.codex/skills/verify/SKILL.md
+++ b/.codex/skills/verify/SKILL.md
@@ -27,6 +27,8 @@ Do not modify `.claude/commands/verify.md`.
 ## Codex Adaptation Rules
 
 - Keep the QA contract, CLI matrix handling, and smoke-test behavior from the Claude command.
+- Assume this skill may run in a fresh sub-agent. Build context only from the allowed spec sections, the allowed `CLAUDE.md` sections, the branch under test, and any narrow mismatch note from the coordinator.
+- If invoked from `auto-pilot`, treat implementation failure evidence and any `TEST_MISMATCH` note as inputs to evaluate, not as extra permission to read implementation internals.
 - Report evidence in a way that an implementation agent can act on directly.
 - If a test is wrong relative to the spec, fix the test and state the mismatch explicitly instead of forcing the implementation to match a bad assertion.
 - Preserve the verdict structure from the Claude workflow:
@@ -38,4 +40,27 @@ Do not modify `.claude/commands/verify.md`.
 
 ## Output
 
-Report totals, pass or fail counts, verdict, and concrete evidence for each failure.
+Return the verdict in a compact parseable form:
+
+```text
+TOTAL: <number of conditions>
+PASSED: <count>
+FAILED: <count>
+SKIPPED: <count>
+VERDICT: PASS | FAIL | PARTIAL
+```
+
+For each failure, include:
+
+```text
+FAILURE: <condition name>
+EXPECTED: <what should happen>
+ACTUAL: <what happened>
+EVIDENCE: <proof>
+```
+
+If you correct a bad test assertion, also report:
+
+```text
+TEST_FIX: <what assertion changed and why>
+```

--- a/apps/cli/src/commands/analyze.ts
+++ b/apps/cli/src/commands/analyze.ts
@@ -24,16 +24,12 @@ interface AnalyzeOptions {
 }
 
 function hasUnsupportedSelector(options: AnalyzeOptions): boolean {
-	return Boolean(options.full || options.reliability || options.evidenceChains || options.spatioTemporal);
+	return Boolean(options.full || options.evidenceChains || options.spatioTemporal);
 }
 
 function printUnsupportedSelectorMessage(options: AnalyzeOptions): void {
 	if (options.full) {
 		printError('--full is not implemented yet — it belongs to M6-G7');
-		return;
-	}
-	if (options.reliability) {
-		printError('--reliability is not implemented yet — it belongs to M6-G4');
 		return;
 	}
 	if (options.evidenceChains) {
@@ -45,7 +41,15 @@ function printUnsupportedSelectorMessage(options: AnalyzeOptions): void {
 	}
 }
 
+function countImplementedSelectors(options: AnalyzeOptions): number {
+	return Number(Boolean(options.contradictions)) + Number(Boolean(options.reliability));
+}
+
 function printOutcomeTable(result: AnalyzeResult): void {
+	if (result.data.mode !== 'contradictions') {
+		return;
+	}
+
 	if (result.data.outcomes.length === 0) {
 		return;
 	}
@@ -62,19 +66,49 @@ function printOutcomeTable(result: AnalyzeResult): void {
 	}
 }
 
+function printReliabilityTable(result: AnalyzeResult): void {
+	if (result.data.mode !== 'reliability') {
+		return;
+	}
+
+	if (result.data.outcomes.length === 0) {
+		return;
+	}
+
+	const header = `${'Source ID'.padEnd(36)}  ${'Filename'.padEnd(28)}  ${'Score'.padEnd(7)}  ${'Neighbors'.padEnd(9)}  Shared`;
+	const separator = '-'.repeat(header.length);
+	process.stdout.write(`${header}\n`);
+	process.stdout.write(`${separator}\n`);
+
+	for (const outcome of result.data.outcomes) {
+		const filename = outcome.filename.length > 26 ? `${outcome.filename.substring(0, 23)}...` : outcome.filename;
+		process.stdout.write(
+			`${outcome.sourceId.padEnd(36)}  ${filename.padEnd(28)}  ${outcome.reliabilityScore.toFixed(2).padEnd(7)}  ${String(outcome.neighborCount).padEnd(9)}  ${outcome.sharedEntityCount}\n`,
+		);
+	}
+}
+
 export function registerAnalyzeCommands(program: Command): void {
 	program
 		.command('analyze')
 		.description('Run graph-wide analysis passes')
 		.option('--contradictions', 'resolve pending contradiction edges')
-		.option('--reliability', 'score source reliability (not yet implemented)')
+		.option('--reliability', 'score source reliability')
 		.option('--evidence-chains', 'compute evidence chains (not yet implemented)')
 		.option('--spatio-temporal', 'compute spatio-temporal clusters (not yet implemented)')
 		.option('--full', 'run the full analyze orchestrator (not yet implemented)')
 		.action(
 			withErrorHandler(async (options: AnalyzeOptions) => {
-				if (!options.contradictions && !hasUnsupportedSelector(options)) {
+				const implementedSelectorCount = countImplementedSelectors(options);
+
+				if (implementedSelectorCount === 0 && !hasUnsupportedSelector(options)) {
 					printError('Provide an analysis selector such as --contradictions');
+					process.exit(1);
+					return;
+				}
+
+				if (implementedSelectorCount > 1) {
+					printError('Running multiple analyze selectors together is not implemented yet — use one selector at a time');
 					process.exit(1);
 					return;
 				}
@@ -104,28 +138,65 @@ export function registerAnalyzeCommands(program: Command): void {
 				const pool = getWorkerPool(config.gcp.cloud_sql);
 
 				try {
-					const result = await executeAnalyze({ contradictions: true }, config, services, pool, logger);
+					const result = await executeAnalyze(
+						{
+							contradictions: options.contradictions ?? false,
+							reliability: options.reliability ?? false,
+						},
+						config,
+						services,
+						pool,
+						logger,
+					);
 
-					printOutcomeTable(result);
+					if (result.data.mode === 'contradictions') {
+						printOutcomeTable(result);
+					} else {
+						printReliabilityTable(result);
+					}
 
 					for (const error of result.errors) {
 						printError(`[${error.code}] ${error.message}`);
 					}
 
-					if (result.data.pendingCount === 0) {
-						printSuccess(`Analyze complete: no pending contradiction edges found (${result.metadata.duration_ms}ms)`);
-						return;
-					}
+					if (result.data.mode === 'contradictions') {
+						if (result.data.pendingCount === 0) {
+							printSuccess(`Analyze complete: no pending contradiction edges found (${result.metadata.duration_ms}ms)`);
+							return;
+						}
 
-					const summary = `${result.data.processedCount} processed, ${result.data.confirmedCount} confirmed, ${result.data.dismissedCount} dismissed, ${result.data.failedCount} failed (${result.metadata.duration_ms}ms)`;
+						const summary = `${result.data.processedCount} processed, ${result.data.confirmedCount} confirmed, ${result.data.dismissedCount} dismissed, ${result.data.failedCount} failed (${result.metadata.duration_ms}ms)`;
 
-					if (result.status === 'failed') {
-						printError(`Analyze failed: ${summary}`);
-						process.exit(1);
-					} else if (result.status === 'partial') {
-						process.stderr.write(`Analyze partial: ${summary}\n`);
+						if (result.status === 'failed') {
+							printError(`Analyze failed: ${summary}`);
+							process.exit(1);
+						} else if (result.status === 'partial') {
+							process.stderr.write(`Analyze partial: ${summary}\n`);
+						} else {
+							printSuccess(`Analyze complete: ${summary}`);
+						}
 					} else {
-						printSuccess(`Analyze complete: ${summary}`);
+						if (result.data.outcomes.length === 0) {
+							printSuccess(`Analyze complete: no graph-connected sources found (${result.metadata.duration_ms}ms)`);
+							return;
+						}
+
+						if (result.data.belowThreshold) {
+							process.stderr.write(
+								`Analyze warning: corpus below meaningful reliability threshold (${result.data.sourceCount}/${result.data.threshold} graph-connected sources)\n`,
+							);
+						}
+
+						const summary = `${result.data.scoredCount} scored, ${result.data.sourceCount} graph-connected sources (${result.metadata.duration_ms}ms)`;
+
+						if (result.status === 'failed') {
+							printError(`Analyze failed: ${summary}`);
+							process.exit(1);
+						} else if (result.status === 'partial') {
+							process.stderr.write(`Analyze partial: ${summary}\n`);
+						} else {
+							printSuccess(`Analyze complete: ${summary}`);
+						}
 					}
 				} finally {
 					await closeAllPools();

--- a/devlog/2026-04-12-source-reliability-scoring.md
+++ b/devlog/2026-04-12-source-reliability-scoring.md
@@ -1,0 +1,8 @@
+---
+date: 2026-04-12
+type: implementation
+title: Source reliability scoring ships in `mulder analyze --reliability`
+tags: [evidence, analyze, reliability, pagerank, m6]
+---
+
+`mulder analyze --reliability` now computes and persists the roadmap’s first-pass `sources.reliability_score` signal from the existing corpus graph instead of leaving G4 as a stub. The implementation builds a source graph from cross-source shared entities, runs a weighted PageRank-style pass, normalizes the scores into `0..1`, and prints a dedicated CLI table plus sparse-corpus warnings without changing the existing contradiction flow. The non-obvious part was separating true no-op runs from graph shrinkage: reruns now clear stale scores only for sources that fall out of an otherwise valid graph, while fully disconnected corpora stay spec-compliant no-ops. The analyze contracts are now selector-aware, so later evidence-chain or credibility-profile work can extend the command surface without rewriting this reliability slice.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,7 +166,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 | 🟢 | G1 | v2.0 schema migrations (009-011) | §4.3 (grounding, evidence_chains, clusters tables) |
 | 🟢 | G2 | Ground step — `mulder ground <entity-id>` | §2.5, §1 (ground cmd) |
 | 🟢 | G3 | Contradiction resolution — `mulder analyze --contradictions` | §2.8 |
-| ⚪ | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
+| 🟢 | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
 | ⚪ | G5 | Evidence chains — `mulder analyze --evidence-chains` | §2.8, §4.3 (evidence_chains table) |
 | ⚪ | G6 | Spatio-temporal clustering | §2.8, §4.3 (clusters table) |
 | ⚪ | G7 | Analyze orchestrator — `mulder analyze --full` | §2.8, §1 (analyze cmd) |

--- a/docs/specs/62_source_reliability_scoring.spec.md
+++ b/docs/specs/62_source_reliability_scoring.spec.md
@@ -1,0 +1,113 @@
+---
+spec: "62"
+title: "Source Reliability Scoring"
+roadmap_step: M6-G4
+functional_spec: ["§2.8", "§5.3"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/152"
+created: 2026-04-12
+---
+
+# Spec 62: Source Reliability Scoring
+
+## 1. Objective
+
+Implement the second Analyze sub-step so `mulder analyze --reliability` computes a single `sources.reliability_score` float using a weighted PageRank-style graph over already-ingested source relationships, then persists the result for downstream evidence, export, and UI consumers. Per `§2.8`, the analysis runs over the full corpus rather than a single story, and per `§5.3` it must surface when the corpus is too sparse for the score to be considered stable. This spec intentionally delivers the current roadmap model; if the later credibility-profile design supersedes it, the scoring engine should be isolated enough to be swapped out without rewriting the CLI surface.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M6-G4` — Source reliability scoring — `mulder analyze --reliability`
+- **Target:** `packages/pipeline/src/analyze/types.ts`, `packages/pipeline/src/analyze/reliability.ts`, `packages/pipeline/src/analyze/index.ts`, `packages/pipeline/src/index.ts`, `apps/cli/src/commands/analyze.ts`
+- **In scope:** building a source graph from current corpus data, running weighted PageRank, normalizing scores into `0..1`, writing `sources.reliability_score`, exposing the `--reliability` CLI flow, and warning when corpus size is below `thresholds.source_reliability`
+- **Out of scope:** multi-dimensional credibility profiles (`M11-L1`), evidence chains (`M6-G5`), spatio-temporal clustering (`M6-G6`), the `--full` analyze orchestrator (`M6-G7`), schema changes, UI/API presentation work, or adding brand-new provenance/citation tables
+- **Constraints:** stay within the existing Analyze package and CLI surface; reuse current repositories and database schema; keep the scoring module isolated from contradiction resolution so later replacement or expansion remains tractable; and treat sparse-corpus handling as a warning/degradation concern, not a reason to fail the step
+
+## 3. Dependencies
+
+- **Requires:** Spec 14 (`M2-B2`) source repository, Spec 22 (`M3-C1`) story repository, Spec 24 (`M3-C3`) story-entity repository, Spec 35 (`M4-D5`) graph step outputs, and Spec 61 (`M6-G3`) Analyze command/step scaffolding
+- **Blocks:** evidence/report surfaces that want a persisted per-source reliability signal, and any future analyze orchestrator path that bundles reliability with other M6 analysis passes
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/pipeline/src/analyze/types.ts`** — extends the Analyze contract with reliability-selector input plus typed reliability outcomes and summary data
+2. **`packages/pipeline/src/analyze/reliability.ts`** — implements source-graph construction from current corpus data, weighted PageRank iteration, sparse-corpus warning logic, and score normalization
+3. **`packages/pipeline/src/analyze/index.ts`** — dispatches reliability analysis, persists `sources.reliability_score`, and returns a selector-specific result without breaking contradiction mode
+4. **`packages/pipeline/src/index.ts`** — re-exports the updated Analyze types and executor surface
+5. **`apps/cli/src/commands/analyze.ts`** — enables `--reliability`, prints a reliability table/summary, rejects unsupported selector combinations, and preserves current error handling for the still-unimplemented analysis modes
+
+### 4.2 Database Changes
+
+None. This step uses the existing `sources.reliability_score FLOAT` column introduced in the core schema.
+
+### 4.3 Config Changes
+
+None. The step uses existing config:
+
+- `analysis.enabled`
+- `analysis.reliability`
+- `thresholds.source_reliability`
+
+### 4.4 Integration Points
+
+- Build the source graph from existing graph-era data already in PostgreSQL: sources, stories, and `story_entities`
+- Represent source-to-source links as weighted edges based on shared entities across distinct sources; because the current schema has no dedicated citation table, entity co-occurrence is the authoritative graph input for this step
+- Run weighted PageRank over that graph, normalize the converged values into `0..1`, and persist them with `updateSource(...)`
+- The Analyze CLI must allow exactly one active implemented selector at a time: `--contradictions` or `--reliability`
+- Sparse-corpus handling should annotate the result and CLI summary when eligible source count is below `thresholds.source_reliability`, but still persist computed scores so existing consumers can use the interim signal
+
+### 4.5 Implementation Phases
+
+Single phase — implement the typed reliability contract, scoring engine, Analyze-step wiring, and CLI support in one coherent change. The work is small enough to land as one vertical slice without a multi-PR split.
+
+## 5. QA Contract
+
+1. **QA-01: Reliability analysis scores graph-connected sources and persists results**
+   - Given: the database contains at least three graph-ready sources with stories that share entities across source boundaries, and `analysis.enabled=true` with `analysis.reliability=true`
+   - When: `mulder analyze --reliability` runs successfully
+   - Then: the command exits `0`, prints a scored-source summary, and every scored source has a non-null `sources.reliability_score` between `0` and `1`
+
+2. **QA-02: Re-running reliability analysis is idempotent for unchanged corpus data**
+   - Given: the same graph-connected sources have already been scored once
+   - When: `mulder analyze --reliability` runs again without any new stories, entities, or source links
+   - Then: the command exits `0`, reports the same number of scored sources, and previously stored reliability scores remain unchanged within exact persisted precision
+
+3. **QA-03: Sparse corpora succeed with a degradation warning**
+   - Given: eligible source count is below `thresholds.source_reliability` but at least one graph-connected source pair exists
+   - When: `mulder analyze --reliability` runs
+   - Then: the command exits `0`, persists reliability scores, and clearly warns that the corpus is below the meaningful reliability threshold
+
+4. **QA-04: Disabled reliability analysis fails before writing scores**
+   - Given: `analysis.enabled=false` or `analysis.reliability=false`
+   - When: `mulder analyze --reliability` runs
+   - Then: the command exits non-zero with an Analyze-step disabled error, and no `sources.reliability_score` values are modified
+
+5. **QA-05: No-op runs succeed when no source graph can be formed**
+   - Given: the database has no graph-connected sources (for example, no stories, no story-entity links, or only isolated single-source entities)
+   - When: `mulder analyze --reliability` runs
+   - Then: the command exits `0`, prints a clear “nothing to analyze” style summary, and makes no score updates
+
+## 5b. CLI Test Matrix
+
+### `mulder analyze --reliability`
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-01 | `--reliability` | Exit `0`, scores all eligible sources and prints a reliability table |
+| CLI-02 | `--reliability` *(run twice)* | Exit `0`, second run preserves the first run’s scores |
+| CLI-03 | `--contradictions --reliability` | Exit non-zero, because multi-selector analyze orchestration belongs to `M6-G7` |
+| CLI-04 | `--reliability --full` | Exit non-zero, because `--full` is not implemented yet |
+
+### Selector validation
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-05 | *(no args)* | Exit non-zero, usage/help indicates that an analysis selector is required |
+| CLI-06 | `--full` | Exit non-zero, because the full Analyze orchestrator is not implemented yet |
+| CLI-07 | `--evidence-chains` | Exit non-zero, because evidence chains belong to `M6-G5` |
+| CLI-08 | `--spatio-temporal` | Exit non-zero, because clustering belongs to `M6-G6` |
+
+## 6. Cost Considerations
+
+None — no paid API calls. This step is pure PostgreSQL computation over existing graph data.

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -59,7 +59,7 @@ export interface UpdateSourceInput {
 	hasNativeText?: boolean;
 	nativeTextRatio?: number;
 	status?: SourceStatus;
-	reliabilityScore?: number;
+	reliabilityScore?: number | null;
 	tags?: string[];
 	metadata?: Record<string, unknown>;
 }

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -18,26 +18,33 @@ import {
 	findStoryById,
 	renderPrompt,
 	updateEdge,
+	updateSource,
 } from '@mulder/core';
 import type pg from 'pg';
 import { z } from 'zod';
 import { z as z3 } from 'zod/v3';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { computeSourceReliability } from './reliability.js';
 import type {
-	AnalyzeData,
 	AnalyzeInput,
 	AnalyzeResult,
+	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
 	ContradictionResolutionResponse,
+	ReliabilityAnalyzeData,
+	SourceReliabilityOutcome,
 } from './types.js';
 
 export type {
 	AnalyzeData,
 	AnalyzeInput,
 	AnalyzeResult,
+	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
 	ContradictionResolutionResponse,
 	ContradictionVerdict,
+	ReliabilityAnalyzeData,
+	SourceReliabilityOutcome,
 	WinningClaim,
 } from './types.js';
 
@@ -282,16 +289,37 @@ async function resolveEdge(
 	};
 }
 
-function makeData(outcomes: ContradictionResolutionOutcome[], failedCount: number, pendingCount: number): AnalyzeData {
+function makeContradictionData(
+	outcomes: ContradictionResolutionOutcome[],
+	failedCount: number,
+	pendingCount: number,
+): ContradictionAnalyzeData {
 	const confirmedCount = outcomes.filter((outcome) => outcome.verdict === 'confirmed').length;
 	const dismissedCount = outcomes.filter((outcome) => outcome.verdict === 'dismissed').length;
 
 	return {
+		mode: 'contradictions',
 		pendingCount,
 		processedCount: outcomes.length,
 		confirmedCount,
 		dismissedCount,
 		failedCount,
+		outcomes,
+	};
+}
+
+function makeReliabilityData(
+	sourceCount: number,
+	threshold: number,
+	belowThreshold: boolean,
+	outcomes: SourceReliabilityOutcome[],
+): ReliabilityAnalyzeData {
+	return {
+		mode: 'reliability',
+		sourceCount,
+		scoredCount: outcomes.length,
+		threshold,
+		belowThreshold,
 		outcomes,
 	};
 }
@@ -303,59 +331,192 @@ export async function execute(
 	pool: pg.Pool | undefined,
 	logger: Logger,
 ): Promise<AnalyzeResult> {
-	const log = createChildLogger(logger, { step: STEP_NAME, contradictions: input.contradictions });
+	const log = createChildLogger(logger, {
+		step: STEP_NAME,
+		contradictions: input.contradictions ?? false,
+		reliability: input.reliability ?? false,
+	});
 	const startTime = performance.now();
 
 	if (!pool) {
 		throw new AnalyzeError('Database pool is required for analyze step', ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED);
 	}
 
-	if (!input.contradictions || !config.analysis.enabled || !config.analysis.contradictions) {
+	const selectedModes = [
+		input.contradictions ? 'contradictions' : null,
+		input.reliability ? 'reliability' : null,
+	].filter((value): value is 'contradictions' | 'reliability' => value !== null);
+	if (selectedModes.length !== 1) {
+		throw new AnalyzeError('Exactly one analyze selector must be enabled', ANALYZE_ERROR_CODES.ANALYZE_DISABLED, {
+			context: { selectedModes },
+		});
+	}
+
+	if (input.contradictions) {
+		if (!config.analysis.enabled || !config.analysis.contradictions) {
+			throw new AnalyzeError(
+				'Contradiction analysis is disabled in the active configuration',
+				ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
+				{
+					context: {
+						enabled: config.analysis.enabled,
+						contradictions: config.analysis.contradictions,
+					},
+				},
+			);
+		}
+
+		const pendingEdges = await findEdgesByType(pool, 'POTENTIAL_CONTRADICTION');
+		const outcomes: ContradictionResolutionOutcome[] = [];
+		const errors: StepError[] = [];
+
+		for (const edge of pendingEdges) {
+			try {
+				const context = await hydrateContext(pool, edge);
+				const outcome = await resolveEdge(context, config, services, pool);
+				outcomes.push(outcome);
+			} catch (cause: unknown) {
+				const analyzeError =
+					cause instanceof AnalyzeError
+						? cause
+						: new AnalyzeError(
+								`Unexpected analyze failure for edge ${edge.id}`,
+								ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED,
+								{
+									cause,
+									context: { edgeId: edge.id },
+								},
+							);
+				errors.push(toStepError(analyzeError, edge.id));
+				log.warn({ err: cause, edgeId: edge.id }, 'Analyze failed for contradiction edge — continuing');
+			}
+		}
+
+		const data = makeContradictionData(outcomes, errors.length, pendingEdges.length);
+		const status = errors.length === 0 ? 'success' : outcomes.length > 0 ? 'partial' : 'failed';
+		const durationMs = Math.round(performance.now() - startTime);
+
+		log.info(
+			{
+				mode: data.mode,
+				pendingCount: data.pendingCount,
+				processedCount: data.processedCount,
+				confirmedCount: data.confirmedCount,
+				dismissedCount: data.dismissedCount,
+				failedCount: data.failedCount,
+				duration_ms: durationMs,
+			},
+			'Analyze step completed',
+		);
+
+		return {
+			status,
+			data,
+			errors,
+			metadata: {
+				duration_ms: durationMs,
+				items_processed: data.processedCount,
+				items_skipped: 0,
+				items_cached: 0,
+			},
+		};
+	}
+
+	if (!config.analysis.enabled || !config.analysis.reliability) {
 		throw new AnalyzeError(
-			'Contradiction analysis is disabled in the active configuration',
+			'Source reliability analysis is disabled in the active configuration',
 			ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
 			{
 				context: {
 					enabled: config.analysis.enabled,
-					contradictions: config.analysis.contradictions,
+					reliability: config.analysis.reliability,
 				},
 			},
 		);
 	}
 
-	const pendingEdges = await findEdgesByType(pool, 'POTENTIAL_CONTRADICTION');
-	const outcomes: ContradictionResolutionOutcome[] = [];
+	const computation = await computeSourceReliability(pool, config.thresholds.source_reliability);
+	const persistedOutcomes: SourceReliabilityOutcome[] = [];
 	const errors: StepError[] = [];
+	const computedSourceIds = new Set(computation.outcomes.map((outcome) => outcome.sourceId));
+	const staleSourceIds =
+		computation.outcomes.length === 0
+			? []
+			: (
+					await pool.query<{ id: string }>('SELECT id FROM sources WHERE reliability_score IS NOT NULL ORDER BY id')
+				).rows
+					.map((row) => row.id)
+					.filter((sourceId) => !computedSourceIds.has(sourceId));
 
-	for (const edge of pendingEdges) {
+	for (const outcome of computation.outcomes) {
 		try {
-			const context = await hydrateContext(pool, edge);
-			const outcome = await resolveEdge(context, config, services, pool);
-			outcomes.push(outcome);
+			await updateSource(pool, outcome.sourceId, {
+				reliabilityScore: outcome.reliabilityScore,
+			});
+			persistedOutcomes.push(outcome);
 		} catch (cause: unknown) {
 			const analyzeError =
 				cause instanceof AnalyzeError
 					? cause
-					: new AnalyzeError(`Unexpected analyze failure for edge ${edge.id}`, ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED, {
-							cause,
-							context: { edgeId: edge.id },
-						});
-			errors.push(toStepError(analyzeError, edge.id));
-			log.warn({ err: cause, edgeId: edge.id }, 'Analyze failed for contradiction edge — continuing');
+					: new AnalyzeError(
+							`Failed to persist source reliability for source ${outcome.sourceId}`,
+							ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED,
+							{
+								cause,
+								context: { sourceId: outcome.sourceId },
+							},
+						);
+			errors.push({
+				code: analyzeError.code,
+				message: `${outcome.sourceId}: ${analyzeError.message}`,
+			});
+			log.warn({ err: cause, sourceId: outcome.sourceId }, 'Analyze failed to persist source reliability — continuing');
 		}
 	}
 
-	const data = makeData(outcomes, errors.length, pendingEdges.length);
-	const status = errors.length === 0 ? 'success' : outcomes.length > 0 ? 'partial' : 'failed';
+	for (const sourceId of staleSourceIds) {
+		try {
+			await updateSource(pool, sourceId, {
+				reliabilityScore: null,
+			});
+		} catch (cause: unknown) {
+			const analyzeError =
+				cause instanceof AnalyzeError
+					? cause
+					: new AnalyzeError(
+							`Failed to clear stale source reliability for source ${sourceId}`,
+							ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED,
+							{
+								cause,
+								context: { sourceId },
+							},
+						);
+			errors.push({
+				code: analyzeError.code,
+				message: `${sourceId}: ${analyzeError.message}`,
+			});
+			log.warn({ err: cause, sourceId }, 'Analyze failed to clear stale source reliability — continuing');
+		}
+	}
+
+	const data = makeReliabilityData(
+		computation.sourceCount,
+		computation.threshold,
+		computation.belowThreshold,
+		persistedOutcomes,
+	);
+	const status = errors.length === 0 ? 'success' : persistedOutcomes.length > 0 ? 'partial' : 'failed';
 	const durationMs = Math.round(performance.now() - startTime);
 
 	log.info(
 		{
-			pendingCount: data.pendingCount,
-			processedCount: data.processedCount,
-			confirmedCount: data.confirmedCount,
-			dismissedCount: data.dismissedCount,
-			failedCount: data.failedCount,
+			mode: data.mode,
+			sourceCount: data.sourceCount,
+			scoredCount: data.scoredCount,
+			threshold: data.threshold,
+			belowThreshold: data.belowThreshold,
+			clearedCount: staleSourceIds.length,
+			failedCount: errors.length,
 			duration_ms: durationMs,
 		},
 		'Analyze step completed',
@@ -367,7 +528,7 @@ export async function execute(
 		errors,
 		metadata: {
 			duration_ms: durationMs,
-			items_processed: data.processedCount,
+			items_processed: data.scoredCount,
 			items_skipped: 0,
 			items_cached: 0,
 		},

--- a/packages/pipeline/src/analyze/reliability.ts
+++ b/packages/pipeline/src/analyze/reliability.ts
@@ -1,0 +1,174 @@
+/**
+ * Source reliability scoring for the Analyze step.
+ *
+ * Builds a source-to-source graph from shared entities across sources and
+ * computes a weighted PageRank-style score that is later normalized to 0..1.
+ *
+ * @see docs/specs/62_source_reliability_scoring.spec.md §4.1
+ * @see docs/functional-spec.md §2.8, §5.3
+ */
+
+import { findAllSources } from '@mulder/core';
+import type pg from 'pg';
+import type { SourceReliabilityOutcome } from './types.js';
+
+const DAMPING_FACTOR = 0.85;
+const EPSILON = 1e-8;
+const MAX_ITERATIONS = 100;
+const SCORE_PRECISION = 6;
+
+interface SourceEdgeRow {
+	source_id_a: string;
+	source_id_b: string;
+	shared_entities: string;
+}
+
+export interface ReliabilityComputation {
+	sourceCount: number;
+	threshold: number;
+	belowThreshold: boolean;
+	outcomes: SourceReliabilityOutcome[];
+}
+
+function roundScore(value: number): number {
+	return Number(value.toFixed(SCORE_PRECISION));
+}
+
+function buildAdjacency(edges: SourceEdgeRow[]): Map<string, Map<string, number>> {
+	const adjacency = new Map<string, Map<string, number>>();
+
+	for (const edge of edges) {
+		const weight = Number.parseInt(edge.shared_entities, 10);
+		if (!Number.isFinite(weight) || weight <= 0) {
+			continue;
+		}
+
+		const neighborsA = adjacency.get(edge.source_id_a) ?? new Map<string, number>();
+		neighborsA.set(edge.source_id_b, weight);
+		adjacency.set(edge.source_id_a, neighborsA);
+
+		const neighborsB = adjacency.get(edge.source_id_b) ?? new Map<string, number>();
+		neighborsB.set(edge.source_id_a, weight);
+		adjacency.set(edge.source_id_b, neighborsB);
+	}
+
+	return adjacency;
+}
+
+function runPageRank(nodeIds: string[], adjacency: Map<string, Map<string, number>>): Map<string, number> {
+	const nodeCount = nodeIds.length;
+	const initialScore = 1 / nodeCount;
+	let scores = new Map(nodeIds.map((nodeId) => [nodeId, initialScore]));
+
+	for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+		const nextScores = new Map<string, number>();
+		let totalDelta = 0;
+
+		for (const nodeId of nodeIds) {
+			let incomingContribution = 0;
+
+			for (const otherNodeId of nodeIds) {
+				if (otherNodeId === nodeId) {
+					continue;
+				}
+
+				const outgoing = adjacency.get(otherNodeId);
+				const weightToNode = outgoing?.get(nodeId);
+				if (!outgoing || weightToNode === undefined) {
+					continue;
+				}
+
+				let totalOutgoingWeight = 0;
+				for (const weight of outgoing.values()) {
+					totalOutgoingWeight += weight;
+				}
+
+				if (totalOutgoingWeight > 0) {
+					incomingContribution += (scores.get(otherNodeId) ?? 0) * (weightToNode / totalOutgoingWeight);
+				}
+			}
+
+			const nextScore = (1 - DAMPING_FACTOR) / nodeCount + DAMPING_FACTOR * incomingContribution;
+			nextScores.set(nodeId, nextScore);
+			totalDelta += Math.abs(nextScore - (scores.get(nodeId) ?? 0));
+		}
+
+		scores = nextScores;
+		if (totalDelta < EPSILON) {
+			break;
+		}
+	}
+
+	return scores;
+}
+
+export async function computeSourceReliability(pool: pg.Pool, threshold: number): Promise<ReliabilityComputation> {
+	const result = await pool.query<SourceEdgeRow>(
+		`SELECT
+		   LEAST(st1.source_id, st2.source_id) AS source_id_a,
+		   GREATEST(st1.source_id, st2.source_id) AS source_id_b,
+		   COUNT(DISTINCT se1.entity_id)::text AS shared_entities
+		 FROM story_entities se1
+		 JOIN stories st1 ON st1.id = se1.story_id
+		 JOIN story_entities se2
+		   ON se2.entity_id = se1.entity_id
+		  AND se2.story_id <> se1.story_id
+		 JOIN stories st2 ON st2.id = se2.story_id
+		 WHERE st1.source_id <> st2.source_id
+		 GROUP BY 1, 2
+		 ORDER BY 1, 2`,
+	);
+
+	const adjacency = buildAdjacency(result.rows);
+	const nodeIds = Array.from(adjacency.keys()).sort();
+
+	if (nodeIds.length === 0) {
+		return {
+			sourceCount: 0,
+			threshold,
+			belowThreshold: true,
+			outcomes: [],
+		};
+	}
+
+	const allSources = await findAllSources(pool, { limit: 100000 });
+	const sourceById = new Map(allSources.map((source) => [source.id, source]));
+
+	const rawScores = runPageRank(nodeIds, adjacency);
+	const maxRawScore = Math.max(...Array.from(rawScores.values()));
+
+	const outcomes = nodeIds
+		.map((sourceId) => {
+			const neighbors = adjacency.get(sourceId) ?? new Map<string, number>();
+			let sharedEntityCount = 0;
+			for (const weight of neighbors.values()) {
+				sharedEntityCount += weight;
+			}
+
+			const rawScore = rawScores.get(sourceId) ?? 0;
+			const reliabilityScore = maxRawScore > 0 ? rawScore / maxRawScore : 0;
+			const source = sourceById.get(sourceId);
+
+			return {
+				sourceId,
+				filename: source?.filename ?? sourceId,
+				rawScore: roundScore(rawScore),
+				reliabilityScore: roundScore(reliabilityScore),
+				neighborCount: neighbors.size,
+				sharedEntityCount,
+			};
+		})
+		.sort((left, right) => {
+			if (right.reliabilityScore !== left.reliabilityScore) {
+				return right.reliabilityScore - left.reliabilityScore;
+			}
+			return left.filename.localeCompare(right.filename);
+		});
+
+	return {
+		sourceCount: nodeIds.length,
+		threshold,
+		belowThreshold: nodeIds.length < threshold,
+		outcomes,
+	};
+}

--- a/packages/pipeline/src/analyze/types.ts
+++ b/packages/pipeline/src/analyze/types.ts
@@ -8,7 +8,8 @@
 import type { StepError } from '@mulder/core';
 
 export interface AnalyzeInput {
-	contradictions: boolean;
+	contradictions?: boolean;
+	reliability?: boolean;
 }
 
 export type ContradictionVerdict = 'confirmed' | 'dismissed';
@@ -31,7 +32,8 @@ export interface ContradictionResolutionOutcome {
 	confidence: number;
 }
 
-export interface AnalyzeData {
+export interface ContradictionAnalyzeData {
+	mode: 'contradictions';
 	pendingCount: number;
 	processedCount: number;
 	confirmedCount: number;
@@ -39,6 +41,26 @@ export interface AnalyzeData {
 	failedCount: number;
 	outcomes: ContradictionResolutionOutcome[];
 }
+
+export interface SourceReliabilityOutcome {
+	sourceId: string;
+	filename: string;
+	rawScore: number;
+	reliabilityScore: number;
+	neighborCount: number;
+	sharedEntityCount: number;
+}
+
+export interface ReliabilityAnalyzeData {
+	mode: 'reliability';
+	sourceCount: number;
+	scoredCount: number;
+	threshold: number;
+	belowThreshold: boolean;
+	outcomes: SourceReliabilityOutcome[];
+}
+
+export type AnalyzeData = ContradictionAnalyzeData | ReliabilityAnalyzeData;
 
 export interface AnalyzeResult {
 	status: 'success' | 'partial' | 'failed';

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -2,9 +2,12 @@ export type {
 	AnalyzeData,
 	AnalyzeInput,
 	AnalyzeResult,
+	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
 	ContradictionResolutionResponse,
 	ContradictionVerdict,
+	ReliabilityAnalyzeData,
+	SourceReliabilityOutcome,
 	WinningClaim,
 } from './analyze/index.js';
 export { execute as executeAnalyze } from './analyze/index.js';

--- a/tests/specs/37_qa_error_code_coverage.test.ts
+++ b/tests/specs/37_qa_error_code_coverage.test.ts
@@ -209,7 +209,9 @@ describe('Spec 33 — QA-5: Error Code Coverage', () => {
 			SegmentError: { codeType: 'SegmentErrorCode', codeGroup: 'SEGMENT_ERROR_CODES' },
 			EnrichError: { codeType: 'EnrichErrorCode', codeGroup: 'ENRICH_ERROR_CODES' },
 			EmbedError: { codeType: 'EmbedErrorCode', codeGroup: 'EMBED_ERROR_CODES' },
+			GroundError: { codeType: 'GroundErrorCode', codeGroup: 'GROUND_ERROR_CODES' },
 			GraphError: { codeType: 'GraphErrorCode', codeGroup: 'GRAPH_ERROR_CODES' },
+			AnalyzeError: { codeType: 'AnalyzeErrorCode', codeGroup: 'ANALYZE_ERROR_CODES' },
 			RetrievalError: { codeType: 'RetrievalErrorCode', codeGroup: 'RETRIEVAL_ERROR_CODES' },
 			PromptError: { codeType: 'PromptErrorCode', codeGroup: 'PROMPT_ERROR_CODES' },
 		};

--- a/tests/specs/61_contradiction_resolution.test.ts
+++ b/tests/specs/61_contradiction_resolution.test.ts
@@ -119,13 +119,15 @@ function seedContradictionEdge(args: {
 	db.runSql(
 		[
 			'INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis)',
-			`VALUES (${sqlString(args.edgeId)}, ${sqlString(ENTITY_ID)}, ${sqlString(ENTITY_ID)}, 'contradiction_status', ${jsonLiteral({
-				attribute: 'status',
-				valueA: args.valueA,
-				valueB: args.valueB,
-				storyIdA: args.storyIdA,
-				storyIdB: args.storyIdB,
-			})}, NULL, ${sqlString(args.storyId ?? args.storyIdA)}, 'POTENTIAL_CONTRADICTION', NULL)`,
+			`VALUES (${sqlString(args.edgeId)}, ${sqlString(ENTITY_ID)}, ${sqlString(ENTITY_ID)}, 'contradiction_status', ${jsonLiteral(
+				{
+					attribute: 'status',
+					valueA: args.valueA,
+					valueB: args.valueB,
+					storyIdA: args.storyIdA,
+					storyIdB: args.storyIdB,
+				},
+			)}, NULL, ${sqlString(args.storyId ?? args.storyIdA)}, 'POTENTIAL_CONTRADICTION', NULL)`,
 		].join(' '),
 	);
 }
@@ -235,7 +237,9 @@ describe('Spec 61 — Contradiction Resolution', () => {
 		expect(edgeType(VALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
 		expect(edgeAnalysis(VALID_EDGE_ID)).toBeNull();
 
-		const result2 = runCli(['analyze', '--contradictions'], { env: { MULDER_CONFIG: contradictionsDisabledConfigPath } });
+		const result2 = runCli(['analyze', '--contradictions'], {
+			env: { MULDER_CONFIG: contradictionsDisabledConfigPath },
+		});
 		expect(result2.exitCode).not.toBe(0);
 		expect(result2.stderr).toContain('ANALYZE_DISABLED');
 		expect(edgeType(VALID_EDGE_ID)).toBe('POTENTIAL_CONTRADICTION');
@@ -326,10 +330,13 @@ describe('Spec 61 — Contradiction Resolution', () => {
 		expect(result.stderr).toContain('M6-G7');
 	});
 
-	it('CLI-07: --reliability exits non-zero because source reliability scoring belongs to M6-G4', () => {
+	it('CLI-07: --reliability now succeeds because source reliability scoring is implemented', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
 		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G4');
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
 	it('CLI-08: --evidence-chains exits non-zero because evidence chains belong to M6-G5', () => {
@@ -354,9 +361,11 @@ describe('CLI Smoke Tests: analyze', () => {
 	});
 
 	it('SMOKE-02: mulder analyze --contradictions --reliability exits non-zero without crashing', () => {
-		const result = runCli(['analyze', '--contradictions', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		const result = runCli(['analyze', '--contradictions', '--reliability'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G4');
+		expect(result.stderr).toContain('one selector at a time');
 	});
 
 	it('SMOKE-03: mulder analyze --contradictions --spatio-temporal exits non-zero without crashing', () => {

--- a/tests/specs/62_source_reliability_scoring.test.ts
+++ b/tests/specs/62_source_reliability_scoring.test.ts
@@ -1,0 +1,379 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const SOURCE_A_ID = '00000000-0000-0000-0000-000000620101';
+const SOURCE_B_ID = '00000000-0000-0000-0000-000000620102';
+const SOURCE_C_ID = '00000000-0000-0000-0000-000000620103';
+const STORY_A_ID = '00000000-0000-0000-0000-000000620201';
+const STORY_B_ID = '00000000-0000-0000-0000-000000620202';
+const STORY_C_ID = '00000000-0000-0000-0000-000000620203';
+const ENTITY_SHARED_AB = '00000000-0000-0000-0000-000000620301';
+const ENTITY_SHARED_BC = '00000000-0000-0000-0000-000000620302';
+const ENTITY_ISOLATED = '00000000-0000-0000-0000-000000620303';
+
+let tmpDir: string;
+let pgAvailable = false;
+let enabledConfigPath: string;
+let disabledConfigPath: string;
+let reliabilityDisabledConfigPath: string;
+let sparseThresholdConfigPath: string;
+
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 60_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+			...opts?.env,
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function sqlString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function writeAnalyzeConfig(options?: { enabled?: boolean; reliability?: boolean; threshold?: number }): string {
+	const base = readFileSync(EXAMPLE_CONFIG, 'utf-8');
+	const devModeEnabled = base.replace(/^dev_mode:\s*false$/m, 'dev_mode: true');
+	const analysisReplacement = [
+		'analysis:',
+		`  enabled: ${options?.enabled ?? true}`,
+		'  contradictions: true',
+		`  reliability: ${options?.reliability ?? true}`,
+		'  evidence_chains: true',
+		'  spatio_temporal: true',
+		'  cluster_window_days: 30',
+		'',
+		'# --- Sparse Graph Thresholds ---',
+	].join('\n');
+
+	const withAnalysis = devModeEnabled.replace(
+		/analysis:\n[\s\S]*?\n# --- Sparse Graph Thresholds ---/,
+		analysisReplacement,
+	);
+	const threshold = options?.threshold ?? 50;
+	const withThreshold = withAnalysis.replace(/source_reliability:\s*\d+/, `source_reliability: ${threshold}`);
+	const configPath = join(tmpDir, `analyze-62-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
+	writeFileSync(configPath, withThreshold, 'utf-8');
+	return configPath;
+}
+
+function cleanTestData(): void {
+	truncateMulderTables();
+}
+
+function seedSource(args: { id: string; filename: string }): void {
+	db.runSql(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, has_native_text, native_text_ratio, status, metadata)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.filename)}, ${sqlString(`gs://test/raw/${args.filename}`)}, ${sqlString(`${args.id}-hash`)}, true, 1.0, 'graphed', '{}'::jsonb)`,
+		].join(' '),
+	);
+}
+
+function seedStory(args: { id: string; sourceId: string; title: string }): void {
+	db.runSql(
+		[
+			'INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, chunk_count, extraction_confidence, status, metadata)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.sourceId)}, ${sqlString(args.title)}, NULL, 'en', 'article', 1, 1, ${sqlString(`gs://test/segments/${args.id}.md`)}, ${sqlString(`gs://test/segments/${args.id}.json`)}, 0, 0.9, 'graphed', '{}'::jsonb)`,
+		].join(' '),
+	);
+}
+
+function seedEntity(args: { id: string; name: string }): void {
+	db.runSql(
+		[
+			'INSERT INTO entities (id, canonical_id, name, type, attributes, taxonomy_status)',
+			`VALUES (${sqlString(args.id)}, NULL, ${sqlString(args.name)}, 'person', '{}'::jsonb, 'auto')`,
+		].join(' '),
+	);
+}
+
+function linkStoryEntity(storyId: string, entityId: string): void {
+	db.runSql(
+		`INSERT INTO story_entities (story_id, entity_id, confidence, mention_count) VALUES (${sqlString(storyId)}, ${sqlString(entityId)}, 0.9, 1)`,
+	);
+}
+
+function unlinkStoryEntity(storyId: string, entityId: string): void {
+	db.runSql(`DELETE FROM story_entities WHERE story_id = ${sqlString(storyId)} AND entity_id = ${sqlString(entityId)}`);
+}
+
+function setReliabilityScore(sourceId: string, score: number): void {
+	db.runSql(`UPDATE sources SET reliability_score = ${score} WHERE id = ${sqlString(sourceId)}`);
+}
+
+function seedConnectedFixture(): void {
+	seedSource({ id: SOURCE_A_ID, filename: 'source-a.pdf' });
+	seedSource({ id: SOURCE_B_ID, filename: 'source-b.pdf' });
+	seedSource({ id: SOURCE_C_ID, filename: 'source-c.pdf' });
+	seedStory({ id: STORY_A_ID, sourceId: SOURCE_A_ID, title: 'Story A' });
+	seedStory({ id: STORY_B_ID, sourceId: SOURCE_B_ID, title: 'Story B' });
+	seedStory({ id: STORY_C_ID, sourceId: SOURCE_C_ID, title: 'Story C' });
+	seedEntity({ id: ENTITY_SHARED_AB, name: 'Shared AB' });
+	seedEntity({ id: ENTITY_SHARED_BC, name: 'Shared BC' });
+
+	linkStoryEntity(STORY_A_ID, ENTITY_SHARED_AB);
+	linkStoryEntity(STORY_B_ID, ENTITY_SHARED_AB);
+	linkStoryEntity(STORY_B_ID, ENTITY_SHARED_BC);
+	linkStoryEntity(STORY_C_ID, ENTITY_SHARED_BC);
+}
+
+function seedIsolatedFixture(): void {
+	seedSource({ id: SOURCE_A_ID, filename: 'isolated-a.pdf' });
+	seedSource({ id: SOURCE_B_ID, filename: 'isolated-b.pdf' });
+	seedStory({ id: STORY_A_ID, sourceId: SOURCE_A_ID, title: 'Isolated A' });
+	seedStory({ id: STORY_B_ID, sourceId: SOURCE_B_ID, title: 'Isolated B' });
+	seedEntity({ id: ENTITY_ISOLATED, name: 'Only A' });
+	seedEntity({ id: ENTITY_SHARED_AB, name: 'Only B' });
+	linkStoryEntity(STORY_A_ID, ENTITY_ISOLATED);
+	linkStoryEntity(STORY_B_ID, ENTITY_SHARED_AB);
+}
+
+function getReliabilityScores(): Array<{ id: string; score: string | null }> {
+	const raw = db.runSql(
+		`SELECT COALESCE(json_agg(row_to_json(scores) ORDER BY id)::text, '[]')
+		 FROM (
+		   SELECT id, reliability_score::text AS score
+		   FROM sources
+		   WHERE id IN (${sqlString(SOURCE_A_ID)}, ${sqlString(SOURCE_B_ID)}, ${sqlString(SOURCE_C_ID)})
+		 ) scores;`,
+	);
+	return JSON.parse(raw);
+}
+
+describe('Spec 62 — Source Reliability Scoring', () => {
+	beforeAll(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-62-'));
+		enabledConfigPath = writeAnalyzeConfig({ enabled: true, reliability: true, threshold: 50 });
+		disabledConfigPath = writeAnalyzeConfig({ enabled: false, reliability: true, threshold: 50 });
+		reliabilityDisabledConfigPath = writeAnalyzeConfig({ enabled: true, reliability: false, threshold: 50 });
+		sparseThresholdConfigPath = writeAnalyzeConfig({ enabled: true, reliability: true, threshold: 5 });
+
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
+			return;
+		}
+
+		ensureSchema();
+		cleanTestData();
+	}, 120_000);
+
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanTestData();
+	});
+
+	afterAll(() => {
+		if (pgAvailable) {
+			cleanTestData();
+		}
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('QA-01: reliability analysis scores graph-connected sources and persists results', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Source ID');
+		expect(result.stderr).toContain('Analyze complete');
+
+		const scores = getReliabilityScores();
+		const populatedScores = scores.filter((entry) => entry.score !== null);
+		expect(populatedScores).toHaveLength(3);
+		for (const entry of populatedScores) {
+			const numericScore = Number(entry.score);
+			expect(numericScore).toBeGreaterThanOrEqual(0);
+			expect(numericScore).toBeLessThanOrEqual(1);
+		}
+		expect(Number(scores.find((entry) => entry.id === SOURCE_B_ID)?.score ?? 0)).toBeGreaterThan(
+			Number(scores.find((entry) => entry.id === SOURCE_A_ID)?.score ?? 0),
+		);
+	});
+
+	it('QA-02: re-running reliability analysis is idempotent for unchanged corpus data', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		const first = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(first.exitCode).toBe(0);
+		const firstScores = getReliabilityScores();
+
+		const second = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(second.exitCode).toBe(0);
+		expect(getReliabilityScores()).toEqual(firstScores);
+	});
+
+	it('QA-03: sparse corpora succeed with a degradation warning', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: sparseThresholdConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('below meaningful reliability threshold');
+		expect(getReliabilityScores().filter((entry) => entry.score !== null)).toHaveLength(3);
+	});
+
+	it('QA-04: disabled reliability analysis fails before writing scores', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: disabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('ANALYZE_DISABLED');
+		expect(getReliabilityScores().filter((entry) => entry.score !== null)).toHaveLength(0);
+
+		const result2 = runCli(['analyze', '--reliability'], {
+			env: { MULDER_CONFIG: reliabilityDisabledConfigPath },
+		});
+		expect(result2.exitCode).not.toBe(0);
+		expect(result2.stderr).toContain('ANALYZE_DISABLED');
+		expect(getReliabilityScores().filter((entry) => entry.score !== null)).toHaveLength(0);
+	});
+
+	it('QA-05: no-op runs succeed when no source graph can be formed', () => {
+		if (!pgAvailable) return;
+		seedIsolatedFixture();
+		setReliabilityScore(SOURCE_A_ID, 0.42);
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('no graph-connected sources found');
+		expect(getReliabilityScores()).toEqual([
+			{ id: SOURCE_A_ID, score: '0.42' },
+			{ id: SOURCE_B_ID, score: null },
+		]);
+	});
+
+	it('CLI-01: --reliability scores eligible sources and prints a reliability table', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Source ID');
+		expect(result.stdout).toContain('source-b.pdf');
+		expect(result.stderr).toContain('Analyze complete');
+	});
+
+	it('CLI-02: running --reliability twice preserves the first run scores', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		expect(runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } }).exitCode).toBe(0);
+		const before = getReliabilityScores();
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(getReliabilityScores()).toEqual(before);
+	});
+
+	it('REGRESSION-01: rerun clears stale scores for sources that are no longer graph-connected', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
+		expect(runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } }).exitCode).toBe(0);
+		expect(Number(getReliabilityScores().find((entry) => entry.id === SOURCE_C_ID)?.score ?? 0)).toBeGreaterThan(0);
+
+		unlinkStoryEntity(STORY_B_ID, ENTITY_SHARED_BC);
+		unlinkStoryEntity(STORY_C_ID, ENTITY_SHARED_BC);
+
+		const result = runCli(['analyze', '--reliability'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+
+		const scores = getReliabilityScores();
+		expect(scores.find((entry) => entry.id === SOURCE_A_ID)?.score).not.toBeNull();
+		expect(scores.find((entry) => entry.id === SOURCE_B_ID)?.score).not.toBeNull();
+		expect(scores.find((entry) => entry.id === SOURCE_C_ID)?.score).toBeNull();
+	});
+
+	it('CLI-03: --contradictions --reliability exits non-zero because multi-selector analyze is not implemented yet', () => {
+		const result = runCli(['analyze', '--contradictions', '--reliability'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('one selector at a time');
+	});
+
+	it('CLI-04: --reliability --full exits non-zero because --full belongs to M6-G7', () => {
+		const result = runCli(['analyze', '--reliability', '--full'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G7');
+	});
+
+	it('CLI-05: no args exits non-zero and asks for an analysis selector', () => {
+		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('--contradictions');
+	});
+
+	it('CLI-06: --full exits non-zero because the full Analyze orchestrator is not implemented yet', () => {
+		const result = runCli(['analyze', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G7');
+	});
+
+	it('CLI-07: --evidence-chains exits non-zero because evidence chains belong to M6-G5', () => {
+		const result = runCli(['analyze', '--evidence-chains'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G5');
+	});
+
+	it('CLI-08: --spatio-temporal exits non-zero because clustering belongs to M6-G6', () => {
+		const result = runCli(['analyze', '--spatio-temporal'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G6');
+	});
+});
+
+describe('CLI Smoke Tests: analyze reliability', () => {
+	it('SMOKE-01: mulder analyze --help exits 0 and shows the reliability selector', () => {
+		const result = runCli(['analyze', '--help'], { env: { MULDER_CONFIG: enabledConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Usage:');
+		expect(result.stdout).toContain('--reliability');
+	});
+
+	it('SMOKE-02: mulder analyze --contradictions --reliability exits non-zero without crashing', () => {
+		const result = runCli(['analyze', '--contradictions', '--reliability'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('one selector at a time');
+	});
+
+	it('SMOKE-03: mulder analyze --reliability --spatio-temporal exits non-zero without crashing', () => {
+		const result = runCli(['analyze', '--reliability', '--spatio-temporal'], {
+			env: { MULDER_CONFIG: enabledConfigPath },
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('M6-G6');
+	});
+});


### PR DESCRIPTION
## Summary
- implement `mulder analyze --reliability` with a weighted PageRank-style source graph scorer
- persist `sources.reliability_score`, add selector-aware analyze result types, and print a dedicated CLI reliability table
- add Spec 62 coverage, stale-score regression coverage, roadmap completion, and a devlog entry

## Verification
- pnpm turbo run build
- npx biome check .
- npx vitest run tests/specs/37_qa_error_code_coverage.test.ts tests/specs/61_contradiction_resolution.test.ts tests/specs/62_source_reliability_scoring.test.ts --reporter=verbose
- npx vitest run tests/ --reporter=verbose

Closes #152