### PR TITLE
feat: add full analyze orchestration

### DIFF
--- a/apps/cli/src/commands/analyze.ts
+++ b/apps/cli/src/commands/analyze.ts
@@ -10,7 +10,7 @@
  */
 
 import { closeAllPools, createLogger, createServiceRegistry, getWorkerPool, loadConfig } from '@mulder/core';
-import type { AnalyzeResult } from '@mulder/pipeline';
+import type { AnalyzePassResult, AnalyzeResult } from '@mulder/pipeline';
 import { executeAnalyze } from '@mulder/pipeline';
 import type { Command } from 'commander';
 import { withErrorHandler } from '../lib/errors.js';
@@ -25,17 +25,7 @@ interface AnalyzeOptions {
 	thesis?: string[];
 }
 
-function hasUnsupportedSelector(options: AnalyzeOptions): boolean {
-	return Boolean(options.full);
-}
-
-function printUnsupportedSelectorMessage(options: AnalyzeOptions): void {
-	if (options.full) {
-		printError('--full is not implemented yet — it belongs to M6-G7');
-	}
-}
-
-function countImplementedSelectors(options: AnalyzeOptions): number {
+function countExplicitSelectors(options: AnalyzeOptions): number {
 	return (
 		Number(Boolean(options.contradictions)) +
 		Number(Boolean(options.reliability)) +
@@ -50,6 +40,25 @@ function normalizeTheses(values?: string[]): string[] {
 	}
 
 	return values.filter((value) => value.trim().length > 0);
+}
+
+function usesFullMode(options: AnalyzeOptions): boolean {
+	return Boolean(options.full) || countExplicitSelectors(options) === 0;
+}
+
+function printFullPassTable(result: AnalyzeResult): void {
+	if (result.data.mode !== 'full' || result.data.passes.length === 0) {
+		return;
+	}
+
+	const header = `${'Pass'.padEnd(18)}  ${'Status'.padEnd(8)}  Summary`;
+	const separator = '-'.repeat(header.length);
+	process.stdout.write(`${header}\n`);
+	process.stdout.write(`${separator}\n`);
+
+	for (const pass of result.data.passes) {
+		process.stdout.write(`${pass.pass.padEnd(18)}  ${pass.status.padEnd(8)}  ${pass.summary}\n`);
+	}
 }
 
 function printEvidenceChainsTable(result: AnalyzeResult): void {
@@ -138,6 +147,141 @@ function printSpatioTemporalTable(result: AnalyzeResult): void {
 	}
 }
 
+function printAnalyzeErrors(result: AnalyzeResult): void {
+	for (const error of result.errors) {
+		printError(`[${error.code}] ${error.message}`);
+	}
+}
+
+function summarizeFullPasses(passes: AnalyzePassResult[]): string {
+	const successCount = passes.filter((pass) => pass.status === 'success').length;
+	const partialCount = passes.filter((pass) => pass.status === 'partial').length;
+	const failedCount = passes.filter((pass) => pass.status === 'failed').length;
+	const skippedCount = passes.filter((pass) => pass.status === 'skipped').length;
+
+	return `${successCount} successful, ${partialCount} partial, ${failedCount} failed, ${skippedCount} skipped`;
+}
+
+function printFullAnalyzeResult(result: AnalyzeResult): void {
+	if (result.data.mode !== 'full') {
+		return;
+	}
+
+	printFullPassTable(result);
+	printAnalyzeErrors(result);
+
+	const summary = `${summarizeFullPasses(result.data.passes)} (${result.metadata.duration_ms}ms)`;
+
+	if (result.status === 'failed') {
+		printError(`Analyze failed: ${summary}`);
+		process.exit(1);
+		return;
+	}
+
+	if (result.status === 'partial') {
+		process.stderr.write(`Analyze partial: ${summary}\n`);
+		return;
+	}
+
+	printSuccess(`Analyze complete: ${summary}`);
+}
+
+function printSingleAnalyzeResult(result: AnalyzeResult): void {
+	printAnalyzeErrors(result);
+
+	if (result.data.mode === 'contradictions') {
+		if (result.data.pendingCount === 0) {
+			printSuccess(`Analyze complete: no pending contradiction edges found (${result.metadata.duration_ms}ms)`);
+			return;
+		}
+
+		const summary = `${result.data.processedCount} processed, ${result.data.confirmedCount} confirmed, ${result.data.dismissedCount} dismissed, ${result.data.failedCount} failed (${result.metadata.duration_ms}ms)`;
+
+		if (result.status === 'failed') {
+			printError(`Analyze failed: ${summary}`);
+			process.exit(1);
+		} else if (result.status === 'partial') {
+			process.stderr.write(`Analyze partial: ${summary}\n`);
+		} else {
+			printSuccess(`Analyze complete: ${summary}`);
+		}
+		return;
+	}
+
+	if (result.data.mode === 'reliability') {
+		if (result.data.outcomes.length === 0) {
+			printSuccess(`Analyze complete: no graph-connected sources found (${result.metadata.duration_ms}ms)`);
+			return;
+		}
+
+		if (result.data.belowThreshold) {
+			process.stderr.write(
+				`Analyze warning: corpus below meaningful reliability threshold (${result.data.sourceCount}/${result.data.threshold} graph-connected sources)\n`,
+			);
+		}
+
+		const summary = `${result.data.scoredCount} scored, ${result.data.sourceCount} graph-connected sources (${result.metadata.duration_ms}ms)`;
+
+		if (result.status === 'failed') {
+			printError(`Analyze failed: ${summary}`);
+			process.exit(1);
+		} else if (result.status === 'partial') {
+			process.stderr.write(`Analyze partial: ${summary}\n`);
+		} else {
+			printSuccess(`Analyze complete: ${summary}`);
+		}
+		return;
+	}
+
+	if (result.data.mode === 'spatio-temporal') {
+		if (result.data.warning) {
+			process.stderr.write(`Analyze warning: ${result.data.warning}\n`);
+		}
+
+		if (result.data.nothingToAnalyze) {
+			printSuccess(`Analyze complete: no clusterable events found (${result.metadata.duration_ms}ms)`);
+			return;
+		}
+
+		if (result.data.persistedCount === 0 && !result.data.belowThreshold) {
+			printSuccess(`Analyze complete: no clusters found (${result.metadata.duration_ms}ms)`);
+			return;
+		}
+
+		const summary = `${result.data.persistedCount} clusters persisted (${result.data.temporalClusterCount} temporal, ${result.data.spatialClusterCount} spatial, ${result.data.spatioTemporalClusterCount} spatio-temporal) (${result.metadata.duration_ms}ms)`;
+
+		if (result.status === 'failed') {
+			printError(`Analyze failed: ${summary}`);
+			process.exit(1);
+		} else if (result.status === 'partial') {
+			process.stderr.write(`Analyze partial: ${summary}\n`);
+		} else {
+			printSuccess(`Analyze complete: ${summary}`);
+		}
+		return;
+	}
+
+	if (result.data.mode !== 'evidence-chains') {
+		return;
+	}
+
+	if (result.data.supportingCount === 0 && result.data.contradictionCount === 0 && result.data.failedCount === 0) {
+		printSuccess(`Analyze complete: no evidence chains found (${result.metadata.duration_ms}ms)`);
+		return;
+	}
+
+	const summary = `${result.data.successCount} successful theses, ${result.data.failedCount} failed, ${result.data.supportingCount} supporting, ${result.data.contradictionCount} contradiction-backed (${result.metadata.duration_ms}ms)`;
+
+	if (result.status === 'failed') {
+		printError(`Analyze failed: ${summary}`);
+		process.exit(1);
+	} else if (result.status === 'partial') {
+		process.stderr.write(`Analyze partial: ${summary}\n`);
+	} else {
+		printSuccess(`Analyze complete: ${summary}`);
+	}
+}
+
 export function registerAnalyzeCommands(program: Command): void {
 	program
 		.command('analyze')
@@ -154,39 +298,34 @@ export function registerAnalyzeCommands(program: Command): void {
 			[],
 		)
 		.option('--spatio-temporal', 'compute spatio-temporal clusters')
-		.option('--full', 'run the full analyze orchestrator (not yet implemented)')
+		.option('--full', 'run all enabled analyze passes in sequence (default)')
 		.action(
 			withErrorHandler(async (options: AnalyzeOptions) => {
 				const rawTheses = normalizeTheses(options.thesis);
+				const fullMode = usesFullMode(options);
 
 				if (options.thesis && options.thesis.length > 0 && rawTheses.length === 0) {
-					printError('--thesis requires evidence-chain analysis and cannot be empty');
+					printError('--thesis requires at least one non-empty value');
 					process.exit(1);
 					return;
 				}
 
-				if (rawTheses.length > 0 && !options.evidenceChains) {
-					printError('--thesis can only be used with --evidence-chains');
+				if (rawTheses.length > 0 && !(options.evidenceChains || fullMode)) {
+					printError('--thesis can only be used with --evidence-chains or full analyze mode');
 					process.exit(1);
 					return;
 				}
 
-				const implementedSelectorCount = countImplementedSelectors(options);
+				const explicitSelectorCount = countExplicitSelectors(options);
 
-				if (implementedSelectorCount === 0 && !hasUnsupportedSelector(options)) {
-					printError('Provide an analysis selector such as --contradictions');
+				if (explicitSelectorCount > 1) {
+					printError('Running multiple analyze selectors together is not supported — use one selector or --full');
 					process.exit(1);
 					return;
 				}
 
-				if (implementedSelectorCount > 1) {
-					printError('Running multiple analyze selectors together is not implemented yet — use one selector at a time');
-					process.exit(1);
-					return;
-				}
-
-				if (hasUnsupportedSelector(options)) {
-					printUnsupportedSelectorMessage(options);
+				if (options.full && explicitSelectorCount > 0) {
+					printError('--full cannot be combined with explicit single-pass selectors');
 					process.exit(1);
 					return;
 				}
@@ -212,6 +351,7 @@ export function registerAnalyzeCommands(program: Command): void {
 				try {
 					const result = await executeAnalyze(
 						{
+							full: fullMode,
 							contradictions: options.contradictions ?? false,
 							reliability: options.reliability ?? false,
 							evidenceChains: options.evidenceChains ?? false,
@@ -230,97 +370,14 @@ export function registerAnalyzeCommands(program: Command): void {
 						printReliabilityTable(result);
 					} else if (result.data.mode === 'spatio-temporal') {
 						printSpatioTemporalTable(result);
-					} else {
+					} else if (result.data.mode === 'evidence-chains') {
 						printEvidenceChainsTable(result);
 					}
 
-					for (const error of result.errors) {
-						printError(`[${error.code}] ${error.message}`);
-					}
-
-					if (result.data.mode === 'contradictions') {
-						if (result.data.pendingCount === 0) {
-							printSuccess(`Analyze complete: no pending contradiction edges found (${result.metadata.duration_ms}ms)`);
-							return;
-						}
-
-						const summary = `${result.data.processedCount} processed, ${result.data.confirmedCount} confirmed, ${result.data.dismissedCount} dismissed, ${result.data.failedCount} failed (${result.metadata.duration_ms}ms)`;
-
-						if (result.status === 'failed') {
-							printError(`Analyze failed: ${summary}`);
-							process.exit(1);
-						} else if (result.status === 'partial') {
-							process.stderr.write(`Analyze partial: ${summary}\n`);
-						} else {
-							printSuccess(`Analyze complete: ${summary}`);
-						}
-					} else if (result.data.mode === 'reliability') {
-						if (result.data.outcomes.length === 0) {
-							printSuccess(`Analyze complete: no graph-connected sources found (${result.metadata.duration_ms}ms)`);
-							return;
-						}
-
-						if (result.data.belowThreshold) {
-							process.stderr.write(
-								`Analyze warning: corpus below meaningful reliability threshold (${result.data.sourceCount}/${result.data.threshold} graph-connected sources)\n`,
-							);
-						}
-
-						const summary = `${result.data.scoredCount} scored, ${result.data.sourceCount} graph-connected sources (${result.metadata.duration_ms}ms)`;
-
-						if (result.status === 'failed') {
-							printError(`Analyze failed: ${summary}`);
-							process.exit(1);
-						} else if (result.status === 'partial') {
-							process.stderr.write(`Analyze partial: ${summary}\n`);
-						} else {
-							printSuccess(`Analyze complete: ${summary}`);
-						}
-					} else if (result.data.mode === 'spatio-temporal') {
-						if (result.data.warning) {
-							process.stderr.write(`Analyze warning: ${result.data.warning}\n`);
-						}
-
-						if (result.data.nothingToAnalyze) {
-							printSuccess(`Analyze complete: no clusterable events found (${result.metadata.duration_ms}ms)`);
-							return;
-						}
-
-						if (result.data.persistedCount === 0 && !result.data.belowThreshold) {
-							printSuccess(`Analyze complete: no clusters found (${result.metadata.duration_ms}ms)`);
-							return;
-						}
-
-						const summary = `${result.data.persistedCount} clusters persisted (${result.data.temporalClusterCount} temporal, ${result.data.spatialClusterCount} spatial, ${result.data.spatioTemporalClusterCount} spatio-temporal) (${result.metadata.duration_ms}ms)`;
-
-						if (result.status === 'failed') {
-							printError(`Analyze failed: ${summary}`);
-							process.exit(1);
-						} else if (result.status === 'partial') {
-							process.stderr.write(`Analyze partial: ${summary}\n`);
-						} else {
-							printSuccess(`Analyze complete: ${summary}`);
-						}
+					if (result.data.mode === 'full') {
+						printFullAnalyzeResult(result);
 					} else {
-						if (
-							result.data.supportingCount === 0 &&
-							result.data.contradictionCount === 0 &&
-							result.data.failedCount === 0
-						) {
-							printSuccess(`Analyze complete: no evidence chains found (${result.metadata.duration_ms}ms)`);
-							return;
-						}
-
-						const summary = `${result.data.successCount} successful theses, ${result.data.failedCount} failed, ${result.data.supportingCount} supporting, ${result.data.contradictionCount} contradiction-backed (${result.metadata.duration_ms}ms)`;
-
-						if (result.status === 'failed') {
-							printError(`Analyze failed: ${summary}`);
-							process.exit(1);
-						} else if (result.status === 'partial') {
-							process.stderr.write(`Analyze partial: ${summary}\n`);
-						} else {
-							printSuccess(`Analyze complete: ${summary}`);
-						}
+						printSingleAnalyzeResult(result);
 					}
 				} finally {
 					await closeAllPools();

--- a/apps/cli/src/commands/pipeline.ts
+++ b/apps/cli/src/commands/pipeline.ts
@@ -69,7 +69,7 @@ function shortId(id: string): string {
 function registerRunSubcommand(parent: Command): void {
 	parent
 		.command('run')
-		.description('Run the full pipeline (ingest → extract → segment → enrich → embed → graph)')
+		.description('Run the full pipeline (ingest → extract → segment → enrich → embed → graph → [analyze])')
 		.argument('[path]', 'Path to a PDF file or directory')
 		.option('--up-to <step>', `Stop after this step (one of: ${RUN_FLAG_STEPS.join('|')})`)
 		.option('--from <step>', `Resume from this step (one of: ${RUN_FLAG_STEPS.join('|')})`)
@@ -81,6 +81,7 @@ function registerRunSubcommand(parent: Command): void {
 Examples:
   $ mulder pipeline run ./pdfs/                          # Full pipeline on every PDF in a directory
   $ mulder pipeline run paper.pdf --up-to enrich         # Stop after entity extraction
+  $ mulder pipeline run paper.pdf --up-to graph          # Stop before global analyze
   $ mulder pipeline run paper.pdf --from embed           # Resume after enrich on an existing source`,
 		)
 		.action(
@@ -155,6 +156,7 @@ Examples:
 					if (options.dryRun) {
 						process.stdout.write(`Planned steps: ${result.data.plannedSteps.join(' → ')}\n`);
 						process.stdout.write(`Sources to process: ${result.data.totalSources}\n`);
+						process.stdout.write(`Global analyze: ${result.data.analysis.summary}\n`);
 						printSuccess('Dry run complete (no changes made)');
 						return;
 					}
@@ -179,6 +181,8 @@ Examples:
 							process.stdout.write(`... ${result.data.sources.length - rowLimit} more rows truncated\n`);
 						}
 					}
+
+					process.stdout.write(`Global analyze: ${result.data.analysis.status} — ${result.data.analysis.summary}\n`);
 
 					const summary = `${result.data.totalSources} sources, ${result.data.completedSources} completed, ${result.data.failedSources} failed (${result.metadata.duration_ms}ms)`;
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,7 +169,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 | 🟢 | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
 | 🟢 | G5 | Evidence chains — `mulder analyze --evidence-chains` | §2.8, §4.3 (evidence_chains table) |
 | 🟢 | G6 | Spatio-temporal clustering | §2.8, §4.3 (clusters table) |
-| 🟡 | G7 | Analyze orchestrator — `mulder analyze --full` | §2.8, §1 (analyze cmd) |
+| 🟢 | G7 | Analyze orchestrator — `mulder analyze --full` | §2.8, §1 (analyze cmd) |
 
 **Also read for all M6 steps:** §2 (global step conventions), §4.8 (Vertex AI wrapper for Gemini calls)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,7 +169,7 @@ Web grounding, contradiction resolution, evidence chains, spatial clustering. Th
 | 🟢 | G4 | Source reliability scoring — `mulder analyze --reliability` | §2.8, §5.3 |
 | 🟢 | G5 | Evidence chains — `mulder analyze --evidence-chains` | §2.8, §4.3 (evidence_chains table) |
 | 🟢 | G6 | Spatio-temporal clustering | §2.8, §4.3 (clusters table) |
-| ⚪ | G7 | Analyze orchestrator — `mulder analyze --full` | §2.8, §1 (analyze cmd) |
+| 🟡 | G7 | Analyze orchestrator — `mulder analyze --full` | §2.8, §1 (analyze cmd) |
 
 **Also read for all M6 steps:** §2 (global step conventions), §4.8 (Vertex AI wrapper for Gemini calls)
 

--- a/docs/specs/65_analyze_full_orchestrator.spec.md
+++ b/docs/specs/65_analyze_full_orchestrator.spec.md
@@ -1,0 +1,160 @@
+---
+spec: "65"
+title: "Analyze Full Orchestrator"
+roadmap_step: M6-G7
+functional_spec: ["§1", "§2.8", "§3.1", "§3.2"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/158"
+created: 2026-04-12
+---
+
+# Spec 65: Analyze Full Orchestrator
+
+## 1. Objective
+
+Implement Mulder's `M6-G7` coordinator so `mulder analyze --full` and bare `mulder analyze` run the enabled Analyze sub-passes in a stable order, aggregate their outcomes into one user-facing result, and let the pipeline orchestrator invoke that full-graph analysis phase automatically after `graph` when analysis is enabled. Per `§2.8`, Analyze remains a modular full-graph step whose sub-analyses can run independently; this step adds the missing orchestration layer without re-implementing the existing contradiction, reliability, evidence-chain, or spatio-temporal engines. Per `§1`, `--full` is the intended default CLI surface, and per `§3.1`/`§3.2` the full document pipeline should be able to append optional global analysis after per-source graph work completes.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M6-G7` — Analyze orchestrator — `mulder analyze --full`
+- **Target:** `packages/pipeline/src/analyze/types.ts`, `packages/pipeline/src/analyze/index.ts`, `packages/pipeline/src/index.ts`, `packages/pipeline/src/pipeline/types.ts`, `packages/pipeline/src/pipeline/index.ts`, `apps/cli/src/commands/analyze.ts`, `apps/cli/src/commands/pipeline.ts`
+- **In scope:** full-mode Analyze input and aggregate result types; sequential orchestration of the existing G3-G6 Analyze sub-passes; CLI behavior where bare `mulder analyze` defaults to full mode; readable full-run summaries with skipped/pass/fail accounting; skipping disabled or currently unconfigured passes without treating them as fatal; and appending a global Analyze phase to `mulder pipeline run` when analysis is enabled and the run reaches `graph`
+- **Out of scope:** new contradiction, reliability, evidence-chain, or clustering algorithms; schema migrations; new config fields; worker/job-queue behavior; per-source retry semantics for Analyze; UI/API presentation; or changing how the individual G3-G6 selectors behave when they are run explicitly
+- **Constraints:** preserve the existing individual selector contracts; run full-mode passes in functional-spec order (`contradictions` → `reliability` → `evidence-chains` → `spatio-temporal`); treat `analysis.enabled=false` as a hard disable for full mode; treat `analysis.evidence_chains=true` with an empty thesis list as a full-mode skip rather than a fatal error; and invoke Analyze once per pipeline batch, never once per source
+
+## 3. Dependencies
+
+- **Requires:** Spec 36 (`M4-D6`) pipeline orchestrator, Specs 61-64 (`M6-G3` through `M6-G6`) for the individual Analyze sub-passes, and the existing `analysis` config surface in `packages/core/src/config/`
+- **Blocks:** end-to-end v2.0 pipeline runs that are supposed to finish with global analysis, and any workflow that expects a single command to execute all currently implemented Analyze passes in sequence
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/pipeline/src/analyze/types.ts`** — extends Analyze inputs/results with a `full` mode plus typed per-pass summaries, skipped-pass reporting, and aggregate metadata suitable for CLI and pipeline consumers
+2. **`packages/pipeline/src/analyze/index.ts`** — implements the full-mode coordinator by dispatching the existing contradiction, reliability, evidence-chain, and spatio-temporal branches in order, folding their `success`/`partial`/`failed` outcomes into one aggregate result, and skipping disabled or thesis-less passes with explicit reasons
+3. **`packages/pipeline/src/index.ts`** — re-exports the expanded Analyze contract from the pipeline package barrel
+4. **`apps/cli/src/commands/analyze.ts`** — makes bare `mulder analyze` behave like `--full`, allows explicit `--full`, preserves mutual exclusivity with individual selectors, prints a compact per-pass summary for full runs, and keeps the existing selector-specific tables for single-pass invocations
+5. **`packages/pipeline/src/pipeline/types.ts`** — extends the pipeline result contract with a small global-Analyze summary so the CLI can report whether post-graph analysis ran and how it finished
+6. **`packages/pipeline/src/pipeline/index.ts`** — appends a single global Analyze call after per-source graph processing when analysis is enabled and the pipeline run has not been limited to `--up-to graph` or earlier, then folds the global Analyze verdict into the overall pipeline result without trying to treat Analyze as a source-scoped step
+7. **`apps/cli/src/commands/pipeline.ts`** — updates help text and user-facing descriptions so the “full pipeline” messaging matches the actual post-graph Analyze behavior when analysis is enabled
+
+### 4.2 Database Changes
+
+None. This step orchestrates the existing Analyze persistence surfaces:
+
+- `entity_edges.analysis` and contradiction edge types from Spec 61
+- `sources.reliability_score` from Spec 62
+- `evidence_chains` snapshots from Spec 63
+- `spatio_temporal_clusters` snapshots from Spec 64
+
+The coordinator must not introduce new tables or write new ad hoc persistence records beyond what the existing sub-passes already own.
+
+### 4.3 Config Changes
+
+None. Full-mode orchestration uses the existing config:
+
+- `analysis.enabled`
+- `analysis.contradictions`
+- `analysis.reliability`
+- `analysis.evidence_chains`
+- `analysis.evidence_theses`
+- `analysis.spatio_temporal`
+
+Behavior:
+
+- If `analysis.enabled=false`, full Analyze fails fast with a clear disabled error
+- Disabled sub-passes are skipped and reported in the aggregate result
+- Evidence-chain analysis is skipped in full mode when `analysis.evidence_theses` is empty, with a clear “no thesis input configured” reason
+- Explicit single-pass selectors (`--contradictions`, `--reliability`, `--evidence-chains`, `--spatio-temporal`) keep their current validation and failure semantics
+
+### 4.4 Integration Points
+
+- Full Analyze must reuse the existing single-pass branches rather than duplicating their internal logic; the coordinator should compose them through one shared executor path so later Analyze passes can slot in without a second control flow
+- Full-mode ordering must match the functional spec: contradiction resolution first, then reliability scoring, then evidence chains, then spatio-temporal clustering
+- Bare `mulder analyze` should map to full mode; explicit selectors should remain mutually exclusive with `--full`
+- Full-mode CLI output should show each pass with its verdict (`success`, `partial`, `failed`, `skipped`) and a concise reason/summary, followed by an overall Analyze summary and non-zero exit only for invalid invocation or total failure
+- `mulder pipeline run` should continue to track per-source work through `graph`, then invoke one global Analyze call for the batch when analysis is enabled; `--up-to graph` remains the way to skip analysis intentionally
+- Pipeline result status should absorb the global Analyze verdict: a successful source batch with a partial full Analyze run becomes pipeline `partial`, while a total Analyze failure after successful graph work becomes pipeline `failed`
+
+### 4.5 Implementation Phases
+
+**Phase 1: Full-mode Analyze contract**
+- Files: `packages/pipeline/src/analyze/types.ts`, `packages/pipeline/src/index.ts`
+- Deliverable: a stable typed input/output shape for `full` Analyze runs, including per-pass and aggregate reporting
+
+**Phase 2: Coordinator + CLI**
+- Files: `packages/pipeline/src/analyze/index.ts`, `apps/cli/src/commands/analyze.ts`
+- Deliverable: `mulder analyze --full` and bare `mulder analyze` run the enabled passes in sequence and report a usable aggregate summary
+
+**Phase 3: Pipeline handoff**
+- Files: `packages/pipeline/src/pipeline/types.ts`, `packages/pipeline/src/pipeline/index.ts`, `apps/cli/src/commands/pipeline.ts`
+- Deliverable: `mulder pipeline run` can finish with one global Analyze phase when analysis is enabled, and its help/output accurately describe that behavior
+
+## 5. QA Contract
+
+1. **QA-01: Bare analyze runs the enabled full analysis sequence**
+   - Given: `analysis.enabled=true`, at least one individual Analyze sub-pass is enabled and runnable, and the corpus contains data for at least one enabled pass
+   - When: `mulder analyze` runs with no selector flags
+   - Then: the command exits `0` or partial-success, executes the enabled passes in full-mode order, and prints an aggregate summary that includes each attempted or skipped pass
+
+2. **QA-02: Explicit full mode matches bare analyze behavior**
+   - Given: the same configuration and corpus state as QA-01
+   - When: `mulder analyze --full` runs
+   - Then: the command produces the same per-pass sequencing and overall verdict class as bare `mulder analyze`
+
+3. **QA-03: Full mode skips disabled or thesis-less passes without aborting runnable ones**
+   - Given: `analysis.enabled=true`, at least one Analyze pass is enabled and runnable, `analysis.evidence_chains=true`, and `analysis.evidence_theses=[]`
+   - When: `mulder analyze --full` runs
+   - Then: the command still executes the runnable passes, reports evidence chains as skipped with a clear reason, and does not fail solely because no thesis input is configured
+
+4. **QA-04: Full mode fails fast when analysis is globally disabled**
+   - Given: `analysis.enabled=false`
+   - When: `mulder analyze --full` or bare `mulder analyze` runs
+   - Then: the command exits non-zero with an Analyze disabled error before any contradiction, reliability, evidence-chain, or clustering writes occur
+
+5. **QA-05: Explicit selector mode keeps existing single-pass semantics**
+   - Given: `analysis.enabled=true` and the corpus contains data for contradiction resolution
+   - When: `mulder analyze --contradictions` runs
+   - Then: the command behaves as a single-pass contradiction run, not as full mode, and does not also execute reliability, evidence-chain, or spatio-temporal passes
+
+6. **QA-06: Pipeline run appends global Analyze after graph when enabled**
+   - Given: `analysis.enabled=true`, the pipeline can process at least one source through `graph`, and the run is not limited to `--up-to graph` or earlier
+   - When: `mulder pipeline run <path>` completes
+   - Then: the overall run includes one post-graph Analyze phase, and the final pipeline verdict reflects both per-source processing and the global Analyze result
+
+7. **QA-07: Pipeline run can intentionally stop before analysis**
+   - Given: `analysis.enabled=true`
+   - When: `mulder pipeline run <path> --up-to graph` runs
+   - Then: the run completes without invoking full Analyze, and the user-facing summary reflects a graph-terminal run rather than an analysis-inclusive one
+
+## 5b. CLI Test Matrix
+
+### `mulder analyze`
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-01 | *(no args)* | Executes full Analyze mode using the enabled passes and prints an aggregate summary |
+| CLI-02 | `--full` | Same full-mode behavior as bare `mulder analyze` |
+| CLI-03 | `--full --contradictions` | Exit non-zero, because full mode and explicit selectors are mutually exclusive |
+| CLI-04 | `--full --reliability` | Exit non-zero, because full mode and explicit selectors are mutually exclusive |
+| CLI-05 | `--contradictions` | Runs only contradiction resolution |
+| CLI-06 | `--reliability` | Runs only reliability scoring |
+| CLI-07 | `--evidence-chains` | Runs only evidence-chain analysis |
+| CLI-08 | `--spatio-temporal` | Runs only spatio-temporal clustering |
+
+### `mulder pipeline run`
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-09 | `<path>` | Full pipeline help/output reflects that Analyze runs after graph when analysis is enabled |
+| CLI-10 | `<path> --up-to graph` | Stops after graph and does not invoke Analyze |
+| CLI-11 | `<path> --up-to enrich` | Stops before graph and never reaches Analyze |
+| CLI-12 | `<path> --dry-run` | Planned output stays side-effect free and does not claim that Analyze already ran |
+
+## 6. Cost Considerations
+
+- **Services called:** none directly by the coordinator, but full mode may trigger the existing contradiction-resolution Gemini calls from Spec 61 when that pass is enabled and pending contradictions exist
+- **Estimated incremental cost:** orchestration itself is free; any paid cost comes only from already-implemented sub-passes it invokes
+- **Dev mode alternative:** yes — the existing dev fixtures for contradiction resolution and the database-backed Analyze passes remain available under full mode
+- **Safety flags:** `analysis.enabled` hard-disables full mode, and full mode must skip thesis-less evidence-chain runs instead of forcing unnecessary failures

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -44,13 +44,17 @@ import { computeSourceReliability } from './reliability.js';
 import { computeSpatioTemporalClusters } from './spatio-temporal.js';
 import type {
 	AnalyzeInput,
+	AnalyzePassName,
+	AnalyzePassResult,
 	AnalyzeResult,
 	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
 	ContradictionResolutionResponse,
 	EvidenceChainsAnalyzeData,
 	EvidenceChainThesisOutcome,
+	FullAnalyzeData,
 	ReliabilityAnalyzeData,
+	SingleAnalyzeData,
 	SourceReliabilityOutcome,
 	SpatioTemporalAnalyzeData,
 } from './types.js';
@@ -58,6 +62,8 @@ import type {
 export type {
 	AnalyzeData,
 	AnalyzeInput,
+	AnalyzePassName,
+	AnalyzePassResult,
 	AnalyzeResult,
 	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
@@ -65,7 +71,9 @@ export type {
 	ContradictionVerdict,
 	EvidenceChainsAnalyzeData,
 	EvidenceChainThesisOutcome,
+	FullAnalyzeData,
 	ReliabilityAnalyzeData,
+	SingleAnalyzeData,
 	SourceReliabilityOutcome,
 	SpatioTemporalAnalyzeData,
 	SpatioTemporalCluster,
@@ -466,287 +474,384 @@ function makeSpatioTemporalData(
 	};
 }
 
-export async function execute(
-	input: AnalyzeInput,
-	config: MulderConfig,
-	services: Services,
-	pool: pg.Pool | undefined,
-	logger: Logger,
-): Promise<AnalyzeResult> {
-	const log = createChildLogger(logger, {
-		step: STEP_NAME,
-		contradictions: input.contradictions ?? false,
-		reliability: input.reliability ?? false,
-		evidenceChains: input.evidenceChains ?? false,
-		spatioTemporal: input.spatioTemporal ?? false,
-	});
-	const startTime = performance.now();
+const FULL_PASS_ORDER: readonly AnalyzePassName[] = [
+	'contradictions',
+	'reliability',
+	'evidence-chains',
+	'spatio-temporal',
+] as const;
 
-	if (!pool) {
-		throw new AnalyzeError('Database pool is required for analyze step', ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED);
-	}
-
-	const hasRawThesisOverrides = Array.isArray(input.theses) && input.theses.length > 0;
-	const thesisOverrides = normalizeThesisList(input.theses);
-	if (hasRawThesisOverrides && thesisOverrides.length === 0) {
-		throw new AnalyzeError(
-			'At least one non-empty thesis override is required',
-			ANALYZE_ERROR_CODES.ANALYZE_THESIS_INPUT_MISSING,
-			{
-				context: { thesisCount: input.theses?.length ?? 0 },
-			},
-		);
-	}
-
-	if (hasRawThesisOverrides && !input.evidenceChains) {
-		throw new AnalyzeError(
-			'The --thesis override can only be used with evidence-chain analysis',
-			ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED,
-			{
-				context: { thesisCount: thesisOverrides.length },
-			},
-		);
-	}
-
-	const selectedModes = [
+function getSelectedModes(input: AnalyzeInput): AnalyzePassName[] {
+	return [
 		input.contradictions ? 'contradictions' : null,
 		input.reliability ? 'reliability' : null,
 		input.evidenceChains ? 'evidence-chains' : null,
 		input.spatioTemporal ? 'spatio-temporal' : null,
-	].filter(
-		(value): value is 'contradictions' | 'reliability' | 'evidence-chains' | 'spatio-temporal' => value !== null,
+	].filter((value): value is AnalyzePassName => value !== null);
+}
+
+function summarizeAnalyzeData(data: SingleAnalyzeData): string {
+	switch (data.mode) {
+		case 'contradictions':
+			return data.pendingCount === 0
+				? 'no pending contradiction edges'
+				: `${data.processedCount} processed, ${data.confirmedCount} confirmed, ${data.dismissedCount} dismissed, ${data.failedCount} failed`;
+		case 'reliability':
+			return data.outcomes.length === 0
+				? 'no graph-connected sources found'
+				: `${data.scoredCount} scored, ${data.sourceCount} graph-connected sources`;
+		case 'evidence-chains':
+			return data.supportingCount === 0 && data.contradictionCount === 0 && data.failedCount === 0
+				? 'no evidence chains found'
+				: `${data.successCount} successful theses, ${data.failedCount} failed, ${data.supportingCount} supporting, ${data.contradictionCount} contradiction-backed`;
+		case 'spatio-temporal':
+			if (data.nothingToAnalyze) {
+				return 'no clusterable events found';
+			}
+			if (data.persistedCount === 0 && !data.belowThreshold) {
+				return 'no clusters found';
+			}
+			if (data.belowThreshold) {
+				return data.warning ?? `insufficient event density (${data.eventCount}/${data.threshold})`;
+			}
+			return `${data.persistedCount} clusters persisted (${data.temporalClusterCount} temporal, ${data.spatialClusterCount} spatial, ${data.spatioTemporalClusterCount} spatio-temporal)`;
+	}
+}
+
+function getPassMetadataTotals(passes: AnalyzePassResult[]): AnalyzeResult['metadata'] {
+	return {
+		duration_ms: passes.reduce((total, pass) => total + pass.metadata.duration_ms, 0),
+		items_processed: passes.reduce((total, pass) => total + pass.metadata.items_processed, 0),
+		items_skipped: passes.reduce((total, pass) => total + pass.metadata.items_skipped, 0),
+		items_cached: passes.reduce((total, pass) => total + pass.metadata.items_cached, 0),
+	};
+}
+
+function createSkippedPassResult(pass: AnalyzePassName, summary: string): AnalyzePassResult {
+	return {
+		pass,
+		status: 'skipped',
+		summary,
+		data: null,
+		errors: [],
+		metadata: {
+			duration_ms: 0,
+			items_processed: 0,
+			items_skipped: 1,
+			items_cached: 0,
+		},
+	};
+}
+
+function createFailedPassResult(pass: AnalyzePassName, error: AnalyzeError): AnalyzePassResult {
+	return {
+		pass,
+		status: 'failed',
+		summary: error.message,
+		data: null,
+		errors: [toStepError(error, pass)],
+		metadata: {
+			duration_ms: 0,
+			items_processed: 0,
+			items_skipped: 0,
+			items_cached: 0,
+		},
+	};
+}
+
+function toAnalyzePassResult(pass: AnalyzePassName, result: AnalyzeResult): AnalyzePassResult {
+	if (result.data.mode === 'full') {
+		throw new AnalyzeError(
+			'Full analyze results cannot be nested inside full analyze pass results',
+			ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED,
+			{
+				context: { pass },
+			},
+		);
+	}
+
+	return {
+		pass,
+		status: result.status,
+		summary: summarizeAnalyzeData(result.data),
+		data: result.data,
+		errors: result.errors,
+		metadata: result.metadata,
+	};
+}
+
+function makeFullAnalyzeData(passes: AnalyzePassResult[]): FullAnalyzeData {
+	const attemptedPasses = passes.filter((pass) => pass.status !== 'skipped');
+	const successCount = passes.filter((pass) => pass.status === 'success').length;
+	const partialCount = passes.filter((pass) => pass.status === 'partial').length;
+	const failedCount = passes.filter((pass) => pass.status === 'failed').length;
+	const skippedCount = passes.filter((pass) => pass.status === 'skipped').length;
+
+	return {
+		mode: 'full',
+		passCount: passes.length,
+		attemptedCount: attemptedPasses.length,
+		successCount,
+		partialCount,
+		failedCount,
+		skippedCount,
+		passes,
+	};
+}
+
+function getFullAnalyzeStatus(data: FullAnalyzeData): AnalyzeResult['status'] {
+	if (data.attemptedCount === 0) {
+		return 'success';
+	}
+	if (data.failedCount === data.attemptedCount) {
+		return 'failed';
+	}
+	if (data.failedCount > 0 || data.partialCount > 0) {
+		return 'partial';
+	}
+	return 'success';
+}
+
+async function executeContradictionsPass(
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool,
+	log: Logger,
+): Promise<AnalyzeResult> {
+	const startTime = performance.now();
+
+	if (!config.analysis.enabled || !config.analysis.contradictions) {
+		throw new AnalyzeError(
+			'Contradiction analysis is disabled in the active configuration',
+			ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
+			{
+				context: {
+					enabled: config.analysis.enabled,
+					contradictions: config.analysis.contradictions,
+				},
+			},
+		);
+	}
+
+	const pendingEdges = await findEdgesByType(pool, 'POTENTIAL_CONTRADICTION');
+	const outcomes: ContradictionResolutionOutcome[] = [];
+	const errors: StepError[] = [];
+
+	for (const edge of pendingEdges) {
+		try {
+			const context = await hydrateContext(pool, edge);
+			const outcome = await resolveEdge(context, config, services, pool);
+			outcomes.push(outcome);
+		} catch (cause: unknown) {
+			const analyzeError =
+				cause instanceof AnalyzeError
+					? cause
+					: new AnalyzeError(`Unexpected analyze failure for edge ${edge.id}`, ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED, {
+							cause,
+							context: { edgeId: edge.id },
+						});
+			errors.push(toStepError(analyzeError, edge.id));
+			log.warn({ err: cause, edgeId: edge.id }, 'Analyze failed for contradiction edge — continuing');
+		}
+	}
+
+	const data = makeContradictionData(outcomes, errors.length, pendingEdges.length);
+	const status = errors.length === 0 ? 'success' : outcomes.length > 0 ? 'partial' : 'failed';
+	const durationMs = Math.round(performance.now() - startTime);
+
+	log.info(
+		{
+			mode: data.mode,
+			pendingCount: data.pendingCount,
+			processedCount: data.processedCount,
+			confirmedCount: data.confirmedCount,
+			dismissedCount: data.dismissedCount,
+			failedCount: data.failedCount,
+			duration_ms: durationMs,
+		},
+		'Analyze step completed',
 	);
-	if (selectedModes.length !== 1) {
-		throw new AnalyzeError('Exactly one analyze selector must be enabled', ANALYZE_ERROR_CODES.ANALYZE_DISABLED, {
-			context: { selectedModes },
-		});
-	}
 
-	if (input.contradictions) {
-		if (!config.analysis.enabled || !config.analysis.contradictions) {
-			throw new AnalyzeError(
-				'Contradiction analysis is disabled in the active configuration',
-				ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
-				{
-					context: {
-						enabled: config.analysis.enabled,
-						contradictions: config.analysis.contradictions,
-					},
-				},
-			);
-		}
+	return {
+		status,
+		data,
+		errors,
+		metadata: {
+			duration_ms: durationMs,
+			items_processed: data.processedCount,
+			items_skipped: 0,
+			items_cached: 0,
+		},
+	};
+}
 
-		const pendingEdges = await findEdgesByType(pool, 'POTENTIAL_CONTRADICTION');
-		const outcomes: ContradictionResolutionOutcome[] = [];
-		const errors: StepError[] = [];
+async function executeEvidenceChainsPass(
+	config: MulderConfig,
+	pool: pg.Pool,
+	log: Logger,
+	thesisOverrides: string[],
+): Promise<AnalyzeResult> {
+	const startTime = performance.now();
 
-		for (const edge of pendingEdges) {
-			try {
-				const context = await hydrateContext(pool, edge);
-				const outcome = await resolveEdge(context, config, services, pool);
-				outcomes.push(outcome);
-			} catch (cause: unknown) {
-				const analyzeError =
-					cause instanceof AnalyzeError
-						? cause
-						: new AnalyzeError(
-								`Unexpected analyze failure for edge ${edge.id}`,
-								ANALYZE_ERROR_CODES.ANALYZE_LLM_FAILED,
-								{
-									cause,
-									context: { edgeId: edge.id },
-								},
-							);
-				errors.push(toStepError(analyzeError, edge.id));
-				log.warn({ err: cause, edgeId: edge.id }, 'Analyze failed for contradiction edge — continuing');
-			}
-		}
-
-		const data = makeContradictionData(outcomes, errors.length, pendingEdges.length);
-		const status = errors.length === 0 ? 'success' : outcomes.length > 0 ? 'partial' : 'failed';
-		const durationMs = Math.round(performance.now() - startTime);
-
-		log.info(
+	if (!config.analysis.enabled || !config.analysis.evidence_chains) {
+		throw new AnalyzeError(
+			'Evidence chain analysis is disabled in the active configuration',
+			ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
 			{
-				mode: data.mode,
-				pendingCount: data.pendingCount,
-				processedCount: data.processedCount,
-				confirmedCount: data.confirmedCount,
-				dismissedCount: data.dismissedCount,
-				failedCount: data.failedCount,
-				duration_ms: durationMs,
-			},
-			'Analyze step completed',
-		);
-
-		return {
-			status,
-			data,
-			errors,
-			metadata: {
-				duration_ms: durationMs,
-				items_processed: data.processedCount,
-				items_skipped: 0,
-				items_cached: 0,
-			},
-		};
-	}
-
-	if (input.evidenceChains) {
-		if (!config.analysis.enabled || !config.analysis.evidence_chains) {
-			throw new AnalyzeError(
-				'Evidence chain analysis is disabled in the active configuration',
-				ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
-				{
-					context: {
-						enabled: config.analysis.enabled,
-						evidenceChains: config.analysis.evidence_chains,
-					},
+				context: {
+					enabled: config.analysis.enabled,
+					evidenceChains: config.analysis.evidence_chains,
 				},
-			);
-		}
-
-		const thesisInputs =
-			thesisOverrides.length > 0 ? thesisOverrides : normalizeThesisList(config.analysis.evidence_theses);
-		if (thesisInputs.length === 0) {
-			throw new AnalyzeError(
-				'At least one thesis query is required for evidence-chain analysis',
-				ANALYZE_ERROR_CODES.ANALYZE_THESIS_INPUT_MISSING,
-			);
-		}
-
-		const outcomes: EvidenceChainThesisOutcome[] = [];
-		const errors: StepError[] = [];
-
-		for (const thesis of thesisInputs) {
-			try {
-				const computation = await computeEvidenceChainsForThesis(pool, config, thesis);
-				const computedAt = new Date();
-				const snapshotRows = buildEvidenceChainInputs(computation.thesis, computation, computedAt);
-				const writtenCount = await replaceEvidenceChainsSnapshot(pool, computation.thesis, snapshotRows);
-
-				outcomes.push({
-					thesis: computation.thesis,
-					status: 'success',
-					seedCount: computation.seedIds.length,
-					supportingCount: computation.supportingChains.length,
-					contradictionCount: computation.contradictionChains.length,
-					writtenCount,
-				});
-			} catch (cause: unknown) {
-				const analyzeError =
-					cause instanceof AnalyzeError
-						? cause
-						: new AnalyzeError(
-								`Unexpected analyze failure for thesis "${thesis}"`,
-								ANALYZE_ERROR_CODES.ANALYZE_TRAVERSAL_FAILED,
-								{
-									cause,
-									context: { thesis },
-								},
-							);
-				errors.push(toStepError(analyzeError, thesis));
-				outcomes.push({
-					thesis,
-					status: 'failed',
-					seedCount: 0,
-					supportingCount: 0,
-					contradictionCount: 0,
-					writtenCount: 0,
-				});
-				log.warn({ err: cause, thesis }, 'Analyze failed for evidence-chain thesis — continuing');
-			}
-		}
-
-		const data = makeEvidenceChainsData(outcomes);
-		const status =
-			errors.length === 0 ? 'success' : outcomes.some((outcome) => outcome.status === 'success') ? 'partial' : 'failed';
-		const durationMs = Math.round(performance.now() - startTime);
-
-		log.info(
-			{
-				mode: data.mode,
-				thesisCount: data.thesisCount,
-				processedCount: data.processedCount,
-				successCount: data.successCount,
-				failedCount: data.failedCount,
-				supportingCount: data.supportingCount,
-				contradictionCount: data.contradictionCount,
-				duration_ms: durationMs,
 			},
-			'Analyze step completed',
 		);
-
-		return {
-			status,
-			data,
-			errors,
-			metadata: {
-				duration_ms: durationMs,
-				items_processed: data.processedCount,
-				items_skipped: data.failedCount,
-				items_cached: 0,
-			},
-		};
 	}
 
-	if (input.spatioTemporal) {
-		if (!config.analysis.enabled || !config.analysis.spatio_temporal) {
-			throw new AnalyzeError(
-				'Spatio-temporal analysis is disabled in the active configuration',
-				ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
-				{
-					context: {
-						enabled: config.analysis.enabled,
-						spatioTemporal: config.analysis.spatio_temporal,
-					},
+	const thesisInputs =
+		thesisOverrides.length > 0 ? thesisOverrides : normalizeThesisList(config.analysis.evidence_theses);
+	if (thesisInputs.length === 0) {
+		throw new AnalyzeError(
+			'At least one thesis query is required for evidence-chain analysis',
+			ANALYZE_ERROR_CODES.ANALYZE_THESIS_INPUT_MISSING,
+		);
+	}
+
+	const outcomes: EvidenceChainThesisOutcome[] = [];
+	const errors: StepError[] = [];
+
+	for (const thesis of thesisInputs) {
+		try {
+			const computation = await computeEvidenceChainsForThesis(pool, config, thesis);
+			const computedAt = new Date();
+			const snapshotRows = buildEvidenceChainInputs(computation.thesis, computation, computedAt);
+			const writtenCount = await replaceEvidenceChainsSnapshot(pool, computation.thesis, snapshotRows);
+
+			outcomes.push({
+				thesis: computation.thesis,
+				status: 'success',
+				seedCount: computation.seedIds.length,
+				supportingCount: computation.supportingChains.length,
+				contradictionCount: computation.contradictionChains.length,
+				writtenCount,
+			});
+		} catch (cause: unknown) {
+			const analyzeError =
+				cause instanceof AnalyzeError
+					? cause
+					: new AnalyzeError(
+							`Unexpected analyze failure for thesis "${thesis}"`,
+							ANALYZE_ERROR_CODES.ANALYZE_TRAVERSAL_FAILED,
+							{
+								cause,
+								context: { thesis },
+							},
+						);
+			errors.push(toStepError(analyzeError, thesis));
+			outcomes.push({
+				thesis,
+				status: 'failed',
+				seedCount: 0,
+				supportingCount: 0,
+				contradictionCount: 0,
+				writtenCount: 0,
+			});
+			log.warn({ err: cause, thesis }, 'Analyze failed for evidence-chain thesis — continuing');
+		}
+	}
+
+	const data = makeEvidenceChainsData(outcomes);
+	const status =
+		errors.length === 0 ? 'success' : outcomes.some((outcome) => outcome.status === 'success') ? 'partial' : 'failed';
+	const durationMs = Math.round(performance.now() - startTime);
+
+	log.info(
+		{
+			mode: data.mode,
+			thesisCount: data.thesisCount,
+			processedCount: data.processedCount,
+			successCount: data.successCount,
+			failedCount: data.failedCount,
+			supportingCount: data.supportingCount,
+			contradictionCount: data.contradictionCount,
+			duration_ms: durationMs,
+		},
+		'Analyze step completed',
+	);
+
+	return {
+		status,
+		data,
+		errors,
+		metadata: {
+			duration_ms: durationMs,
+			items_processed: data.processedCount,
+			items_skipped: data.failedCount,
+			items_cached: 0,
+		},
+	};
+}
+
+async function executeSpatioTemporalPass(config: MulderConfig, pool: pg.Pool, log: Logger): Promise<AnalyzeResult> {
+	const startTime = performance.now();
+
+	if (!config.analysis.enabled || !config.analysis.spatio_temporal) {
+		throw new AnalyzeError(
+			'Spatio-temporal analysis is disabled in the active configuration',
+			ANALYZE_ERROR_CODES.ANALYZE_DISABLED,
+			{
+				context: {
+					enabled: config.analysis.enabled,
+					spatioTemporal: config.analysis.spatio_temporal,
 				},
-			);
-		}
-
-		const computation = await computeSpatioTemporalClusters(
-			pool,
-			config.analysis.cluster_window_days,
-			config.thresholds.temporal_clustering,
-		);
-
-		const persistedCount = computation.nothingToAnalyze
-			? 0
-			: (await replaceSpatioTemporalClustersSnapshot(pool, computation.snapshotRows)).length;
-
-		const data = makeSpatioTemporalData(computation, persistedCount);
-		const durationMs = Math.round(performance.now() - startTime);
-
-		log.info(
-			{
-				mode: data.mode,
-				eventCount: data.eventCount,
-				timestampEventCount: data.timestampEventCount,
-				geometryEventCount: data.geometryEventCount,
-				spatioTemporalEventCount: data.spatioTemporalEventCount,
-				persistedCount: data.persistedCount,
-				temporalClusterCount: data.temporalClusterCount,
-				spatialClusterCount: data.spatialClusterCount,
-				spatioTemporalClusterCount: data.spatioTemporalClusterCount,
-				belowThreshold: data.belowThreshold,
-				nothingToAnalyze: data.nothingToAnalyze,
-				duration_ms: durationMs,
 			},
-			'Analyze step completed',
 		);
-
-		return {
-			status: 'success',
-			data,
-			errors: [],
-			metadata: {
-				duration_ms: durationMs,
-				items_processed: data.persistedCount,
-				items_skipped: data.belowThreshold ? data.eventCount : 0,
-				items_cached: 0,
-			},
-		};
 	}
+
+	const computation = await computeSpatioTemporalClusters(
+		pool,
+		config.analysis.cluster_window_days,
+		config.thresholds.temporal_clustering,
+	);
+
+	const persistedCount = computation.nothingToAnalyze
+		? 0
+		: (await replaceSpatioTemporalClustersSnapshot(pool, computation.snapshotRows)).length;
+
+	const data = makeSpatioTemporalData(computation, persistedCount);
+	const durationMs = Math.round(performance.now() - startTime);
+
+	log.info(
+		{
+			mode: data.mode,
+			eventCount: data.eventCount,
+			timestampEventCount: data.timestampEventCount,
+			geometryEventCount: data.geometryEventCount,
+			spatioTemporalEventCount: data.spatioTemporalEventCount,
+			persistedCount: data.persistedCount,
+			temporalClusterCount: data.temporalClusterCount,
+			spatialClusterCount: data.spatialClusterCount,
+			spatioTemporalClusterCount: data.spatioTemporalClusterCount,
+			belowThreshold: data.belowThreshold,
+			nothingToAnalyze: data.nothingToAnalyze,
+			duration_ms: durationMs,
+		},
+		'Analyze step completed',
+	);
+
+	return {
+		status: 'success',
+		data,
+		errors: [],
+		metadata: {
+			duration_ms: durationMs,
+			items_processed: data.persistedCount,
+			items_skipped: data.belowThreshold ? data.eventCount : 0,
+			items_cached: 0,
+		},
+	};
+}
+
+async function executeReliabilityPass(config: MulderConfig, pool: pg.Pool, log: Logger): Promise<AnalyzeResult> {
+	const startTime = performance.now();
 
 	if (!config.analysis.enabled || !config.analysis.reliability) {
 		throw new AnalyzeError(
@@ -859,4 +964,187 @@ export async function execute(
 			items_cached: 0,
 		},
 	};
+}
+
+async function executeSinglePass(
+	pass: AnalyzePassName,
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool,
+	logger: Logger,
+	thesisOverrides: string[],
+): Promise<AnalyzeResult> {
+	const passLog = createChildLogger(logger, {
+		step: STEP_NAME,
+		pass,
+	});
+
+	switch (pass) {
+		case 'contradictions':
+			return executeContradictionsPass(config, services, pool, passLog);
+		case 'reliability':
+			return executeReliabilityPass(config, pool, passLog);
+		case 'evidence-chains':
+			return executeEvidenceChainsPass(config, pool, passLog, thesisOverrides);
+		case 'spatio-temporal':
+			return executeSpatioTemporalPass(config, pool, passLog);
+	}
+}
+
+async function executeFullAnalyze(
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool,
+	logger: Logger,
+	thesisOverrides: string[],
+): Promise<AnalyzeResult> {
+	const log = createChildLogger(logger, {
+		step: STEP_NAME,
+		full: true,
+	});
+	const startTime = performance.now();
+
+	if (!config.analysis.enabled) {
+		throw new AnalyzeError('Analyze is disabled in the active configuration', ANALYZE_ERROR_CODES.ANALYZE_DISABLED, {
+			context: { enabled: config.analysis.enabled },
+		});
+	}
+
+	const passes: AnalyzePassResult[] = [];
+
+	for (const pass of FULL_PASS_ORDER) {
+		if (pass === 'contradictions' && !config.analysis.contradictions) {
+			passes.push(createSkippedPassResult(pass, 'disabled by config'));
+			continue;
+		}
+		if (pass === 'reliability' && !config.analysis.reliability) {
+			passes.push(createSkippedPassResult(pass, 'disabled by config'));
+			continue;
+		}
+		if (pass === 'evidence-chains') {
+			if (!config.analysis.evidence_chains) {
+				passes.push(createSkippedPassResult(pass, 'disabled by config'));
+				continue;
+			}
+			const thesisInputs =
+				thesisOverrides.length > 0 ? thesisOverrides : normalizeThesisList(config.analysis.evidence_theses);
+			if (thesisInputs.length === 0) {
+				passes.push(createSkippedPassResult(pass, 'no thesis input configured'));
+				continue;
+			}
+		}
+		if (pass === 'spatio-temporal' && !config.analysis.spatio_temporal) {
+			passes.push(createSkippedPassResult(pass, 'disabled by config'));
+			continue;
+		}
+
+		try {
+			const passResult = await executeSinglePass(pass, config, services, pool, log, thesisOverrides);
+			passes.push(toAnalyzePassResult(pass, passResult));
+		} catch (cause: unknown) {
+			const analyzeError =
+				cause instanceof AnalyzeError
+					? cause
+					: new AnalyzeError(
+							`Unexpected full analyze failure in ${pass}`,
+							ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED,
+							{
+								cause,
+								context: { pass },
+							},
+						);
+			log.warn({ err: cause, pass }, 'Analyze full mode pass failed');
+			passes.push(createFailedPassResult(pass, analyzeError));
+		}
+	}
+
+	const data = makeFullAnalyzeData(passes);
+	const status = getFullAnalyzeStatus(data);
+	const durationMs = Math.round(performance.now() - startTime);
+	const metadataTotals = getPassMetadataTotals(passes);
+	const errors = passes.flatMap((pass) => pass.errors);
+
+	log.info(
+		{
+			mode: data.mode,
+			passCount: data.passCount,
+			attemptedCount: data.attemptedCount,
+			successCount: data.successCount,
+			partialCount: data.partialCount,
+			failedCount: data.failedCount,
+			skippedCount: data.skippedCount,
+			duration_ms: durationMs,
+		},
+		'Analyze step completed',
+	);
+
+	return {
+		status,
+		data,
+		errors,
+		metadata: {
+			duration_ms: durationMs,
+			items_processed: metadataTotals.items_processed,
+			items_skipped: metadataTotals.items_skipped,
+			items_cached: metadataTotals.items_cached,
+		},
+	};
+}
+
+export async function execute(
+	input: AnalyzeInput,
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool | undefined,
+	logger: Logger,
+): Promise<AnalyzeResult> {
+	if (!pool) {
+		throw new AnalyzeError('Database pool is required for analyze step', ANALYZE_ERROR_CODES.ANALYZE_WRITE_FAILED);
+	}
+
+	const hasRawThesisOverrides = Array.isArray(input.theses) && input.theses.length > 0;
+	const thesisOverrides = normalizeThesisList(input.theses);
+	if (hasRawThesisOverrides && thesisOverrides.length === 0) {
+		throw new AnalyzeError(
+			'At least one non-empty thesis override is required',
+			ANALYZE_ERROR_CODES.ANALYZE_THESIS_INPUT_MISSING,
+			{
+				context: { thesisCount: input.theses?.length ?? 0 },
+			},
+		);
+	}
+
+	if (hasRawThesisOverrides && !input.evidenceChains && !input.full) {
+		throw new AnalyzeError(
+			'The --thesis override can only be used with evidence-chain analysis',
+			ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED,
+			{
+				context: { thesisCount: thesisOverrides.length },
+			},
+		);
+	}
+
+	const selectedModes = getSelectedModes(input);
+
+	if (input.full) {
+		if (selectedModes.length > 0) {
+			throw new AnalyzeError(
+				'Full analyze mode cannot be combined with explicit single-pass selectors',
+				ANALYZE_ERROR_CODES.ANALYZE_VALIDATION_FAILED,
+				{
+					context: { selectedModes },
+				},
+			);
+		}
+
+		return executeFullAnalyze(config, services, pool, logger, thesisOverrides);
+	}
+
+	if (selectedModes.length !== 1) {
+		throw new AnalyzeError('Exactly one analyze selector must be enabled', ANALYZE_ERROR_CODES.ANALYZE_DISABLED, {
+			context: { selectedModes },
+		});
+	}
+
+	return executeSinglePass(selectedModes[0], config, services, pool, logger, thesisOverrides);
 }

--- a/packages/pipeline/src/analyze/types.ts
+++ b/packages/pipeline/src/analyze/types.ts
@@ -8,12 +8,17 @@
 import type { StepError } from '@mulder/core';
 
 export interface AnalyzeInput {
+	full?: boolean;
 	contradictions?: boolean;
 	reliability?: boolean;
 	evidenceChains?: boolean;
 	spatioTemporal?: boolean;
 	theses?: string[];
 }
+
+export type AnalyzePassName = 'contradictions' | 'reliability' | 'evidence-chains' | 'spatio-temporal';
+
+export type AnalyzePassStatus = 'success' | 'partial' | 'failed' | 'skipped';
 
 export type ContradictionVerdict = 'confirmed' | 'dismissed';
 
@@ -122,11 +127,38 @@ export interface SpatioTemporalAnalyzeData {
 	warning: string | null;
 }
 
-export type AnalyzeData =
+export type SingleAnalyzeData =
 	| ContradictionAnalyzeData
 	| ReliabilityAnalyzeData
 	| EvidenceChainsAnalyzeData
 	| SpatioTemporalAnalyzeData;
+
+export interface AnalyzePassResult {
+	pass: AnalyzePassName;
+	status: AnalyzePassStatus;
+	summary: string;
+	data: SingleAnalyzeData | null;
+	errors: StepError[];
+	metadata: {
+		duration_ms: number;
+		items_processed: number;
+		items_skipped: number;
+		items_cached: number;
+	};
+}
+
+export interface FullAnalyzeData {
+	mode: 'full';
+	passCount: number;
+	attemptedCount: number;
+	successCount: number;
+	partialCount: number;
+	failedCount: number;
+	skippedCount: number;
+	passes: AnalyzePassResult[];
+}
+
+export type AnalyzeData = SingleAnalyzeData | FullAnalyzeData;
 
 export interface AnalyzeResult {
 	status: 'success' | 'partial' | 'failed';

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,6 +1,8 @@
 export type {
 	AnalyzeData,
 	AnalyzeInput,
+	AnalyzePassName,
+	AnalyzePassResult,
 	AnalyzeResult,
 	ContradictionAnalyzeData,
 	ContradictionResolutionOutcome,
@@ -8,7 +10,9 @@ export type {
 	ContradictionVerdict,
 	EvidenceChainsAnalyzeData,
 	EvidenceChainThesisOutcome,
+	FullAnalyzeData,
 	ReliabilityAnalyzeData,
+	SingleAnalyzeData,
 	SourceReliabilityOutcome,
 	SpatioTemporalAnalyzeData,
 	SpatioTemporalCluster,
@@ -89,6 +93,7 @@ export { execute as executeGround } from './ground/index.js';
 export type { IngestFileResult, IngestInput, IngestResult } from './ingest/index.js';
 export { execute as executeIngest } from './ingest/index.js';
 export type {
+	PipelineGlobalAnalysisOutcome,
 	PipelineRunInput,
 	PipelineRunOptions,
 	PipelineRunResult,

--- a/packages/pipeline/src/pipeline/index.ts
+++ b/packages/pipeline/src/pipeline/index.ts
@@ -31,6 +31,7 @@ import {
 	upsertPipelineRunSource,
 } from '@mulder/core';
 import type pg from 'pg';
+import { execute as executeAnalyze } from '../analyze/index.js';
 import { execute as executeEmbed } from '../embed/index.js';
 import { execute as executeEnrich } from '../enrich/index.js';
 import { execute as executeExtract } from '../extract/index.js';
@@ -38,6 +39,7 @@ import { execute as executeGraph } from '../graph/index.js';
 import { execute as executeIngest } from '../ingest/index.js';
 import { execute as executeSegment } from '../segment/index.js';
 import type {
+	PipelineGlobalAnalysisOutcome,
 	PipelineRunInput,
 	PipelineRunOptions,
 	PipelineRunResult,
@@ -47,6 +49,7 @@ import type {
 
 // Re-export types for the package barrel.
 export type {
+	PipelineGlobalAnalysisOutcome,
 	PipelineRunInput,
 	PipelineRunOptions,
 	PipelineRunResult,
@@ -248,6 +251,22 @@ function computePlannedSteps(options: PipelineRunOptions): PipelineStepName[] {
 	}
 
 	return STEP_ORDER.slice(fromIdx, upToIdx + 1);
+}
+
+function createSkippedGlobalAnalysis(summary: string): PipelineGlobalAnalysisOutcome {
+	return {
+		status: 'skipped',
+		summary,
+		result: null,
+	};
+}
+
+function summarizeGlobalAnalyzeResult(result: Awaited<ReturnType<typeof executeAnalyze>>): string {
+	if (result.data.mode === 'full') {
+		return `${result.data.successCount} successful, ${result.data.partialCount} partial, ${result.data.failedCount} failed, ${result.data.skippedCount} skipped`;
+	}
+
+	return result.status;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -572,6 +591,11 @@ export async function execute(
 
 		log.info({ plannedSteps, dryRunSourceCount }, 'pipeline.run.dry_run');
 
+		const dryRunAnalysis =
+			config.analysis.enabled && plannedSteps.includes('graph') && options.upTo === undefined
+				? createSkippedGlobalAnalysis('dry run — global analyze would run after graph')
+				: createSkippedGlobalAnalysis('dry run — global analyze would not run');
+
 		return {
 			status: 'success',
 			runId: '',
@@ -584,6 +608,7 @@ export async function execute(
 				failedSources: 0,
 				skippedSources: dryRunSourceCount,
 				sources: [],
+				analysis: dryRunAnalysis,
 			},
 			errors: [],
 			metadata: {
@@ -675,6 +700,25 @@ export async function execute(
 			}
 		}
 
+		let globalAnalysis: PipelineGlobalAnalysisOutcome;
+		if (options.upTo !== undefined) {
+			globalAnalysis = createSkippedGlobalAnalysis('pipeline stopped before global analyze');
+		} else if (!plannedSteps.includes('graph')) {
+			globalAnalysis = createSkippedGlobalAnalysis('planned steps stop before graph');
+		} else if (!config.analysis.enabled) {
+			globalAnalysis = createSkippedGlobalAnalysis('analysis disabled by config');
+		} else if (completedCount === 0) {
+			globalAnalysis = createSkippedGlobalAnalysis('no sources reached graph successfully');
+		} else {
+			const analyzeResult = await executeAnalyze({ full: true }, config, services, pool, runLog);
+			errors.push(...analyzeResult.errors);
+			globalAnalysis = {
+				status: analyzeResult.status,
+				summary: summarizeGlobalAnalyzeResult(analyzeResult),
+				result: analyzeResult,
+			};
+		}
+
 		// 6. Finalisation (Phase 3).
 		let runStatus: 'success' | 'partial' | 'failed';
 		if (sources.length === 0) {
@@ -684,6 +728,12 @@ export async function execute(
 		} else if (completedCount === 0) {
 			runStatus = 'failed';
 		} else {
+			runStatus = 'partial';
+		}
+
+		if (globalAnalysis.status === 'failed') {
+			runStatus = 'failed';
+		} else if (globalAnalysis.status === 'partial' && runStatus !== 'failed') {
 			runStatus = 'partial';
 		}
 
@@ -698,6 +748,7 @@ export async function execute(
 				totalSources: sources.length,
 				completedSources: completedCount,
 				failedSources: failedCount,
+				globalAnalysisStatus: globalAnalysis.status,
 			},
 			'pipeline.run.finish',
 		);
@@ -714,12 +765,13 @@ export async function execute(
 				failedSources: failedCount,
 				skippedSources: 0,
 				sources: sourceOutcomes,
+				analysis: globalAnalysis,
 			},
 			errors,
 			metadata: {
 				duration_ms: durationMs,
-				items_processed: completedCount,
-				items_skipped: 0,
+				items_processed: completedCount + (globalAnalysis.result?.metadata.items_processed ?? 0),
+				items_skipped: globalAnalysis.result?.metadata.items_skipped ?? 0,
 			},
 		};
 	} catch (cause) {

--- a/packages/pipeline/src/pipeline/types.ts
+++ b/packages/pipeline/src/pipeline/types.ts
@@ -11,6 +11,7 @@
  */
 
 import type { StepError } from '@mulder/core';
+import type { AnalyzeResult } from '../analyze/types.js';
 
 // ────────────────────────────────────────────────────────────
 // Step naming
@@ -63,6 +64,12 @@ export interface PipelineRunSourceOutcome {
 	errorMessage: string | null;
 }
 
+export interface PipelineGlobalAnalysisOutcome {
+	status: 'success' | 'partial' | 'failed' | 'skipped';
+	summary: string;
+	result: AnalyzeResult | null;
+}
+
 /** Orchestrator result. */
 export interface PipelineRunResult {
 	/** `success` = all sources completed; `partial` = some failed; `failed` = all failed. */
@@ -78,6 +85,7 @@ export interface PipelineRunResult {
 		failedSources: number;
 		skippedSources: number;
 		sources: PipelineRunSourceOutcome[];
+		analysis: PipelineGlobalAnalysisOutcome;
 	};
 	errors: StepError[];
 	metadata: {

--- a/tests/specs/61_contradiction_resolution.test.ts
+++ b/tests/specs/61_contradiction_resolution.test.ts
@@ -312,22 +312,30 @@ describe('Spec 61 — Contradiction Resolution', () => {
 		expect(`${result.stdout}\n${result.stderr}`).toMatch(/unknown option|unexpected option/i);
 	});
 
-	it('CLI-04: --contradictions --full exits non-zero because --full belongs to M6-G7', () => {
+	it('CLI-04: --contradictions --full exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
 		const result = runCli(['analyze', '--contradictions', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.stderr).toContain('--full cannot be combined');
 	});
 
-	it('CLI-05: no args exits non-zero and asks for an analysis selector', () => {
+	it('CLI-05: no args now runs full analyze mode by default', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
 		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('--contradictions');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('contradictions');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
-	it('CLI-06: --full exits non-zero because the full Analyze orchestrator is not implemented yet', () => {
+	it('CLI-06: --full runs the same full analyze sequence explicitly', () => {
+		if (!pgAvailable) return;
+		seedValidFixture();
+
 		const result = runCli(['analyze', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('reliability');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
 	it('CLI-07: --reliability now succeeds because source reliability scoring is implemented', () => {
@@ -368,7 +376,7 @@ describe('CLI Smoke Tests: analyze', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
 	it('SMOKE-03: mulder analyze --contradictions --spatio-temporal exits non-zero with selector validation', () => {
@@ -376,6 +384,6 @@ describe('CLI Smoke Tests: analyze', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 });

--- a/tests/specs/62_source_reliability_scoring.test.ts
+++ b/tests/specs/62_source_reliability_scoring.test.ts
@@ -317,27 +317,35 @@ describe('Spec 62 — Source Reliability Scoring', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
-	it('CLI-04: --reliability --full exits non-zero because --full belongs to M6-G7', () => {
+	it('CLI-04: --reliability --full exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
 		const result = runCli(['analyze', '--reliability', '--full'], {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.stderr).toContain('--full cannot be combined');
 	});
 
-	it('CLI-05: no args exits non-zero and asks for an analysis selector', () => {
+	it('CLI-05: no args now runs full analyze mode by default', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
 		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('--contradictions');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('reliability');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
-	it('CLI-06: --full exits non-zero because the full Analyze orchestrator is not implemented yet', () => {
+	it('CLI-06: --full runs the full analyze sequence explicitly', () => {
+		if (!pgAvailable) return;
+		seedConnectedFixture();
+
 		const result = runCli(['analyze', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('contradictions');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
 	it('CLI-07: --evidence-chains exits non-zero when no thesis input is configured', () => {
@@ -369,7 +377,7 @@ describe('CLI Smoke Tests: analyze reliability', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
 	it('SMOKE-03: mulder analyze --reliability --spatio-temporal exits non-zero with selector validation', () => {
@@ -377,6 +385,6 @@ describe('CLI Smoke Tests: analyze reliability', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 });

--- a/tests/specs/63_evidence_chains.test.ts
+++ b/tests/specs/63_evidence_chains.test.ts
@@ -425,7 +425,7 @@ describe('Spec 63 — Evidence Chains', () => {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
 	it('CLI-06: `--evidence-chains --contradictions` exits non-zero because multi-selector analyze is not implemented yet', () => {
@@ -433,15 +433,15 @@ describe('Spec 63 — Evidence Chains', () => {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
-	it('CLI-07: `--evidence-chains --full` exits non-zero because `--full` belongs to M6-G7', () => {
+	it('CLI-07: `--evidence-chains --full` exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
 		const result = runCli(['analyze', '--evidence-chains', '--full'], {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.stderr).toContain('--full cannot be combined');
 	});
 
 	it('CLI-08: `--evidence-chains --thesis ""` exits non-zero with thesis validation feedback', () => {
@@ -449,13 +449,18 @@ describe('Spec 63 — Evidence Chains', () => {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('cannot be empty');
+		expect(result.stderr).toContain('at least one non-empty value');
 	});
 
-	it('CLI-09: `mulder analyze` with no args exits non-zero and asks for an analysis selector', () => {
+	it('CLI-09: `mulder analyze` with no args now runs full analyze mode and skips thesis-less evidence chains', () => {
+		if (!pgAvailable) return;
+		seedSupportFixture();
+
 		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledEmptyThesisConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('analysis selector');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('evidence-chains');
+		expect(result.stdout).toContain('skipped');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
 	it('CLI-10: `--spatio-temporal` now succeeds as a no-op when no clusterable events exist', () => {

--- a/tests/specs/64_spatio_temporal_clustering.test.ts
+++ b/tests/specs/64_spatio_temporal_clustering.test.ts
@@ -347,7 +347,7 @@ describe('Spec 64 — Spatio-Temporal Clustering', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
 	it('CLI-04: --spatio-temporal --evidence-chains exits non-zero because multi-selector analyze is not implemented yet', () => {
@@ -355,7 +355,7 @@ describe('Spec 64 — Spatio-Temporal Clustering', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
 	it('CLI-05: --spatio-temporal --contradictions exits non-zero because multi-selector analyze is not implemented yet', () => {
@@ -363,26 +363,34 @@ describe('Spec 64 — Spatio-Temporal Clustering', () => {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('one selector at a time');
+		expect(result.stderr).toContain('one selector or --full');
 	});
 
-	it('CLI-06: --spatio-temporal --full exits non-zero because --full belongs to M6-G7', () => {
+	it('CLI-06: --spatio-temporal --full exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
 		const result = runCli(['analyze', '--spatio-temporal', '--full'], {
 			env: { MULDER_CONFIG: enabledConfigPath },
 		});
 		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.stderr).toContain('--full cannot be combined');
 	});
 
-	it('CLI-07: no args exits non-zero and asks for an analysis selector', () => {
+	it('CLI-07: no args now runs full analyze mode by default', () => {
+		if (!pgAvailable) return;
+		seedThreeEventFixture();
+
 		const result = runCli(['analyze'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('analysis selector');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('spatio-temporal');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 
-	it('CLI-08: --full exits non-zero because the full Analyze orchestrator is not implemented yet', () => {
+	it('CLI-08: --full runs the full analyze sequence explicitly', () => {
+		if (!pgAvailable) return;
+		seedThreeEventFixture();
+
 		const result = runCli(['analyze', '--full'], { env: { MULDER_CONFIG: enabledConfigPath } });
-		expect(result.exitCode).not.toBe(0);
-		expect(result.stderr).toContain('M6-G7');
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('contradictions');
+		expect(result.stderr).toContain('Analyze complete');
 	});
 });

--- a/tests/specs/65_analyze_full_orchestrator.test.ts
+++ b/tests/specs/65_analyze_full_orchestrator.test.ts
@@ -1,0 +1,195 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const FIXTURE_DIR = resolve(ROOT, 'fixtures/raw');
+const EXTRACTED_DIR = resolve(ROOT, '.local/storage/extracted');
+const SEGMENTS_DIR = resolve(ROOT, '.local/storage/segments');
+const NATIVE_TEXT_PDF = resolve(FIXTURE_DIR, 'native-text-sample.pdf');
+
+let tmpDir: string;
+let pgAvailable = false;
+let analyzeEnabledConfigPath: string;
+
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 120_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+			...opts?.env,
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function writeAnalyzeEnabledConfig(): string {
+	const base = readFileSync(EXAMPLE_CONFIG, 'utf-8');
+	const devModeEnabled = base.replace(/^dev_mode:\s*false$/m, 'dev_mode: true');
+	const replacement = [
+		'analysis:',
+		'  enabled: true',
+		'  contradictions: true',
+		'  reliability: true',
+		'  evidence_chains: true',
+		'  evidence_theses: []',
+		'  cluster_window_days: 30',
+		'  spatio_temporal: true',
+		'',
+		'# --- Sparse Graph Thresholds ---',
+	].join('\n');
+
+	const updated = devModeEnabled.replace(/analysis:\n[\s\S]*?\n# --- Sparse Graph Thresholds ---/, replacement);
+	const configPath = join(tmpDir, `analyze-enabled-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
+	writeFileSync(configPath, updated, 'utf-8');
+	return configPath;
+}
+
+function cleanStorageFixtures(): void {
+	for (const dir of [SEGMENTS_DIR, EXTRACTED_DIR]) {
+		if (!existsSync(dir)) {
+			continue;
+		}
+
+		for (const entry of readdirSync(dir)) {
+			if (entry === '_schema.json') continue;
+			rmSync(join(dir, entry), { recursive: true, force: true });
+		}
+	}
+}
+
+function ensurePageImages(sourceId: string): void {
+	const pagesDir = join(EXTRACTED_DIR, sourceId, 'pages');
+	if (existsSync(pagesDir)) {
+		return;
+	}
+
+	const layoutPath = join(EXTRACTED_DIR, sourceId, 'layout.json');
+	if (!existsSync(layoutPath)) {
+		return;
+	}
+
+	const layout = JSON.parse(readFileSync(layoutPath, 'utf-8')) as { pageCount: number };
+	mkdirSync(pagesDir, { recursive: true });
+	const minimalPng = Buffer.from(
+		'89504e470d0a1a0a0000000d49484452000000010000000108020000009001be' +
+			'0000000c4944415478da6360f80f00000101000518d84e0000000049454e44ae426082',
+		'hex',
+	);
+
+	for (let i = 1; i <= layout.pageCount; i++) {
+		const padded = String(i).padStart(3, '0');
+		writeFileSync(join(pagesDir, `page-${padded}.png`), minimalPng);
+	}
+}
+
+function makeWorkDir(name: string): string {
+	const dir = resolve(tmpDir, name);
+	rmSync(dir, { recursive: true, force: true });
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, 'native-text-sample.pdf'), readFileSync(NATIVE_TEXT_PDF));
+	return dir;
+}
+
+describe.sequential('Spec 65 — Analyze Full Orchestrator', () => {
+	beforeAll(() => {
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			console.warn('SKIP: PostgreSQL container not available. Start with:\n  docker compose up -d');
+			return;
+		}
+
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-spec65-'));
+		ensureSchema();
+		analyzeEnabledConfigPath = writeAnalyzeEnabledConfig();
+	});
+
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		truncateMulderTables();
+		cleanStorageFixtures();
+	});
+
+	afterAll(() => {
+		if (!pgAvailable) return;
+		truncateMulderTables();
+		cleanStorageFixtures();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('QA-06: pipeline run appends one global analyze phase after graph when analysis is enabled', () => {
+		if (!pgAvailable) return;
+
+		const workDir = makeWorkDir('qa06');
+		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], {
+			env: { MULDER_CONFIG: analyzeEnabledConfigPath },
+			timeout: 240_000,
+		});
+		expect(stage1.exitCode).toBe(0);
+
+		const sourceId = db.runSql(
+			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
+		);
+		expect(sourceId).toMatch(/^[0-9a-f-]+$/);
+		ensurePageImages(sourceId);
+
+		const stage2 = runCli(['pipeline', 'run', workDir, '--from', 'segment'], {
+			env: { MULDER_CONFIG: analyzeEnabledConfigPath },
+			timeout: 600_000,
+		});
+		expect(stage2.exitCode).toBe(0);
+		expect(stage2.stdout).toContain('Global analyze: success');
+
+		const runStatus = db.runSql('SELECT status FROM pipeline_runs ORDER BY created_at DESC LIMIT 1;');
+		expect(runStatus).toBe('completed');
+
+		const sourceStep = db.runSql(
+			'SELECT current_step FROM pipeline_run_sources WHERE run_id = (SELECT id FROM pipeline_runs ORDER BY created_at DESC LIMIT 1) ' +
+				`AND source_id = '${sourceId}';`,
+		);
+		expect(sourceStep).toBe('graph');
+	}, 900_000);
+
+	it('QA-07: --up-to graph intentionally skips the global analyze phase', () => {
+		if (!pgAvailable) return;
+
+		const workDir = makeWorkDir('qa07');
+		const stage1 = runCli(['pipeline', 'run', workDir, '--up-to', 'extract'], {
+			env: { MULDER_CONFIG: analyzeEnabledConfigPath },
+			timeout: 240_000,
+		});
+		expect(stage1.exitCode).toBe(0);
+
+		const sourceId = db.runSql(
+			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
+		);
+		ensurePageImages(sourceId);
+
+		const stage2 = runCli(['pipeline', 'run', workDir, '--from', 'segment', '--up-to', 'graph'], {
+			env: { MULDER_CONFIG: analyzeEnabledConfigPath },
+			timeout: 600_000,
+		});
+		expect(stage2.exitCode).toBe(0);
+		expect(stage2.stdout).toContain('Global analyze: skipped');
+		expect(stage2.stdout).toContain('pipeline stopped before global analyze');
+	}, 900_000);
+});


### PR DESCRIPTION
## Summary
- implement Spec 65 / M6-G7 so bare `mulder analyze` and `--full` run enabled analyze passes in sequence
- aggregate per-pass analyze results in the pipeline layer and report post-graph global analysis from `mulder pipeline run`
- add and update black-box spec coverage for the new full-analyze behavior and selector semantics

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- tests/specs/61_contradiction_resolution.test.ts tests/specs/62_source_reliability_scoring.test.ts tests/specs/63_evidence_chains.test.ts tests/specs/64_spatio_temporal_clustering.test.ts`
- `pnpm exec vitest run tests/specs/65_analyze_full_orchestrator.test.ts`

Closes #158
