### PR TITLE
Fix evidence-chain sparse-data gating

### DIFF
--- a/apps/cli/src/commands/analyze.ts
+++ b/apps/cli/src/commands/analyze.ts
@@ -265,6 +265,24 @@ function printSingleAnalyzeResult(result: AnalyzeResult): void {
 		return;
 	}
 
+	if (result.data.warning) {
+		process.stderr.write(`Analyze warning: ${result.data.warning}\n`);
+	}
+
+	if (result.data.belowThreshold) {
+		const summary = `${result.data.skippedCount} theses skipped (${result.metadata.duration_ms}ms)`;
+
+		if (result.status === 'failed') {
+			printError(`Analyze failed: ${summary}`);
+			process.exit(1);
+		} else if (result.status === 'partial') {
+			process.stderr.write(`Analyze partial: ${summary}\n`);
+		} else {
+			printSuccess(`Analyze complete: ${summary}`);
+		}
+		return;
+	}
+
 	if (result.data.supportingCount === 0 && result.data.contradictionCount === 0 && result.data.failedCount === 0) {
 		printSuccess(`Analyze complete: no evidence chains found (${result.metadata.duration_ms}ms)`);
 		return;

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -1474,7 +1474,7 @@ thresholds:
 - **Taxonomy** < threshold: Entities are extracted but not normalized. Raw entity names in the graph.
 - **Corroboration** < threshold: Score returned as `null` / `"insufficient_data"`, not `1`.
 - **Hybrid Retrieval** with sparse data: All three strategies (vector, fulltext, graph) still execute. The graph strategy naturally returns 0 hits when there are no entities to seed traversal — this is the "fallback to pure vector search" behavior in practice. RRF fusion handles the empty-strategy case correctly: only the strategies that returned results contribute to the fused list. The `confidence.degraded` flag is set so the orchestrator and clients can react.
-- **Evidence chains** < threshold: Feature disabled, API endpoint returns `501 Not Yet Available` with explanation.
+- **Evidence chains** < `thresholds.corroboration_meaningful`: Feature disabled for sparse corpora. `mulder analyze --evidence-chains` reports a clear degraded/not-yet-available reason, performs no traversal, and does not write `evidence_chains` rows. The future API endpoint returns `501 Not Yet Available` with explanation.
 
 **API response `confidence` object:**
 ```json

--- a/docs/specs/63_evidence_chains.spec.md
+++ b/docs/specs/63_evidence_chains.spec.md
@@ -4,7 +4,7 @@ title: "Evidence Chains"
 roadmap_step: M6-G5
 functional_spec: ["§2.8", "§4.3"]
 scope: phased
-issue: "https://github.com/mulkatz/mulder/issues/154"
+issue: "https://github.com/mulkatz/mulder/issues/162"
 created: 2026-04-12
 ---
 
@@ -12,15 +12,15 @@ created: 2026-04-12
 
 ## 1. Objective
 
-Implement Mulder's third Analyze sub-step so `mulder analyze --evidence-chains` resolves one or more thesis queries into deterministic graph traversals, stores the resulting evidence paths in `evidence_chains`, and exposes the results through the existing Analyze CLI surface. Per `§2.8`, the step operates on the full graph rather than a single story, uses recursive traversal with cycle detection to trace supporting paths, and persists each thesis/path/strength result for later evidence review and export. Per `§4.3`, the persisted output must land in the existing `evidence_chains` table using its `thesis`, `path`, `strength`, `supports`, and `computed_at` columns.
+Implement Mulder's third Analyze sub-step so `mulder analyze --evidence-chains` resolves one or more thesis queries into deterministic graph traversals, stores the resulting evidence paths in `evidence_chains`, and exposes the results through the existing Analyze CLI surface. Per `§2.8`, the step operates on the full graph rather than a single story, uses recursive traversal with cycle detection to trace supporting paths, and persists each thesis/path/strength result for later evidence review and export. Per `§4.3`, the persisted output must land in the existing `evidence_chains` table using its `thesis`, `path`, `strength`, `supports`, and `computed_at` columns. Per `§5.3`, the feature must stay unavailable on sparse corpora: if the processed-source corpus is below `thresholds.corroboration_meaningful`, Analyze reports a degraded "not yet available" reason and must not traverse or write misleading `evidence_chains` rows.
 
 ## 2. Boundaries
 
 - **Roadmap Step:** `M6-G5` — Evidence chains — `mulder analyze --evidence-chains`
 - **Target:** `packages/core/src/config/schema.ts`, `packages/core/src/config/defaults.ts`, `mulder.config.example.yaml`, `packages/core/src/database/repositories/evidence-chain.repository.ts`, `packages/core/src/database/repositories/index.ts`, `packages/core/src/shared/errors.ts`, `packages/core/src/index.ts`, `packages/pipeline/src/analyze/types.ts`, `packages/pipeline/src/analyze/evidence-chains.ts`, `packages/pipeline/src/analyze/index.ts`, `packages/pipeline/src/index.ts`, `apps/cli/src/commands/analyze.ts`
-- **In scope:** config support for default thesis queries, deterministic thesis-to-seed resolution using existing alias/entity matching, recursive graph traversal for evidence-path discovery, persistence helpers for replacing chain snapshots per thesis, Analyze-step orchestration and reporting for evidence-chain runs, and CLI support for `--evidence-chains` plus repeatable thesis overrides
+- **In scope:** config support for default thesis queries, deterministic thesis-to-seed resolution using existing alias/entity matching, recursive graph traversal for evidence-path discovery, persistence helpers for replacing chain snapshots per thesis, sparse-data availability gating before traversal or writes, Analyze-step orchestration and reporting for evidence-chain runs, and CLI support for `--evidence-chains` plus repeatable thesis overrides
 - **Out of scope:** LLM-based thesis interpretation, the `--full` Analyze orchestrator (`M6-G7`), spatio-temporal clustering (`M6-G6`), UI/API evidence browsing, new schema migrations, or changes to retrieval ranking, reranking, or export surfaces beyond what is required to persist evidence-chain rows
-- **Constraints:** keep the step global rather than source- or story-scoped; gate execution with `analysis.enabled` and `analysis.evidence_chains`; prefer deterministic SQL + alias matching over paid model calls; reuse the existing retrieval graph limits (`retrieval.strategies.graph.max_hops`, `retrieval.strategies.graph.supernode_threshold`) for traversal safety; and preserve idempotency by replacing previously stored rows for a thesis on recomputation rather than appending duplicates
+- **Constraints:** keep the step global rather than source- or story-scoped; gate execution with `analysis.enabled` and `analysis.evidence_chains`; treat `thresholds.corroboration_meaningful` as the evidence-chain availability threshold, measured against processed sources beyond raw ingest; prefer deterministic SQL + alias matching over paid model calls; reuse the existing retrieval graph limits (`retrieval.strategies.graph.max_hops`, `retrieval.strategies.graph.supernode_threshold`) for traversal safety; and preserve idempotency by replacing previously stored rows for a thesis on recomputation rather than appending duplicates
 
 ## 3. Dependencies
 
@@ -40,7 +40,7 @@ Implement Mulder's third Analyze sub-step so `mulder analyze --evidence-chains` 
 7. **`packages/core/src/index.ts`** — re-exports the new config, repository, and error symbols for pipeline/CLI consumers
 8. **`packages/pipeline/src/analyze/types.ts`** — extends `AnalyzeInput` with `evidenceChains` and repeatable `theses`, and adds typed evidence-chain outcomes + summary data
 9. **`packages/pipeline/src/analyze/evidence-chains.ts`** — computes evidence chains: resolve thesis queries to seed entities, run recursive traversal with cycle detection and supernode pruning, derive per-path strength, and emit both supporting and contradiction-backed outcomes
-10. **`packages/pipeline/src/analyze/index.ts`** — dispatches the evidence-chain mode, enforces config gates, replaces persisted rows per thesis, and reports success/partial/failure alongside the existing contradiction and reliability modes
+10. **`packages/pipeline/src/analyze/index.ts`** — dispatches the evidence-chain mode, enforces config plus sparse-data gates, replaces persisted rows per thesis only when the feature is available, and reports success/partial/failure alongside the existing contradiction and reliability modes
 11. **`packages/pipeline/src/index.ts`** — re-exports the expanded Analyze contract
 12. **`apps/cli/src/commands/analyze.ts`** — enables `--evidence-chains`, adds repeatable `--thesis <text>` overrides, validates selector combinations, and prints an evidence-chain summary/table
 
@@ -69,6 +69,7 @@ Behavior:
 - If `--thesis` is provided one or more times, those thesis strings are the entire input set for the run
 - If no `--thesis` flags are provided, use `analysis.evidence_theses`
 - If neither source provides a non-empty thesis, fail fast with a clear Analyze-step validation error
+- Evidence-chain availability reuses `thresholds.corroboration_meaningful`; when the processed-source corpus is below that threshold, the step reports a sparse-data skip and must not traverse or persist rows
 
 Traversal should reuse the existing retrieval graph tuning already present in config:
 
@@ -78,11 +79,12 @@ Traversal should reuse the existing retrieval graph tuning already present in co
 ### 4.4 Integration Points
 
 - Thesis-to-seed resolution should reuse `extractQueryEntities()` from `@mulder/retrieval` so the step stays deterministic and aligned with Mulder's existing query-entity matching behavior
+- Sparse-data gating should reuse the shared processed-source corpus count so evidence chains, taxonomy bootstrap, and query confidence all reason about corpus size from the same source-of-truth metric
 - Supporting chains should follow the established recursive-CTE traversal pattern from graph retrieval, including cycle detection and supernode pruning
 - Contradiction-backed chains should reuse resolved contradiction edges (`CONFIRMED_CONTRADICTION`) for any thesis seed entity and persist those rows with `supports=false`
 - Persistence should live behind repository helpers so Analyze does not issue ad hoc insert/delete SQL inline
 - The Analyze CLI must continue to allow exactly one implemented selector at a time, now including `--evidence-chains`
-- CLI output should mirror the current Analyze ergonomics: concise table first, summary second, and non-zero exit only for total failure or invalid invocation
+- CLI output should mirror the current Analyze ergonomics: concise table first, summary second, sparse-data skips reported as warnings, and non-zero exit only for total failure or invalid invocation
 
 ### 4.5 Implementation Phases
 
@@ -100,37 +102,42 @@ Traversal should reuse the existing retrieval graph tuning already present in co
 
 ## 5. QA Contract
 
-1. **QA-01: Configured evidence theses persist supporting chains**
-   - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, `analysis.evidence_theses` contains a thesis whose terms resolve to at least one graph-connected entity, and supporting relationship edges exist in the corpus
+1. **QA-01: Sparse corpora skip evidence-chain traversal and writes**
+   - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, at least one thesis input is available, and the processed-source corpus is below `thresholds.corroboration_meaningful`
+   - When: `mulder analyze --evidence-chains` runs
+   - Then: the command exits `0`, reports a clear sparse-data disabled/degraded reason, and does not insert or replace any `evidence_chains` rows
+
+2. **QA-02: Configured evidence theses persist supporting chains**
+   - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, `analysis.evidence_theses` contains a thesis whose terms resolve to at least one graph-connected entity, the processed-source corpus is at or above `thresholds.corroboration_meaningful`, and supporting relationship edges exist in the corpus
    - When: `mulder analyze --evidence-chains` runs successfully
    - Then: the command exits `0`, creates one or more `evidence_chains` rows for that thesis with non-empty `path`, `strength > 0`, and `supports=true`
 
-2. **QA-02: Re-running the same thesis is idempotent**
-   - Given: the same thesis has already been computed once against an unchanged corpus
+3. **QA-03: Re-running the same thesis is idempotent**
+   - Given: the same thesis has already been computed once against an unchanged corpus whose processed-source count stays at or above `thresholds.corroboration_meaningful`
    - When: `mulder analyze --evidence-chains` is run again with the same thesis input
    - Then: the command exits `0`, the thesis still has a single recomputed snapshot in `evidence_chains`, and no duplicate rows accumulate across runs
 
-3. **QA-03: CLI thesis overrides work without config theses**
-   - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, `analysis.evidence_theses` is empty, and the corpus contains aliases matching a supplied thesis string
+4. **QA-04: CLI thesis overrides work without config theses**
+   - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, `analysis.evidence_theses` is empty, the processed-source corpus is at or above `thresholds.corroboration_meaningful`, and the corpus contains aliases matching a supplied thesis string
    - When: `mulder analyze --evidence-chains --thesis "Acme activity in Berlin"` runs
    - Then: the command exits `0`, computes chains for the supplied thesis, and persists rows whose `thesis` column matches the CLI-provided string
 
-4. **QA-04: Confirmed contradiction evidence is persisted as non-supporting**
-   - Given: a thesis resolves to an entity that already has at least one `CONFIRMED_CONTRADICTION` edge
+5. **QA-05: Confirmed contradiction evidence is persisted as non-supporting**
+   - Given: a thesis resolves to an entity that already has at least one `CONFIRMED_CONTRADICTION` edge, and the processed-source corpus is at or above `thresholds.corroboration_meaningful`
    - When: `mulder analyze --evidence-chains` runs for that thesis
    - Then: at least one persisted `evidence_chains` row for the thesis has `supports=false` and a positive `strength`
 
-5. **QA-05: Missing thesis input fails before traversal or writes**
+6. **QA-06: Missing thesis input fails before traversal or writes**
    - Given: `analysis.enabled=true`, `analysis.evidence_chains=true`, `analysis.evidence_theses` is empty, and no `--thesis` flag is provided
    - When: `mulder analyze --evidence-chains` runs
    - Then: the command exits non-zero with an Analyze-step validation error, and no new rows are inserted into `evidence_chains`
 
-6. **QA-06: Unresolvable theses report partial failure without blocking valid ones**
-   - Given: one thesis resolves to graph-connected entities and another thesis resolves to no entities
+7. **QA-07: Unresolvable theses report partial failure without blocking valid ones**
+   - Given: one thesis resolves to graph-connected entities, another thesis resolves to no entities, and the processed-source corpus is at or above `thresholds.corroboration_meaningful`
    - When: `mulder analyze --evidence-chains --thesis "valid thesis" --thesis "unknown thesis"` runs
    - Then: the valid thesis persists rows successfully, the unresolved thesis is reported as a failure, and the overall command reports partial completion rather than rolling back the successful thesis
 
-7. **QA-07: Disabled evidence-chain analysis fails before writes**
+8. **QA-08: Disabled evidence-chain analysis fails before writes**
    - Given: `analysis.enabled=false` or `analysis.evidence_chains=false`
    - When: `mulder analyze --evidence-chains` runs
    - Then: the command exits non-zero with an Analyze-step disabled error, and no `evidence_chains` rows are modified
@@ -141,21 +148,22 @@ Traversal should reuse the existing retrieval graph tuning already present in co
 
 | # | Args / Flags | Expected Behavior |
 |---|-------------|-------------------|
-| CLI-01 | `--evidence-chains` | Exit `0`, uses configured thesis strings and persists evidence-chain rows |
-| CLI-02 | `--evidence-chains --thesis "Acme activity in Berlin"` | Exit `0`, computes rows for the provided thesis only |
-| CLI-03 | `--evidence-chains --thesis "A" --thesis "B"` | Exit `0` or partial, processes both thesis strings in one run |
-| CLI-04 | `--evidence-chains` *(run twice)* | Exit `0`, recomputes the thesis snapshot without accumulating duplicate rows |
-| CLI-05 | `--evidence-chains --reliability` | Exit non-zero, because running multiple Analyze selectors together is not implemented yet |
-| CLI-06 | `--evidence-chains --contradictions` | Exit non-zero, because running multiple Analyze selectors together is not implemented yet |
-| CLI-07 | `--evidence-chains --full` | Exit non-zero, because `--full` belongs to `M6-G7` |
-| CLI-08 | `--evidence-chains --thesis ""` | Exit non-zero with thesis validation feedback |
+| CLI-01 | `--evidence-chains` *(corpus below `thresholds.corroboration_meaningful`)* | Exit `0`, reports sparse-data gating, and persists no evidence-chain rows |
+| CLI-02 | `--evidence-chains` | Exit `0`, uses configured thesis strings and persists evidence-chain rows when the corpus is at or above the threshold |
+| CLI-03 | `--evidence-chains --thesis "Acme activity in Berlin"` | Exit `0`, computes rows for the provided thesis only |
+| CLI-04 | `--evidence-chains --thesis "A" --thesis "B"` | Exit `0` or partial, processes both thesis strings in one run |
+| CLI-05 | `--evidence-chains` *(run twice)* | Exit `0`, recomputes the thesis snapshot without accumulating duplicate rows |
+| CLI-06 | `--evidence-chains --reliability` | Exit non-zero, because running multiple Analyze selectors together is not implemented yet |
+| CLI-07 | `--evidence-chains --contradictions` | Exit non-zero, because running multiple Analyze selectors together is not implemented yet |
+| CLI-08 | `--evidence-chains --full` | Exit non-zero, because `--full` belongs to `M6-G7` |
+| CLI-09 | `--evidence-chains --thesis ""` | Exit non-zero with thesis validation feedback |
 
 ### Selector validation
 
 | # | Args / Flags | Expected Behavior |
 |---|-------------|-------------------|
-| CLI-09 | *(no args)* | Exit non-zero, usage/help indicates that an analysis selector is required |
-| CLI-10 | `--spatio-temporal` | Exit non-zero, because clustering belongs to `M6-G6` |
+| CLI-10 | *(no args)* | Exit non-zero, usage/help indicates that an analysis selector is required |
+| CLI-11 | `--spatio-temporal` | Exit non-zero, because clustering belongs to `M6-G6` |
 
 ## 6. Cost Considerations
 

--- a/packages/pipeline/src/analyze/evidence-chains.ts
+++ b/packages/pipeline/src/analyze/evidence-chains.ts
@@ -10,9 +10,16 @@
  */
 
 import type { MulderConfig } from '@mulder/core';
-import { ANALYZE_ERROR_CODES, AnalyzeError, createChildLogger, createLogger } from '@mulder/core';
+import {
+	ANALYZE_ERROR_CODES,
+	AnalyzeError,
+	countProcessedSources,
+	createChildLogger,
+	createLogger,
+} from '@mulder/core';
 import { extractQueryEntities } from '@mulder/retrieval';
 import type pg from 'pg';
+import type { EvidenceChainsAvailability } from './types.js';
 
 export interface EvidenceChainPath {
 	path: string[];
@@ -46,6 +53,24 @@ const moduleLogger = createChildLogger(logger, { module: 'analyze-evidence-chain
 
 function normalizeThesis(thesis: string): string {
 	return thesis.trim();
+}
+
+export function buildEvidenceChainsWarning(sourceCount: number, threshold: number): string {
+	return `evidence chains degraded: not yet available until the corpus reaches the meaningful threshold (${sourceCount}/${threshold} processed sources)`;
+}
+
+export async function loadEvidenceChainsAvailability(
+	pool: pg.Pool,
+	threshold: number,
+): Promise<EvidenceChainsAvailability> {
+	const sourceCount = await countProcessedSources(pool);
+
+	return {
+		sourceCount,
+		threshold,
+		belowThreshold: sourceCount < threshold,
+		warning: sourceCount < threshold ? buildEvidenceChainsWarning(sourceCount, threshold) : null,
+	};
 }
 
 async function resolveThesisSeedIds(pool: pg.Pool, thesis: string): Promise<string[]> {

--- a/packages/pipeline/src/analyze/index.ts
+++ b/packages/pipeline/src/analyze/index.ts
@@ -39,7 +39,12 @@ import type pg from 'pg';
 import { z } from 'zod';
 import { z as z3 } from 'zod/v3';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { computeEvidenceChainsForThesis, type EvidenceChainThesisComputation } from './evidence-chains.js';
+import {
+	buildEvidenceChainsWarning,
+	computeEvidenceChainsForThesis,
+	type EvidenceChainThesisComputation,
+	loadEvidenceChainsAvailability,
+} from './evidence-chains.js';
 import { computeSourceReliability } from './reliability.js';
 import { computeSpatioTemporalClusters } from './spatio-temporal.js';
 import type {
@@ -51,6 +56,7 @@ import type {
 	ContradictionResolutionOutcome,
 	ContradictionResolutionResponse,
 	EvidenceChainsAnalyzeData,
+	EvidenceChainsAvailability,
 	EvidenceChainThesisOutcome,
 	FullAnalyzeData,
 	ReliabilityAnalyzeData,
@@ -70,6 +76,7 @@ export type {
 	ContradictionResolutionResponse,
 	ContradictionVerdict,
 	EvidenceChainsAnalyzeData,
+	EvidenceChainsAvailability,
 	EvidenceChainThesisOutcome,
 	FullAnalyzeData,
 	ReliabilityAnalyzeData,
@@ -219,6 +226,17 @@ function buildEvidenceChainInputs(
 	];
 }
 
+function buildSkippedEvidenceChainOutcomes(theses: string[]): EvidenceChainThesisOutcome[] {
+	return theses.map((thesis) => ({
+		thesis,
+		status: 'skipped',
+		seedCount: 0,
+		supportingCount: 0,
+		contradictionCount: 0,
+		writtenCount: 0,
+	}));
+}
+
 async function replaceEvidenceChainsSnapshot(
 	pool: pg.Pool,
 	thesis: string,
@@ -252,20 +270,29 @@ async function replaceEvidenceChainsSnapshot(
 	}
 }
 
-function makeEvidenceChainsData(outcomes: EvidenceChainThesisOutcome[]): EvidenceChainsAnalyzeData {
+function makeEvidenceChainsData(
+	outcomes: EvidenceChainThesisOutcome[],
+	availability: EvidenceChainsAvailability,
+): EvidenceChainsAnalyzeData {
 	const supportingCount = outcomes.reduce((total, outcome) => total + outcome.supportingCount, 0);
 	const contradictionCount = outcomes.reduce((total, outcome) => total + outcome.contradictionCount, 0);
 	const successCount = outcomes.filter((outcome) => outcome.status === 'success').length;
 	const failedCount = outcomes.filter((outcome) => outcome.status === 'failed').length;
+	const skippedCount = outcomes.filter((outcome) => outcome.status === 'skipped').length;
 
 	return {
 		mode: 'evidence-chains',
 		thesisCount: outcomes.length,
-		processedCount: outcomes.length,
+		processedCount: successCount + failedCount,
 		successCount,
+		skippedCount,
 		failedCount,
 		supportingCount,
 		contradictionCount,
+		sourceCount: availability.sourceCount,
+		threshold: availability.threshold,
+		belowThreshold: availability.belowThreshold,
+		warning: availability.warning,
 		outcomes,
 	};
 }
@@ -501,6 +528,11 @@ function summarizeAnalyzeData(data: SingleAnalyzeData): string {
 				? 'no graph-connected sources found'
 				: `${data.scoredCount} scored, ${data.sourceCount} graph-connected sources`;
 		case 'evidence-chains':
+			if (data.belowThreshold) {
+				return data.skippedCount > 0
+					? `${data.skippedCount} theses skipped`
+					: (data.warning ?? 'evidence chains not yet available');
+			}
 			return data.supportingCount === 0 && data.contradictionCount === 0 && data.failedCount === 0
 				? 'no evidence chains found'
 				: `${data.successCount} successful theses, ${data.failedCount} failed, ${data.supportingCount} supporting, ${data.contradictionCount} contradiction-backed`;
@@ -715,10 +747,29 @@ async function executeEvidenceChainsPass(
 		);
 	}
 
-	const outcomes: EvidenceChainThesisOutcome[] = [];
+	const availability = await loadEvidenceChainsAvailability(pool, config.thresholds.corroboration_meaningful);
+
+	if (availability.belowThreshold) {
+		log.warn(
+			{
+				sourceCount: availability.sourceCount,
+				threshold: availability.threshold,
+				belowThreshold: availability.belowThreshold,
+			},
+			'Evidence chains not yet available — corpus below meaningful threshold',
+		);
+	}
+
+	const outcomes: EvidenceChainThesisOutcome[] = availability.belowThreshold
+		? buildSkippedEvidenceChainOutcomes(thesisInputs)
+		: [];
 	const errors: StepError[] = [];
 
 	for (const thesis of thesisInputs) {
+		if (availability.belowThreshold) {
+			continue;
+		}
+
 		try {
 			const computation = await computeEvidenceChainsForThesis(pool, config, thesis);
 			const computedAt = new Date();
@@ -758,7 +809,7 @@ async function executeEvidenceChainsPass(
 		}
 	}
 
-	const data = makeEvidenceChainsData(outcomes);
+	const data = makeEvidenceChainsData(outcomes, availability);
 	const status =
 		errors.length === 0 ? 'success' : outcomes.some((outcome) => outcome.status === 'success') ? 'partial' : 'failed';
 	const durationMs = Math.round(performance.now() - startTime);
@@ -784,7 +835,7 @@ async function executeEvidenceChainsPass(
 		metadata: {
 			duration_ms: durationMs,
 			items_processed: data.processedCount,
-			items_skipped: data.failedCount,
+			items_skipped: data.skippedCount + data.failedCount,
 			items_cached: 0,
 		},
 	};
@@ -1030,6 +1081,16 @@ async function executeFullAnalyze(
 				thesisOverrides.length > 0 ? thesisOverrides : normalizeThesisList(config.analysis.evidence_theses);
 			if (thesisInputs.length === 0) {
 				passes.push(createSkippedPassResult(pass, 'no thesis input configured'));
+				continue;
+			}
+			const availability = await loadEvidenceChainsAvailability(pool, config.thresholds.corroboration_meaningful);
+			if (availability.belowThreshold) {
+				passes.push(
+					createSkippedPassResult(
+						pass,
+						availability.warning ?? buildEvidenceChainsWarning(availability.sourceCount, availability.threshold),
+					),
+				);
 				continue;
 			}
 		}

--- a/packages/pipeline/src/analyze/types.ts
+++ b/packages/pipeline/src/analyze/types.ts
@@ -68,7 +68,7 @@ export interface ReliabilityAnalyzeData {
 	outcomes: SourceReliabilityOutcome[];
 }
 
-export type EvidenceChainThesisStatus = 'success' | 'failed';
+export type EvidenceChainThesisStatus = 'success' | 'failed' | 'skipped';
 
 export interface EvidenceChainThesisOutcome {
 	thesis: string;
@@ -79,14 +79,26 @@ export interface EvidenceChainThesisOutcome {
 	writtenCount: number;
 }
 
+export interface EvidenceChainsAvailability {
+	sourceCount: number;
+	threshold: number;
+	belowThreshold: boolean;
+	warning: string | null;
+}
+
 export interface EvidenceChainsAnalyzeData {
 	mode: 'evidence-chains';
 	thesisCount: number;
 	processedCount: number;
 	successCount: number;
+	skippedCount: number;
 	failedCount: number;
 	supportingCount: number;
 	contradictionCount: number;
+	sourceCount: number;
+	threshold: number;
+	belowThreshold: boolean;
+	warning: string | null;
 	outcomes: EvidenceChainThesisOutcome[];
 }
 

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -9,6 +9,7 @@ export type {
 	ContradictionResolutionResponse,
 	ContradictionVerdict,
 	EvidenceChainsAnalyzeData,
+	EvidenceChainsAvailability,
 	EvidenceChainThesisOutcome,
 	FullAnalyzeData,
 	ReliabilityAnalyzeData,

--- a/tests/specs/63_evidence_chains.test.ts
+++ b/tests/specs/63_evidence_chains.test.ts
@@ -37,6 +37,7 @@ let pgAvailable = false;
 let enabledSingleThesisConfigPath: string;
 let enabledDualThesisConfigPath: string;
 let enabledEmptyThesisConfigPath: string;
+let sparseThresholdConfigPath: string;
 let disabledConfigPath: string;
 let featureDisabledConfigPath: string;
 
@@ -72,6 +73,7 @@ function writeAnalyzeConfig(options?: {
 	enabled?: boolean;
 	evidenceChains?: boolean;
 	evidenceTheses?: string[];
+	threshold?: number;
 }): string {
 	const base = readFileSync(EXAMPLE_CONFIG, 'utf-8');
 	const devModeEnabled = base.replace(/^dev_mode:\s*false$/m, 'dev_mode: true');
@@ -98,8 +100,12 @@ function writeAnalyzeConfig(options?: {
 		/analysis:\n[\s\S]*?\n# --- Sparse Graph Thresholds ---/,
 		analysisReplacement,
 	);
+	const withThreshold =
+		options?.threshold !== undefined
+			? withAnalysis.replace(/corroboration_meaningful:\s*\d+/, `corroboration_meaningful: ${options.threshold}`)
+			: withAnalysis;
 	const configPath = join(tmpDir, `analyze-63-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
-	writeFileSync(configPath, withAnalysis, 'utf-8');
+	writeFileSync(configPath, withThreshold, 'utf-8');
 	return configPath;
 }
 
