### PR TITLE
refactor: clarify evidence package boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ mulder/
 │   ├── retrieval/                # Hybrid search: vector, fulltext, graph, fusion, reranker
 │   ├── taxonomy/                 # Bootstrap, normalize, merge
 │   ├── worker/                   # Job queue consumer (FOR UPDATE SKIP LOCKED)
-│   └── evidence/                 # v2.0: Contradictions, reliability, chains, spatiotemporal
+│   └── evidence/                 # Public evidence/analyze facade over pipeline analyze exports
 │
 ├── apps/
 │   ├── cli/                      # CLI application (commands/ + lib/)
@@ -218,6 +218,8 @@ mulder/
 │
 └── demo/                         # Demo UI
 ```
+
+`packages/evidence` is the public package boundary for Analyze-facing consumers. Keep the underlying analyze implementation in `packages/pipeline` unless a later spec intentionally migrates that code.
 
 ## Key Patterns
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -2220,7 +2220,7 @@ mulder/
 │   │       ├── loop.ts             # Worker event loop
 │   │       └── reaper.ts           # Stuck job recovery
 │   │
-│   └── evidence/                   # v2.0: Evidence analysis
+│   └── evidence/                   # Public evidence/analyze facade over pipeline analyze exports
 │       ├── package.json
 │       └── src/
 │           ├── contradictions.ts
@@ -2267,12 +2267,12 @@ mulder/
 ### Package Dependencies
 
 ```
-apps/cli     → packages/core, packages/pipeline, packages/retrieval, packages/taxonomy, packages/evidence, packages/worker
+apps/cli     → packages/core, packages/pipeline, packages/retrieval, packages/taxonomy
 apps/api     → packages/core, packages/retrieval, packages/taxonomy, packages/evidence, packages/worker
-packages/pipeline  → packages/core
+packages/pipeline  → packages/core, packages/retrieval, packages/taxonomy
 packages/retrieval → packages/core
 packages/taxonomy  → packages/core
-packages/evidence  → packages/core
+packages/evidence  → packages/pipeline
 packages/worker    → packages/core, packages/pipeline
 ```
 

--- a/docs/specs/02_monorepo_setup.spec.md
+++ b/docs/specs/02_monorepo_setup.spec.md
@@ -177,8 +177,8 @@ Each package follows the same pattern:
 | `packages/retrieval` | `@mulder/retrieval` | `@mulder/core` |
 | `packages/taxonomy` | `@mulder/taxonomy` | `@mulder/core` |
 | `packages/worker` | `@mulder/worker` | `@mulder/core`, `@mulder/pipeline` |
-| `packages/evidence` | `@mulder/evidence` | `@mulder/core` |
-| `apps/cli` | `@mulder/cli` | `@mulder/core`, `@mulder/pipeline`, `@mulder/retrieval`, `@mulder/taxonomy`, `@mulder/evidence`, `@mulder/worker` |
+| `packages/evidence` | `@mulder/evidence` | `@mulder/pipeline` |
+| `apps/cli` | `@mulder/cli` | `@mulder/core`, `@mulder/pipeline`, `@mulder/retrieval`, `@mulder/taxonomy` |
 | `apps/api` | `@mulder/api` | `@mulder/core`, `@mulder/retrieval`, `@mulder/taxonomy`, `@mulder/evidence`, `@mulder/worker` |
 
 Per §13 package dependency graph.
@@ -216,7 +216,7 @@ Per §13 package dependency graph.
 }
 ```
 
-**Each `src/index.ts`:** Empty barrel export (`export {};`) to make build succeed.
+**Each `src/index.ts`:** Minimal package entry point. In the initial scaffolding phase these can be empty barrels (`export {};`), but later specs may replace them with real public exports as package boundaries solidify.
 
 ### 4.3 Directory Scaffolding
 
@@ -252,7 +252,7 @@ node_modules/
 
 **Phase 1:** Root config files (package.json, pnpm-workspace.yaml, turbo.json, tsconfig.base.json, biome.json, vitest.config.ts)
 **Phase 2:** Core package (packages/core) — no dependencies, the foundation
-**Phase 3:** Leaf packages (pipeline, retrieval, taxonomy, evidence) — depend only on core
+**Phase 3:** Leaf packages (pipeline, retrieval, taxonomy, evidence) — start from the package graph in §4.2 and add only the workspace dependencies each package actually needs
 **Phase 4:** Worker package — depends on core + pipeline
 **Phase 5:** Apps (cli, api) — depend on multiple packages
 **Phase 6:** `pnpm install` + `pnpm turbo run build` + `biome check` — verify everything compiles

