### PR TITLE
[AI Core] Add Ground plausibility validation before persistence

### DIFF
--- a/docs/specs/66_ground_plausibility_validation.spec.md
+++ b/docs/specs/66_ground_plausibility_validation.spec.md
@@ -1,0 +1,93 @@
+---
+spec: "66"
+title: "Ground Plausibility Validation Before Persistence"
+roadmap_step: ""
+functional_spec: ["§2.5"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/161"
+created: 2026-04-13
+---
+
+# Spec 66: Ground Plausibility Validation Before Persistence
+
+## 1. Objective
+
+Close Issue `#161` by adding the missing plausibility gate required by `§2.5` before Ground persists grounded attributes or geometry. The step must continue rejecting malformed or low-confidence responses, and must now also fail cleanly when grounded coordinates or date-like attributes are implausible, leaving both `entity_grounding` and the entity row unchanged.
+
+## 2. Boundaries
+
+- **Roadmap Step:** N/A — off-roadmap Ground hardening tracked by Issue `#161`
+- **Target:** `packages/pipeline/src/ground/index.ts` and `packages/core/src/shared/services.dev.ts`
+- **In scope:** an explicit plausibility-validation phase between payload parsing and persistence, coordinate guardrails that reject impossible latitude/longitude values before any entity mutation, a concrete sanity check that grounded single-date attributes (`verified_date`, `founding_date`) must be real `YYYY-MM-DD` calendar dates that are not later than the grounding day, and deterministic dev-mode fixture behavior that lets black-box QA trigger both accepted and rejected grounding payloads without live Vertex calls
+- **Out of scope:** new CLI flags, schema or migration changes, taxonomy/entity-resolution changes, broader Ground prompt redesign, or live-GCP behavior beyond preserving the same validation contract on real responses
+- **Constraints:** keep all failures in the existing `GROUND_VALIDATION_FAILED` path, do not persist partial grounding rows on rejected payloads, preserve the current support-confidence gate and cache semantics, and keep the QA surface black-box friendly through CLI-observable behavior only
+
+## 3. Dependencies
+
+- **Requires:** Spec 60 (`M6-G2`) Ground step, the existing Ground CLI black-box suite, and the dev-mode grounded generation stub in `packages/core/src/shared/services.dev.ts`
+- **Blocks:** closure of Issue `#161` and any future HTTP/worker exposure of Ground where invalid grounded attributes would become harder to contain after leaving the CLI-only path
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/pipeline/src/ground/index.ts`** — add a dedicated plausibility-validation step after payload parsing and before attribute merging/persistence; reject invalid coordinate payloads, reject grounded `verified_date` / `founding_date` values that are not real `YYYY-MM-DD` dates or fall after the grounding day, and keep rejected payloads from mutating `entity_grounding`, `entities.attributes`, or `entities.geom`
+2. **`packages/core/src/shared/services.dev.ts`** — extend the deterministic grounded dev fixture behavior so QA can provoke one accepted payload plus targeted invalid-coordinate and invalid-date payloads through black-box CLI runs
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None.
+
+### 4.4 Integration Points
+
+- Ground keeps using the existing `GROUND_VALIDATION_FAILED` error path and must fail before `persistEntityGroundingResult()` is called
+- The dev grounded-generation stub becomes the deterministic test hook for plausibility failures so the verification agent can exercise rejection paths without importing implementation code or requiring live Vertex AI
+- Existing Ground cache behavior, CLI selectors, and support-confidence enforcement remain unchanged for valid payloads
+
+### 4.5 Implementation Phases
+
+Single phase — implement the plausibility gate in Ground and expose deterministic dev fixtures for black-box rejection scenarios.
+
+## 5. QA Contract
+
+1. **QA-01: Valid location grounding still persists coordinates and cache data**
+   - Given: a location entity with no `geom` and a deterministic dev grounding response that contains valid coordinates
+   - When: `mulder ground <entity-id>` runs successfully
+   - Then: the command exits `0`, creates exactly one `entity_grounding` row, and updates the entity row so `geom` is no longer null
+
+2. **QA-02: Invalid grounded coordinates are rejected without writes**
+   - Given: an eligible entity whose deterministic dev grounding response contains out-of-range latitude or longitude values
+   - When: `mulder ground <entity-id>` runs
+   - Then: the command exits non-zero with `GROUND_VALIDATION_FAILED`, no `entity_grounding` row is created for that entity, and the entity row remains without grounded geometry changes
+
+3. **QA-03: Implausible grounded date attributes are rejected without writes**
+   - Given: an eligible entity whose deterministic dev grounding response contains `verified_date` or `founding_date` with an invalid `YYYY-MM-DD` value or a date later than the grounding day
+   - When: `mulder ground <entity-id>` runs
+   - Then: the command exits non-zero with `GROUND_VALIDATION_FAILED`, no `entity_grounding` row is created for that entity, and the entity attributes do not gain the invalid grounded date
+
+4. **QA-04: Existing low-confidence rejection still wins before persistence**
+   - Given: grounding metadata reports support confidence below the configured `grounding.min_confidence`
+   - When: `mulder ground <entity-id>` runs
+   - Then: the command exits non-zero with `GROUND_VALIDATION_FAILED`, and no new `entity_grounding` row or grounded entity mutation is persisted
+
+## 5b. CLI Test Matrix
+
+### `mulder ground <entity-id>`
+
+| # | Args / Flags | Expected Behavior |
+|---|-------------|-------------------|
+| CLI-01 | `<valid-location-id>` | Exit `0`, persists one grounding row and applies geometry |
+| CLI-02 | `<invalid-coordinates-id>` | Exit non-zero with `GROUND_VALIDATION_FAILED`, persists no grounding row, leaves geometry unchanged |
+| CLI-03 | `<invalid-date-id>` | Exit non-zero with `GROUND_VALIDATION_FAILED`, persists no grounding row, leaves invalid grounded date absent |
+| CLI-04 | `<low-confidence-id>` | Exit non-zero with `GROUND_VALIDATION_FAILED`, persists no grounding row |
+
+## 6. Cost Considerations
+
+- **Services called:** none beyond the existing Ground step contract; dev-mode verification remains zero-cost
+- **Estimated cost per run:** zero in dev/test mode; unchanged for live grounding
+- **Dev mode alternative:** yes — deterministic grounded dev fixtures are the primary verification path for this follow-up
+- **Safety flags:** no new paid calls, and rejected payloads must fail before any persistence side effects

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -92,6 +92,19 @@ function slugify(value: string): string {
 	);
 }
 
+type GroundingFixtureScenario = 'accepted' | 'invalid-coordinates' | 'invalid-date';
+
+function resolveGroundingFixtureScenario(entityName: string): GroundingFixtureScenario {
+	const normalizedName = entityName.trim().toLowerCase();
+	if (normalizedName.includes('invalid-coordinate') || normalizedName.includes('invalid coordinate')) {
+		return 'invalid-coordinates';
+	}
+	if (normalizedName.includes('invalid-date') || normalizedName.includes('invalid date')) {
+		return 'invalid-date';
+	}
+	return 'accepted';
+}
+
 // ────────────────────────────────────────────────────────────
 // Dev Storage Service
 // ────────────────────────────────────────────────────────────
@@ -398,6 +411,7 @@ class DevLlmService implements LlmService {
 		const nameMatch = options.prompt.match(/## Entity name\s+([^\n]+)/i);
 		const entityType = typeMatch?.[1]?.trim().toLowerCase() ?? 'entity';
 		const entityName = nameMatch?.[1]?.trim() ?? 'Dev Test Entity';
+		const fixtureScenario = resolveGroundingFixtureScenario(entityName);
 
 		let coordinates: Record<string, number> | null = null;
 		let attributes: Record<string, unknown> = {
@@ -435,7 +449,19 @@ class DevLlmService implements LlmService {
 			};
 		}
 
-		this.logger.debug({ entityName, entityType }, 'DevLlmService: groundedGenerate returning deterministic fixture');
+		if (fixtureScenario === 'invalid-coordinates') {
+			coordinates = { lat: 95, lng: 13.405 };
+		} else if (fixtureScenario === 'invalid-date') {
+			attributes = {
+				...attributes,
+				verified_date: '2999-12-31',
+			};
+		}
+
+		this.logger.debug(
+			{ entityName, entityType, fixtureScenario },
+			'DevLlmService: groundedGenerate returning deterministic fixture',
+		);
 
 		return {
 			text: JSON.stringify({

--- a/packages/pipeline/src/ground/index.ts
+++ b/packages/pipeline/src/ground/index.ts
@@ -38,8 +38,8 @@ const groundedPayloadSchema = z.object({
 	confidence: z.number().min(0).max(1).nullable().optional(),
 	coordinates: z
 		.object({
-			lat: z.number().min(-90).max(90),
-			lng: z.number().min(-180).max(180),
+			lat: z.number().finite(),
+			lng: z.number().finite(),
 		})
 		.nullable()
 		.optional(),
@@ -47,6 +47,11 @@ const groundedPayloadSchema = z.object({
 });
 
 type GroundedPayload = z.infer<typeof groundedPayloadSchema>;
+type GroundedDateAttribute = 'verified_date' | 'founding_date';
+type GroundedCoordinatePair = { lat: number; lng: number };
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DATE_ATTRIBUTES: readonly GroundedDateAttribute[] = ['verified_date', 'founding_date'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -128,6 +133,103 @@ function parseGroundedPayload(rawText: string): GroundedPayload {
 			GROUND_ERROR_CODES.GROUND_VALIDATION_FAILED,
 			{ cause },
 		);
+	}
+}
+
+function createValidationError(message: string, context: Record<string, unknown>): GroundError {
+	return new GroundError(message, GROUND_ERROR_CODES.GROUND_VALIDATION_FAILED, { context });
+}
+
+function assertPlausibleCoordinates(coordinates: GroundedCoordinatePair, fieldPath: string): void {
+	if (coordinates.lat < -90 || coordinates.lat > 90) {
+		throw createValidationError('Grounded latitude is outside the valid range', {
+			field: `${fieldPath}.lat`,
+			lat: coordinates.lat,
+		});
+	}
+	if (coordinates.lng < -180 || coordinates.lng > 180) {
+		throw createValidationError('Grounded longitude is outside the valid range', {
+			field: `${fieldPath}.lng`,
+			lng: coordinates.lng,
+		});
+	}
+}
+
+function parseIsoDate(value: string): Date | null {
+	const match = ISO_DATE_PATTERN.exec(value);
+	if (!match) {
+		return null;
+	}
+
+	const year = Number.parseInt(match[1], 10);
+	const month = Number.parseInt(match[2], 10);
+	const day = Number.parseInt(match[3], 10);
+	if (month < 1 || month > 12 || day < 1 || day > 31) {
+		return null;
+	}
+
+	const date = new Date(Date.UTC(year, month - 1, day));
+	if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+		return null;
+	}
+
+	return date;
+}
+
+function validateGroundedDateAttribute(value: unknown, key: GroundedDateAttribute, groundingDayUtcMs: number): void {
+	if (value === undefined || value === null) {
+		return;
+	}
+	if (typeof value !== 'string') {
+		throw createValidationError(`Grounded ${key} must be a YYYY-MM-DD string`, {
+			field: key,
+			value,
+		});
+	}
+
+	const parsedDate = parseIsoDate(value);
+	if (parsedDate === null) {
+		throw createValidationError(`Grounded ${key} must be a real YYYY-MM-DD calendar date`, {
+			field: key,
+			value,
+		});
+	}
+	if (parsedDate.getTime() > groundingDayUtcMs) {
+		throw createValidationError(`Grounded ${key} cannot be later than the grounding day`, {
+			field: key,
+			value,
+		});
+	}
+}
+
+function validatePayloadPlausibility(payload: GroundedPayload, groundedAt: Date): void {
+	if (payload.coordinates !== undefined && payload.coordinates !== null) {
+		assertPlausibleCoordinates(payload.coordinates, 'coordinates');
+	}
+
+	const geoPoint = payload.attributes.geo_point;
+	if (geoPoint !== undefined && geoPoint !== null) {
+		if (!isRecord(geoPoint)) {
+			throw createValidationError('Grounded attributes.geo_point must be an object with lat/lng numbers', {
+				field: 'attributes.geo_point',
+				value: geoPoint,
+			});
+		}
+
+		const lat = geoPoint.lat;
+		const lng = geoPoint.lng;
+		if (typeof lat !== 'number' || typeof lng !== 'number' || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+			throw createValidationError('Grounded attributes.geo_point must include finite lat/lng numbers', {
+				field: 'attributes.geo_point',
+				value: geoPoint,
+			});
+		}
+		assertPlausibleCoordinates({ lat, lng }, 'attributes.geo_point');
+	}
+
+	const groundingDayUtcMs = Date.UTC(groundedAt.getUTCFullYear(), groundedAt.getUTCMonth(), groundedAt.getUTCDate());
+	for (const key of DATE_ATTRIBUTES) {
+		validateGroundedDateAttribute(payload.attributes[key], key, groundingDayUtcMs);
 	}
 }
 
@@ -304,13 +406,14 @@ export async function execute(
 	}
 
 	const payload = parseGroundedPayload(groundedResponse.text);
+	const groundedAt = new Date();
+	validatePayloadPlausibility(payload, groundedAt);
 	const mergedAttributes = buildMergedAttributes(entity, payload);
 	const sourceUrlSet = new Set<string>();
 	collectSourceUrls(groundedResponse.groundingMetadata, sourceUrlSet);
 	const sourceUrls = [...sourceUrlSet];
 	const coordinates = payload.coordinates ?? undefined;
 
-	const groundedAt = new Date();
 	const expiresAt = computeExpiryDate(config.grounding.cache_ttl_days, groundedAt);
 	const groundingRecord: Record<string, unknown> = {
 		summary: payload.summary ?? null,

--- a/tests/specs/66_ground_plausibility_validation.test.ts
+++ b/tests/specs/66_ground_plausibility_validation.test.ts
@@ -1,0 +1,227 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const VALID_LOCATION_ID = '00000000-0000-0000-0000-000000660001';
+const INVALID_COORDINATE_ID = '00000000-0000-0000-0000-000000660002';
+const INVALID_DATE_ID = '00000000-0000-0000-0000-000000660003';
+const LOW_CONFIDENCE_ID = '00000000-0000-0000-0000-000000660004';
+
+let tmpDir: string;
+let defaultConfigPath: string;
+let strictConfigPath: string;
+const pgAvailable = db.isPgAvailable();
+const describeIfPg = pgAvailable ? describe : describe.skip;
+
+function runCli(
+	args: string[],
+	opts?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 60_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function sqlString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function jsonLiteral(value: Record<string, unknown>): string {
+	return `${sqlString(JSON.stringify(value))}::jsonb`;
+}
+
+function writeGroundingConfig(minConfidence = 0.7): string {
+	const base = readFileSync(EXAMPLE_CONFIG, 'utf-8');
+	const replacement = [
+		'grounding:',
+		'  enabled: true',
+		'  mode: "on_demand"',
+		'  enrich_types: ["location", "person", "organization"]',
+		'  cache_ttl_days: 30',
+		`  min_confidence: ${minConfidence}`,
+		'  exclude_domains: ["reddit.com"]',
+		'',
+		'# --- Analysis (v2.0) ---',
+	].join('\n');
+
+	const updated = base.replace(/grounding:\n[\s\S]*?\n# --- Analysis \(v2\.0\) ---/, replacement);
+	const configPath = join(tmpDir, `grounding-66-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
+	writeFileSync(configPath, updated, 'utf-8');
+	return configPath;
+}
+
+function cleanTestData(): void {
+	db.runSql(
+		[
+			'DELETE FROM entity_grounding',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM source_steps',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function seedEntity(args: { id: string; name: string; type: string; attributes?: Record<string, unknown> }): void {
+	db.runSql(
+		[
+			'INSERT INTO entities (id, name, type, attributes, taxonomy_status)',
+			`VALUES (${sqlString(args.id)}, ${sqlString(args.name)}, ${sqlString(args.type)}, ${jsonLiteral(args.attributes ?? {})}, 'auto')`,
+		].join(' '),
+	);
+}
+
+function seedFixtureEntities(): void {
+	seedEntity({ id: VALID_LOCATION_ID, name: 'Berlin', type: 'location' });
+	seedEntity({ id: INVALID_COORDINATE_ID, name: 'Invalid Coordinate Plaza', type: 'location' });
+	seedEntity({ id: INVALID_DATE_ID, name: 'Invalid Date Person', type: 'person' });
+	seedEntity({ id: LOW_CONFIDENCE_ID, name: 'Alice Adler', type: 'person' });
+}
+
+function groundingCount(entityId: string): number {
+	return Number.parseInt(
+		db.runSql(`SELECT COUNT(*) FROM entity_grounding WHERE entity_id = ${sqlString(entityId)};`),
+		10,
+	);
+}
+
+function geomText(entityId: string): string | null {
+	const value = db.runSqlSafe(`SELECT ST_AsText(geom) FROM entities WHERE id = ${sqlString(entityId)};`);
+	return value === '' ? null : value;
+}
+
+function entityAttributes(entityId: string): Record<string, unknown> {
+	const raw = db.runSql(`SELECT attributes::text FROM entities WHERE id = ${sqlString(entityId)};`);
+	return JSON.parse(raw);
+}
+
+if (!pgAvailable) {
+	console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
+}
+
+describeIfPg('Spec 66 — Ground Plausibility Validation Before Persistence', () => {
+	beforeAll(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-66-'));
+		defaultConfigPath = writeGroundingConfig(0.7);
+		strictConfigPath = writeGroundingConfig(0.95);
+
+		const migrate = runCli(['db', 'migrate', defaultConfigPath], {
+			env: { MULDER_CONFIG: defaultConfigPath },
+			timeout: 120_000,
+		});
+		if (migrate.exitCode !== 0) {
+			throw new Error(`Migration failed: ${migrate.stdout} ${migrate.stderr}`);
+		}
+
+		cleanTestData();
+	}, 180_000);
+
+	beforeEach(() => {
+		cleanTestData();
+	});
+
+	afterAll(() => {
+		cleanTestData();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('QA-01: valid location grounding still persists coordinates and cache data', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', VALID_LOCATION_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('grounded');
+		expect(groundingCount(VALID_LOCATION_ID)).toBe(1);
+		expect(geomText(VALID_LOCATION_ID)).toContain('POINT');
+	});
+
+	it('QA-02: invalid grounded coordinates are rejected without writes', () => {
+		seedFixtureEntities();
+		expect(geomText(INVALID_COORDINATE_ID)).toBeNull();
+
+		const result = runCli(['ground', INVALID_COORDINATE_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(INVALID_COORDINATE_ID)).toBe(0);
+		expect(geomText(INVALID_COORDINATE_ID)).toBeNull();
+	});
+
+	it('QA-03: implausible grounded date attributes are rejected without writes', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', INVALID_DATE_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(INVALID_DATE_ID)).toBe(0);
+		expect(entityAttributes(INVALID_DATE_ID).iso_date).toBeUndefined();
+		expect(entityAttributes(INVALID_DATE_ID).verified_date).toBeUndefined();
+	});
+
+	it('QA-04: existing low-confidence rejection still wins before persistence', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', LOW_CONFIDENCE_ID], { env: { MULDER_CONFIG: strictConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(LOW_CONFIDENCE_ID)).toBe(0);
+	});
+
+	it('CLI-01: <valid-location-id> exits 0, persists one grounding row, and applies geometry', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', VALID_LOCATION_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain(VALID_LOCATION_ID);
+		expect(groundingCount(VALID_LOCATION_ID)).toBe(1);
+		expect(geomText(VALID_LOCATION_ID)).toContain('POINT');
+	});
+
+	it('CLI-02: <invalid-coordinates-id> exits non-zero and leaves geometry unchanged', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', INVALID_COORDINATE_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(INVALID_COORDINATE_ID)).toBe(0);
+		expect(geomText(INVALID_COORDINATE_ID)).toBeNull();
+	});
+
+	it('CLI-03: <invalid-date-id> exits non-zero and leaves invalid grounded date absent', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', INVALID_DATE_ID], { env: { MULDER_CONFIG: defaultConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(INVALID_DATE_ID)).toBe(0);
+		expect(entityAttributes(INVALID_DATE_ID).iso_date).toBeUndefined();
+	});
+
+	it('CLI-04: <low-confidence-id> exits non-zero and persists no grounding row', () => {
+		seedFixtureEntities();
+
+		const result = runCli(['ground', LOW_CONFIDENCE_ID], { env: { MULDER_CONFIG: strictConfigPath } });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('GROUND_VALIDATION_FAILED');
+		expect(groundingCount(LOW_CONFIDENCE_ID)).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- add an explicit Ground plausibility gate before persistence for coordinates and single-date grounded attributes
- add deterministic dev-mode invalid-coordinate and invalid-date fixture scenarios for black-box QA
- add Spec 66 black-box coverage for accepted, invalid-coordinate, invalid-date, and low-confidence Ground runs

Closes #161
Implements: `docs/specs/66_ground_plausibility_validation.spec.md`
Related: `docs/specs/60_ground_step.spec.md`

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm vitest run tests/specs/66_ground_plausibility_validation.test.ts --reporter=verbose`

## Notes

- Architect review approved.
- PostgreSQL-backed QA could not fully execute in this environment because Postgres was not reachable at `PGHOST/PGPORT`, so the new Spec 66 suite is present on the branch but currently skips cleanly rather than proving the DB-backed path end to end.