@@ -146,6 +152,23 @@ function seedAlias(args: { id: string; entityId: string; alias: string }): void 
 function linkStoryEntity(storyId: string, entityId: string): void {
 	db.runSql(
 		`INSERT INTO story_entities (story_id, entity_id, confidence, mention_count) VALUES (${sqlString(storyId)}, ${sqlString(entityId)}, 0.9, 1)`,
+	);
+}
+
+function seedEvidenceChain(args: {
+	id: string;
+	thesis: string;
+	path: string[];
+	strength: number;
+	supports: boolean;
+}): void {
+	db.runSql(
+		[
+			'INSERT INTO evidence_chains (id, thesis, path, strength, supports, computed_at)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.thesis)}, ARRAY[${args.path
+				.map((entry) => sqlString(entry))
+				.join(', ')}]::uuid[], ${args.strength}, ${args.supports}, now())`,
+		].join(' '),
 	);
 }
 
@@ -224,6 +247,12 @@ describe('Spec 63 — Evidence Chains', () => {
 			evidenceTheses: [THESIS_PRIMARY, THESIS_SECONDARY],
 		});
 		enabledEmptyThesisConfigPath = writeAnalyzeConfig({ enabled: true, evidenceChains: true, evidenceTheses: [] });
+		sparseThresholdConfigPath = writeAnalyzeConfig({
+			enabled: true,
+			evidenceChains: true,
+			evidenceTheses: [THESIS_PRIMARY],
+			threshold: 5,
+		});
 		disabledConfigPath = writeAnalyzeConfig({ enabled: false, evidenceChains: true, evidenceTheses: [THESIS_PRIMARY] });
 		featureDisabledConfigPath = writeAnalyzeConfig({
 			enabled: true,
@@ -253,7 +282,26 @@ describe('Spec 63 — Evidence Chains', () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	it('QA-01: configured evidence theses persist supporting chains', () => {
+	it('QA-01: sparse corpora skip evidence-chain traversal and writes', () => {
+		if (!pgAvailable) return;
+		seedEvidenceChain({
+			id: '00000000-0000-0000-0000-000000630501',
+			thesis: THESIS_PRIMARY,
+			path: [ENTITY_ACME_ID, ENTITY_BERLIN_ID],
+			strength: 0.88,
+			supports: true,
+		});
+		const beforeChains = fetchChains(THESIS_PRIMARY);
+		const result = runCli(['analyze', '--evidence-chains'], {
+			env: { MULDER_CONFIG: sparseThresholdConfigPath },
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('not yet available');
+		expect(fetchChains(THESIS_PRIMARY)).toEqual(beforeChains);
+		expect(fetchDistinctTheses()).toEqual([THESIS_PRIMARY]);
+	});
+
+	it('QA-02: configured evidence theses persist supporting chains', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -271,7 +319,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		}
 	});
 
-	it('QA-02: re-running the same thesis is idempotent', () => {
+	it('QA-03: re-running the same thesis is idempotent', () => {
 		if (!pgAvailable) return;
 		seedMixedFixture();
 
@@ -295,7 +343,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(secondChains).toEqual(firstChains);
 	});
 
-	it('QA-03: CLI thesis overrides work without config theses', () => {
+	it('QA-04: CLI thesis overrides work without config theses', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -306,7 +354,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchDistinctTheses()).toEqual([THESIS_PRIMARY]);
 	});
 
-	it('QA-04: confirmed contradiction evidence is persisted as non-supporting', () => {
+	it('QA-05: confirmed contradiction evidence is persisted as non-supporting', () => {
 		if (!pgAvailable) return;
 		seedMixedFixture();
 
@@ -318,7 +366,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(chains.some((chain) => Number(chain.strength) > 0)).toBe(true);
 	});
 
-	it('QA-05: missing thesis input fails before traversal or writes', () => {
+	it('QA-06: missing thesis input fails before traversal or writes', () => {
 		if (!pgAvailable) return;
 
 		const result = runCli(['analyze', '--evidence-chains'], { env: { MULDER_CONFIG: enabledEmptyThesisConfigPath } });
@@ -328,7 +376,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchChains()).toHaveLength(0);
 	});
 
-	it('QA-06: unresolvable theses report partial failure without blocking valid ones', () => {
+	it('QA-07: unresolvable theses report partial failure without blocking valid ones', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -343,7 +391,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchChains(THESIS_UNRESOLVED)).toHaveLength(0);
 	});
 
-	it('QA-07: disabled evidence-chain analysis fails before writes', () => {
+	it('QA-08: disabled evidence-chain analysis fails before writes', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -360,7 +408,17 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchChains()).toHaveLength(0);
 	});
 
-	it('CLI-01: `--evidence-chains` uses configured thesis strings and persists evidence-chain rows', () => {
+	it('CLI-01: `--evidence-chains` below `thresholds.corroboration_meaningful` reports sparse-data gating and persists no evidence-chain rows', () => {
+		if (!pgAvailable) return;
+		seedSupportFixture();
+
+		const result = runCli(['analyze', '--evidence-chains'], { env: { MULDER_CONFIG: sparseThresholdConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('not yet available');
+		expect(fetchChains()).toHaveLength(0);
+	});
+
+	it('CLI-02: `--evidence-chains` uses configured thesis strings and persists evidence-chain rows', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -372,7 +430,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchDistinctTheses()).toEqual([THESIS_PRIMARY, THESIS_SECONDARY]);
 	});
 
-	it('CLI-02: `--evidence-chains --thesis <text>` computes rows for the provided thesis only', () => {
+	it('CLI-03: `--evidence-chains --thesis <text>` computes rows for the provided thesis only', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -383,7 +441,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchDistinctTheses()).toEqual([THESIS_PRIMARY]);
 	});
 
-	it('CLI-03: `--evidence-chains --thesis "A" --thesis "B"` processes both thesis strings in one run', () => {
+	it('CLI-04: `--evidence-chains --thesis "A" --thesis "B"` processes both thesis strings in one run', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -396,7 +454,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(fetchDistinctTheses()).toEqual([THESIS_PRIMARY, THESIS_SECONDARY]);
 	});
 
-	it('CLI-04: `--evidence-chains` run twice preserves the first run snapshot', () => {
+	it('CLI-05: `--evidence-chains` run twice preserves the first run snapshot', () => {
 		if (!pgAvailable) return;
 		seedMixedFixture();
 
@@ -420,7 +478,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(secondSnapshot).toEqual(firstSnapshot);
 	});
 
-	it('CLI-05: `--evidence-chains --reliability` exits non-zero because multi-selector analyze is not implemented yet', () => {
+	it('CLI-06: `--evidence-chains --reliability` exits non-zero because multi-selector analyze is not implemented yet', () => {
 		const result = runCli(['analyze', '--evidence-chains', '--reliability'], {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
@@ -428,7 +486,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(result.stderr).toContain('one selector or --full');
 	});
 
-	it('CLI-06: `--evidence-chains --contradictions` exits non-zero because multi-selector analyze is not implemented yet', () => {
+	it('CLI-07: `--evidence-chains --contradictions` exits non-zero because multi-selector analyze is not implemented yet', () => {
 		const result = runCli(['analyze', '--evidence-chains', '--contradictions'], {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
@@ -436,7 +494,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(result.stderr).toContain('one selector or --full');
 	});
 
-	it('CLI-07: `--evidence-chains --full` exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
+	it('CLI-08: `--evidence-chains --full` exits non-zero because full mode and single-pass selectors are mutually exclusive', () => {
 		const result = runCli(['analyze', '--evidence-chains', '--full'], {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
@@ -444,7 +502,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(result.stderr).toContain('--full cannot be combined');
 	});
 
-	it('CLI-08: `--evidence-chains --thesis ""` exits non-zero with thesis validation feedback', () => {
+	it('CLI-09: `--evidence-chains --thesis ""` exits non-zero with thesis validation feedback', () => {
 		const result = runCli(['analyze', '--evidence-chains', '--thesis', ''], {
 			env: { MULDER_CONFIG: enabledEmptyThesisConfigPath },
 		});
@@ -452,7 +510,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(result.stderr).toContain('at least one non-empty value');
 	});
 
-	it('CLI-09: `mulder analyze` with no args now runs full analyze mode and skips thesis-less evidence chains', () => {
+	it('CLI-10: `mulder analyze` with no args now runs full analyze mode and skips thesis-less evidence chains', () => {
 		if (!pgAvailable) return;
 		seedSupportFixture();
 
@@ -463,7 +521,7 @@ describe('Spec 63 — Evidence Chains', () => {
 		expect(result.stderr).toContain('Analyze complete');
 	});
 
-	it('CLI-10: `--spatio-temporal` now succeeds as a no-op when no clusterable events exist', () => {
+	it('CLI-11: `--spatio-temporal` now succeeds as a no-op when no clusterable events exist', () => {
 		if (!pgAvailable) return;
 
 		const result = runCli(['analyze', '--spatio-temporal'], { env: { MULDER_CONFIG: enabledEmptyThesisConfigPath } });


### PR DESCRIPTION
## Summary
- gate evidence-chain analysis on the processed-source corpus size using `thresholds.corroboration_meaningful`
- report sparse-data skips clearly in single-pass and full analyze flows without traversing or writing `evidence_chains`
- align Spec 63, the functional spec, and the black-box QA suite with the new contract

## Testing
- `pnpm turbo run build --filter=@mulder/pipeline --filter=@mulder/cli`
- `npx biome check apps/cli/src/commands/analyze.ts packages/pipeline/src/analyze/evidence-chains.ts packages/pipeline/src/analyze/index.ts packages/pipeline/src/analyze/types.ts packages/pipeline/src/index.ts tests/specs/63_evidence_chains.test.ts docs/specs/63_evidence_chains.spec.md docs/functional-spec.md`
- `pnpm vitest run tests/specs/63_evidence_chains.test.ts`

Closes #162