--- a/docs/specs/66_evidence_package_boundary.spec.md
+++ b/docs/specs/66_evidence_package_boundary.spec.md
@@ -1,0 +1,95 @@
+---
+spec: 66
+title: "[Evidence] Expose analyze via @mulder/evidence"
+roadmap_step: "[Issue #160]"
+functional_spec: "[§2.8, §10.6, §13]"
+scope: "[single]"
+issue: "https://github.com/mulkatz/mulder/issues/160"
+created: 2026-04-13
+---
+
+# Spec 66: [Evidence] Expose analyze via @mulder/evidence
+
+## 1. Objective
+
+Make `@mulder/evidence` the explicit public package boundary for Mulder's Analyze capability without moving the current implementation out of `packages/pipeline/src/analyze/*`. Per `§2.8`, Analyze is a modular full-graph capability with multiple sub-passes; per `§10.6`, future API evidence routes must stay synchronous and avoid reaching into pipeline internals directly. This spec resolves issue #160 by giving M7-era consumers one unambiguous import surface while keeping the existing pipeline implementation intact.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `Issue #160` — Resolve the `@mulder/evidence` package boundary before M7 consumers depend on analyze
+- **Target:** `packages/evidence/src/index.ts`, `packages/evidence/package.json`, `packages/evidence/tsconfig.json`, `CLAUDE.md`, `docs/functional-spec.md`, `docs/specs/02_monorepo_setup.spec.md`, `tests/specs/02_monorepo_setup.test.ts`, `tests/specs/66_evidence_package_boundary.test.ts`
+- **In scope:** turning `@mulder/evidence` into a real facade package for Analyze exports; wiring its package/project dependencies so it can legally re-export analyze types and runtime entry points; updating architecture/package-graph documentation to match that boundary; and adding black-box tests that prove the facade works
+- **Out of scope:** moving Analyze implementation files out of `packages/pipeline`; changing CLI command ownership; introducing new API routes; refactoring retrieval/taxonomy boundaries; or redesigning the full package graph beyond the evidence/analyze seam
+- **Constraints:** keep the current Analyze implementation in `packages/pipeline/src/analyze/*`; keep `apps/api` aligned with `§10.6` by consuming a stable package boundary rather than pipeline internals; preserve ESM-only workspace conventions; and avoid creating circular package references
+
+## 3. Dependencies
+
+- **Requires:** Spec 02 (monorepo package graph), Spec 61 (contradiction resolution), Spec 62 (source reliability scoring), Spec 63 (evidence chains), Spec 64 (spatio-temporal clustering), Spec 65 (analyze orchestrator)
+- **Blocks:** M7 consumers that need Analyze or evidence-domain entry points, especially future `/api/evidence/*` surfaces and any worker/API code that would otherwise guess between `pipeline` and `evidence`
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/evidence/src/index.ts`** — replace the empty module with a deliberate re-export surface for Analyze runtime entry points and public types from `@mulder/pipeline`
+2. **`packages/evidence/package.json`** — add the workspace dependency on `@mulder/pipeline` so the facade's runtime dependency graph matches its export surface
+3. **`packages/evidence/tsconfig.json`** — add the TypeScript project reference to `../pipeline` so composite builds and declaration output stay valid
+4. **`CLAUDE.md`** — update the repo structure and package dependency sections so the architecture doc no longer implies `packages/evidence` is an empty shell
+5. **`docs/functional-spec.md`** — update the source-layout package dependency graph to show `packages/evidence` as the public evidence/analyze facade over pipeline
+6. **`docs/specs/02_monorepo_setup.spec.md`** — correct the historical package graph documentation so spec-level package expectations match the implemented boundary
+7. **`tests/specs/02_monorepo_setup.test.ts`** — update black-box dependency expectations for `packages/evidence`
+8. **`tests/specs/66_evidence_package_boundary.test.ts`** — add focused black-box QA for the new facade import surface and the aligned docs/package graph
+
+### 4.2 Database Changes
+
+None.
+
+### 4.3 Config Changes
+
+None.
+
+### 4.4 Integration Points
+
+- `packages/evidence` becomes the stable import boundary for Analyze-facing consumers
+- `packages/pipeline` remains the implementation owner for pipeline execution and internal orchestration
+- documentation in `CLAUDE.md`, `docs/functional-spec.md`, and the monorepo setup spec must all describe the same dependency graph
+- black-box tests must verify both the package facade and the documented graph so future M7 work cannot regress back into an ambiguous boundary
+
+### 4.5 Implementation Phases
+
+Single phase — implement all files in the order listed in §4.1.
+
+## 5. QA Contract
+
+1. **QA-01: `@mulder/evidence` exposes the Analyze runtime surface**
+   - Given: the workspace has been built with `pnpm turbo run build`
+   - When: an ESM script imports `executeAnalyze` from `@mulder/evidence`
+   - Then: the import succeeds, `executeAnalyze` is a function, and no consumer needs to reach into `@mulder/pipeline` for Analyze execution
+
+2. **QA-02: `@mulder/evidence` exposes key Analyze types**
+   - Given: the workspace has been built
+   - When: an ESM script imports `AnalyzeInput`, `AnalyzeResult`, and `AnalyzePassName` from `@mulder/evidence`
+   - Then: the package resolves those named exports successfully from its public entry point
+
+3. **QA-03: facade build and typecheck are stable on repeat runs**
+   - Given: the package graph has already been built and typechecked once
+   - When: `pnpm --filter @mulder/evidence build` and `pnpm --filter @mulder/evidence typecheck` are run again
+   - Then: both commands exit `0` and the package continues to expose the same Analyze entry point without requiring any manual cleanup
+
+4. **QA-04: documentation names one boundary for Analyze consumers**
+   - Given: `CLAUDE.md`, `docs/functional-spec.md`, and `docs/specs/02_monorepo_setup.spec.md`
+   - When: the package dependency sections are inspected
+   - Then: each document states that `packages/evidence` depends on `packages/pipeline`, and none of them describe `@mulder/evidence` as an empty or misleading package boundary
+
+5. **QA-05: workspace dependency tests reflect the real package graph**
+   - Given: the repository test suite includes monorepo dependency assertions
+   - When: `vitest` runs the monorepo dependency tests and the new spec-66 boundary test
+   - Then: both pass with `packages/evidence` expecting `@mulder/pipeline` in its dependency graph and the facade import surface proving usable from the built package
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+None — no paid API calls.

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -11,6 +11,6 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@mulder/core": "workspace:*"
+		"@mulder/pipeline": "workspace:*"
 	}
 }

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -1,1 +1,23 @@
-export {};
+export type {
+	AnalyzeData,
+	AnalyzeInput,
+	AnalyzePassName,
+	AnalyzePassResult,
+	AnalyzeResult,
+	ContradictionAnalyzeData,
+	ContradictionResolutionOutcome,
+	ContradictionResolutionResponse,
+	ContradictionVerdict,
+	EvidenceChainsAnalyzeData,
+	EvidenceChainThesisOutcome,
+	FullAnalyzeData,
+	ReliabilityAnalyzeData,
+	SingleAnalyzeData,
+	SourceReliabilityOutcome,
+	SpatioTemporalAnalyzeData,
+	SpatioTemporalCluster,
+	SpatioTemporalClusterType,
+	SpatioTemporalEvent,
+	WinningClaim,
+} from '@mulder/pipeline';
+export { executeAnalyze } from '@mulder/pipeline';

--- a/packages/evidence/tsconfig.json
+++ b/packages/evidence/tsconfig.json
@@ -1,9 +1,14 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"baseUrl": ".",
+		"ignoreDeprecations": "6.0",
 		"outDir": "dist",
+		"paths": {
+			"@mulder/pipeline": ["../pipeline/src/index.ts"]
+		},
 		"rootDir": "src"
 	},
 	"include": ["src"],
-	"references": [{ "path": "../core" }]
+	"references": [{ "path": "../pipeline" }]
 }

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -5,5 +5,5 @@
 		"rootDir": "src"
 	},
 	"include": ["src"],
-	"references": [{ "path": "../core" }, { "path": "../taxonomy" }]
+	"references": [{ "path": "../core" }, { "path": "../retrieval" }, { "path": "../taxonomy" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,15 +135,18 @@ importers:
 
   packages/evidence:
     dependencies:
-      '@mulder/core':
+      '@mulder/pipeline':
         specifier: workspace:*
-        version: link:../core
+        version: link:../pipeline
 
   packages/pipeline:
     dependencies:
       '@mulder/core':
         specifier: workspace:*
         version: link:../core
+      '@mulder/retrieval':
+        specifier: workspace:*
+        version: link:../retrieval
       '@mulder/taxonomy':
         specifier: workspace:*
         version: link:../taxonomy

--- a/tests/specs/02_monorepo_setup.test.ts
+++ b/tests/specs/02_monorepo_setup.test.ts
@@ -49,7 +49,7 @@ describe('Spec 02: Monorepo Setup', () => {
 		'packages/retrieval': ['@mulder/core'],
 		'packages/taxonomy': ['@mulder/core'],
 		'packages/worker': ['@mulder/core', '@mulder/pipeline'],
-		'packages/evidence': ['@mulder/core'],
+		'packages/evidence': ['@mulder/pipeline'],
 		'apps/cli': [
 			'@mulder/core',
 			'@mulder/pipeline',

--- a/tests/specs/66_evidence_package_boundary.test.ts
+++ b/tests/specs/66_evidence_package_boundary.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const DOC_PATHS = [
+	resolve(ROOT, 'CLAUDE.md'),
+	resolve(ROOT, 'docs/functional-spec.md'),
+	resolve(ROOT, 'docs/specs/02_monorepo_setup.spec.md'),
+];
+
+function runNodeImport(script: string): string {
+	return execFileSync('node', ['--input-type=module', '--eval', script], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: 120_000,
+	});
+}
+
+describe('Spec 66: Evidence package boundary', () => {
+	beforeAll(() => {
+		execFileSync('pnpm', ['--filter', '@mulder/evidence', 'build'], {
+			cwd: ROOT,
+			encoding: 'utf-8',
+			timeout: 120_000,
+		});
+	});
+
+	it('QA-01 and QA-02: @mulder/evidence exposes analyze runtime and type exports from its public entry point', () => {
+		const evidencePackage = JSON.parse(readFileSync(resolve(ROOT, 'packages/evidence/package.json'), 'utf-8')) as {
+			exports: { '.': string };
+		};
+		const publicEntry = resolve(ROOT, 'packages/evidence', evidencePackage.exports['.']);
+		const output = runNodeImport(`
+			const evidence = await import(${JSON.stringify(publicEntry)});
+			const payload = {
+				executeAnalyzeType: typeof evidence.executeAnalyze,
+			};
+			console.log(JSON.stringify(payload));
+		`);
+		const parsed = JSON.parse(output) as {
+			executeAnalyzeType: string;
+		};
+		const declarationsPath = resolve(ROOT, 'packages/evidence/dist/index.d.ts');
+		const declarations = readFileSync(declarationsPath, 'utf-8');
+
+		expect(parsed.executeAnalyzeType).toBe('function');
+		expect(declarations).toContain('AnalyzeInput');
+		expect(declarations).toContain('AnalyzeResult');
+		expect(declarations).toContain('AnalyzePassName');
+	});
+
+	it('QA-03: evidence facade rebuilds and typechecks cleanly on repeat runs', () => {
+		expect(() =>
+			execFileSync('pnpm', ['--filter', '@mulder/evidence', 'build'], {
+				cwd: ROOT,
+				encoding: 'utf-8',
+				timeout: 120_000,
+			}),
+		).not.toThrow();
+
+		expect(() =>
+			execFileSync('pnpm', ['--filter', '@mulder/evidence', 'typecheck'], {
+				cwd: ROOT,
+				encoding: 'utf-8',
+				timeout: 120_000,
+			}),
+		).not.toThrow();
+	});
+
+	it('QA-04: docs describe packages/evidence as the analyze facade over packages/pipeline', () => {
+		for (const docPath of DOC_PATHS) {
+			const content = readFileSync(docPath, 'utf-8');
+			expect(content, `${docPath} should mention packages/evidence`).toContain('packages/evidence');
+			expect(content, `${docPath} should describe the pipeline dependency`).toContain('packages/pipeline');
+		}
+	});
+
+	it('QA-05: the evidence package graph matches the implemented facade dependency', () => {
+		const evidencePackage = JSON.parse(readFileSync(resolve(ROOT, 'packages/evidence/package.json'), 'utf-8')) as {
+			dependencies?: Record<string, string>;
+		};
+
+		expect(evidencePackage.dependencies).toMatchObject({
+			'@mulder/pipeline': 'workspace:*',
+		});
+		expect(Object.keys(evidencePackage.dependencies ?? {}).filter((name) => name.startsWith('@mulder/'))).toEqual([
+			'@mulder/pipeline',
+		]);
+		expect(existsSync(resolve(ROOT, 'packages/evidence/dist/index.js'))).toBe(true);
+		expect(existsSync(resolve(ROOT, 'packages/evidence/dist/index.d.ts'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- make `@mulder/evidence` the public Analyze facade over `@mulder/pipeline`
- align workspace docs/specs with the actual package graph and add spec 66 coverage
- add the missing pipeline TypeScript project reference needed for the facade build

## Verification
- `pnpm --filter @mulder/evidence build`
- `pnpm exec vitest run ./tests/specs/02_monorepo_setup.test.ts ./tests/specs/66_evidence_package_boundary.test.ts`

Closes #160
