### PR TITLE
[M7-H3] Hono server scaffold for @mulder/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,10 +11,12 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@hono/node-server": "^1.15.0",
 		"@mulder/core": "workspace:*",
 		"@mulder/retrieval": "workspace:*",
 		"@mulder/taxonomy": "workspace:*",
 		"@mulder/evidence": "workspace:*",
-		"@mulder/worker": "workspace:*"
+		"@mulder/worker": "workspace:*",
+		"hono": "^4.7.11"
 	}
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,35 @@
+import { performance } from 'node:perf_hooks';
+import { createChildLogger, createLogger, type Logger } from '@mulder/core';
+import { Hono } from 'hono';
+import { registerHealthRoute } from './routes/health.js';
+
+export interface AppOptions {
+	logger?: Logger;
+}
+
+export function createApp(options: AppOptions = {}): Hono {
+	const rootLogger = options.logger ?? createLogger();
+	const requestLogger = createChildLogger(rootLogger, { module: 'api' });
+	const app = new Hono();
+
+	app.use('*', async (c, next) => {
+		const startedAt = performance.now();
+		try {
+			await next();
+		} finally {
+			requestLogger.info(
+				{
+					method: c.req.method,
+					path: c.req.path,
+					status: c.res.status,
+					duration_ms: Math.round(performance.now() - startedAt),
+				},
+				'request completed',
+			);
+		}
+	});
+
+	registerHealthRoute(app);
+
+	return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,1 +1,44 @@
-export {};
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { serve } from '@hono/node-server';
+import { createLogger } from '@mulder/core';
+import { createApp } from './app.js';
+
+export const DEFAULT_API_PORT = 8080;
+
+export function resolveApiPort(): number {
+	const rawPort = process.env.MULDER_API_PORT ?? process.env.PORT ?? '';
+	const parsedPort = Number.parseInt(rawPort, 10);
+
+	if (Number.isInteger(parsedPort) && parsedPort > 0) {
+		return parsedPort;
+	}
+
+	return DEFAULT_API_PORT;
+}
+
+export function startApiServer(): ReturnType<typeof serve> {
+	const logger = createLogger();
+	const app = createApp({ logger });
+	const port = resolveApiPort();
+	const server = serve({ fetch: app.fetch, port });
+
+	logger.info({ port }, 'API server started');
+
+	process.once('SIGTERM', () => {
+		server.close();
+	});
+
+	process.once('SIGINT', () => {
+		server.close();
+	});
+
+	return server;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	startApiServer();
+}
+
+export { createApp } from './app.js';

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,19 @@
+import type { Hono } from 'hono';
+
+export const API_VERSION = '0.0.0';
+
+export type HealthResponse = {
+	status: 'ok';
+	version: string;
+};
+
+export function getHealthResponse(): HealthResponse {
+	return {
+		status: 'ok',
+		version: API_VERSION,
+	};
+}
+
+export function registerHealthRoute(app: Hono): void {
+	app.get('/api/health', (c) => c.json(getHealthResponse(), 200));
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,7 +185,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 |--------|------|------|------|
 | 🟢 | H1 | Job queue repository — enqueue/dequeue/reap | §4.3 (jobs table), §10.2, §10.3 |
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
-| 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
+| 🟡 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | ⚪ | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | ⚪ | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,7 +185,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 |--------|------|------|------|
 | 🟢 | H1 | Job queue repository — enqueue/dequeue/reap | §4.3 (jobs table), §10.2, §10.3 |
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
-| ⚪ | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
+| 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | ⚪ | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | ⚪ | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,7 +185,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 |--------|------|------|------|
 | 🟢 | H1 | Job queue repository — enqueue/dequeue/reap | §4.3 (jobs table), §10.2, §10.3 |
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
-| 🟡 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
+| 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | ⚪ | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | ⚪ | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |

--- a/docs/specs/69_hono_server_scaffold.spec.md
+++ b/docs/specs/69_hono_server_scaffold.spec.md
@@ -1,0 +1,106 @@
+---
+spec: "69"
+title: "Hono Server Scaffold"
+roadmap_step: M7-H3
+functional_spec: ["§13 (apps/api/)"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/171"
+created: 2026-04-14
+---
+
+# Spec 69: Hono Server Scaffold
+
+## 1. Objective
+
+Introduce Mulder's first real HTTP runtime in `apps/api` so M7 can build on a concrete Hono-based server rather than an empty placeholder package. Per `§13`, `apps/api` is the API application boundary; per the M7 architecture notes, the scaffold should use Hono with `@hono/node-server`, expose an unauthenticated health endpoint, and establish an app/server split that future middleware and route specs can extend without rewriting the bootstrap.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H3` — Hono server scaffold — app, node-server, health endpoint
+- **Target:** `apps/api/package.json`, `apps/api/src/app.ts`, `apps/api/src/index.ts`, `apps/api/src/routes/health.ts`, `tests/specs/69_hono_server_scaffold.test.ts`
+- **In scope:** Hono runtime dependencies for `@mulder/api`; a reusable app factory that mounts `/api/health`; a Node entrypoint that starts the Hono app with `@hono/node-server`; minimal request logging through Mulder's existing logger; and black-box coverage proving the scaffold boots and serves the health route
+- **Out of scope:** auth, rate limiting, request context, structured error middleware (`M7-H4`); pipeline, jobs, search, entity, evidence, or document routes (`M7-H5` through `M7-H10`); OpenAPI/Scalar setup; config schema additions for API settings; and any demo UI work (`M7-H11`)
+- **Constraints:** preserve the CLI-first package boundaries from `CLAUDE.md`; keep business logic out of the HTTP layer; keep the initial server bootstrap small and dependency-light; avoid inventing a broad API config surface before the middleware/routes specs land; and ensure the health endpoint can be called without authentication for Cloud Run-style liveness checks
+
+## 3. Dependencies
+
+- **Requires:** Spec 02 (`M1-A1`) monorepo app/package layout, Spec 05 (`M1-A4`) centralized logging, and the existing `@mulder/api` workspace package scaffold
+- **Blocks:** `M7-H4` middleware composition, `M7-H5` pipeline API routes, `M7-H6` job status API, `M7-H7` search API routes, `M7-H8` entity API routes, `M7-H9` evidence API routes, and `M7-H10` document retrieval routes
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/package.json`** — adds the Hono runtime dependencies needed to boot the API on Node
+2. **`apps/api/src/app.ts`** — exports a small `createApp()` factory that instantiates Hono, applies minimal request logging, and mounts the base routes
+3. **`apps/api/src/routes/health.ts`** — defines the unauthenticated `GET /api/health` handler
+4. **`apps/api/src/index.ts`** — exports the app surface and provides the executable Node server bootstrap
+5. **`tests/specs/69_hono_server_scaffold.test.ts`** — black-box/spec-level verification of the health route and package buildability
+
+### 4.2 Runtime Changes
+
+This step introduces Mulder's first HTTP server process under `apps/api`:
+
+- use `hono` as the application framework
+- use `@hono/node-server` as the Node runtime adapter for local execution and future Cloud Run deployment
+- keep the bootstrap separated into:
+  - an app factory for tests and future composition
+  - a process entrypoint for actual listening
+
+The first route surface is intentionally narrow:
+
+- `GET /api/health`
+
+The health route should return a stable success payload that is shell- and HTTP-observable without depending on the database, GCP, or job queue state.
+
+### 4.3 Config Changes
+
+None. The scaffold may read a simple environment port fallback such as `PORT`/`MULDER_API_PORT`, but it must not add or require new `mulder.config.yaml` schema fields in this step.
+
+### 4.4 Integration Points
+
+- future middleware specs attach to the app factory instead of replacing bootstrap code
+- future route specs register under the same `/api/*` namespace
+- future deployment/runtime work can invoke the exported server entrypoint without restructuring `apps/api`
+- tests can import the app factory directly and avoid shelling out to a long-lived server process for basic route verification
+
+### 4.5 Implementation Phases
+
+**Phase 1: App bootstrap**
+- add Hono runtime dependencies
+- create the app factory and the `/api/health` route
+- wire a Node server entrypoint around the app
+
+**Phase 2: QA coverage**
+- add a black-box API test for `GET /api/health`
+- verify the `@mulder/api` package still typechecks/builds cleanly with the new runtime
+
+## 5. QA Contract
+
+1. **QA-01: Health endpoint responds successfully from the app scaffold**
+   - Given: the `@mulder/api` package app factory
+   - When: a request is made to `GET /api/health`
+   - Then: the response status is `200` and the body reports the service as healthy
+
+2. **QA-02: Health endpoint is reachable under the `/api` namespace**
+   - Given: the scaffolded Hono app
+   - When: the health route is invoked by its public path
+   - Then: the route resolves at `/api/health`, not an ad hoc root-only endpoint
+
+3. **QA-03: Health checks do not require database or GCP connectivity**
+   - Given: no active PostgreSQL, Firestore, or GCP credentials
+   - When: `GET /api/health` runs
+   - Then: the request still succeeds because the liveness probe is process-local only
+
+4. **QA-04: The API package compiles with the new server runtime**
+   - Given: the Hono scaffold files and package dependencies are wired into `@mulder/api`
+   - When: the API package build/typecheck runs
+   - Then: the package compiles successfully and exports the server/app surface without type errors
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+None for direct service spend. This step is a local HTTP scaffold only and must not trigger database queries or paid external APIs.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.15.0
+        version: 1.19.14(hono@4.12.12)
       '@mulder/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -47,6 +50,9 @@ importers:
       '@mulder/worker':
         specifier: workspace:*
         version: link:../../packages/worker
+      hono:
+        specifier: ^4.7.11
+        version: 4.12.12
 
   apps/cli:
     dependencies:
@@ -492,6 +498,12 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1207,6 +1219,10 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -2034,6 +2050,10 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.14(hono@4.12.12)':
+    dependencies:
+      hono: 4.12.12
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2697,6 +2717,8 @@ snapshots:
       function-bind: 1.1.2
 
   help-me@5.0.0: {}
+
+  hono@4.12.12: {}
 
   html-entities@2.6.0: {}
 

--- a/tests/specs/69_hono_server_scaffold.test.ts
+++ b/tests/specs/69_hono_server_scaffold.test.ts
@@ -1,0 +1,170 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const API_DIR = resolve(ROOT, 'apps/api');
+const API_DIST_DIR = resolve(API_DIR, 'dist');
+const API_INDEX = resolve(API_DIST_DIR, 'index.js');
+const API_APP = resolve(API_DIST_DIR, 'app.js');
+
+type SpawnedProcess = ReturnType<typeof spawn>;
+
+async function buildApiPackage(): Promise<void> {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: API_DIR,
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(`API build failed:\n${result.stdout ?? ''}\n${result.stderr ?? ''}`);
+	}
+}
+
+async function findFreePort(): Promise<number> {
+	return await new Promise<number>((resolvePort, rejectPort) => {
+		const server = createServer();
+		server.once('error', rejectPort);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			server.close(() => {
+				if (address && typeof address === 'object') {
+					resolvePort(address.port);
+					return;
+				}
+				rejectPort(new Error('Could not determine free port'));
+			});
+		});
+	});
+}
+
+async function waitForHealth(url: string, timeoutMs = 10_000): Promise<Response> {
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(url);
+			if (response.ok) {
+				return response;
+			}
+		} catch {
+			// Keep polling until the server is ready.
+		}
+
+		await delay(100);
+	}
+
+	throw new Error(`Timed out waiting for ${url}`);
+}
+
+function startApiServer(port: number): SpawnedProcess {
+	return spawn('node', [API_INDEX], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			NODE_ENV: 'test',
+			PORT: String(port),
+			MULDER_LOG_LEVEL: 'silent',
+			PGHOST: '',
+			PGPORT: '',
+			PGDATABASE: '',
+			PGUSER: '',
+			PGPASSWORD: '',
+			GOOGLE_APPLICATION_CREDENTIALS: '',
+			GOOGLE_CLOUD_PROJECT: '',
+		},
+	});
+}
+
+function stopProcess(child: SpawnedProcess): Promise<void> {
+	return new Promise<void>((resolveStop) => {
+		if (child.exitCode === null) {
+			child.once('close', () => resolveStop());
+			child.kill('SIGINT');
+			return;
+		}
+
+		resolveStop();
+	});
+}
+
+describe('Spec 69: Hono Server Scaffold', () => {
+	const originalLogLevel = process.env.MULDER_LOG_LEVEL;
+
+	beforeAll(async () => {
+		process.env.MULDER_LOG_LEVEL = 'silent';
+		await buildApiPackage();
+	});
+
+	afterAll(async () => {
+		if (originalLogLevel === undefined) {
+			delete process.env.MULDER_LOG_LEVEL;
+		} else {
+			process.env.MULDER_LOG_LEVEL = originalLogLevel;
+		}
+		// No shared resources are created in the API scaffold test.
+	});
+
+	it('QA-01: createApp serves a healthy response at /api/health', async () => {
+		const module = await import(pathToFileURL(API_APP).href);
+		expect(typeof module.createApp).toBe('function');
+
+		const app = module.createApp();
+		const response = await app.request('http://localhost/api/health');
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ status: 'ok', version: '0.0.0' });
+	});
+
+	it('QA-02: the Node entrypoint boots Hono and serves /api/health', async () => {
+		const port = await findFreePort();
+		const child = startApiServer(port);
+
+		try {
+			const response = await waitForHealth(`http://127.0.0.1:${port}/api/health`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ status: 'ok', version: '0.0.0' });
+		} finally {
+			await stopProcess(child);
+		}
+	});
+
+	it('QA-03: the health route succeeds without database or GCP connectivity', async () => {
+		const port = await findFreePort();
+		const child = startApiServer(port);
+
+		try {
+			const response = await waitForHealth(`http://127.0.0.1:${port}/api/health`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ status: 'ok', version: '0.0.0' });
+		} finally {
+			await stopProcess(child);
+		}
+	});
+
+	it('QA-04: the api package builds successfully with the scaffolded runtime', async () => {
+		const buildResult = spawnSync('pnpm', ['build'], {
+			cwd: API_DIR,
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+			env: {
+				...process.env,
+				MULDER_LOG_LEVEL: 'silent',
+			},
+		});
+
+		expect(buildResult.status ?? 1).toBe(0);
+		expect(typeof (await import(pathToFileURL(API_INDEX).href)).startApiServer).toBe('function');
+	});
+});

--- a/tests/specs/69_hono_server_scaffold.test.ts
+++ b/tests/specs/69_hono_server_scaffold.test.ts
@@ -16,7 +16,6 @@ type SpawnedProcess = ReturnType<typeof spawn>;
 async function buildApiPackage(): Promise<void> {
 	const result = spawnSync('pnpm', ['build'], {
 		cwd: API_DIR,
-		encoding: 'utf-8',
 		stdio: ['ignore', 'pipe', 'pipe'],
 		env: {
 			...process.env,
@@ -26,7 +25,7 @@ async function buildApiPackage(): Promise<void> {
 
 	expect(result.status ?? 1).toBe(0);
 	if ((result.status ?? 1) !== 0) {
-		throw new Error(`API build failed:\n${result.stdout ?? ''}\n${result.stderr ?? ''}`);
+		throw new Error(`API build failed:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`);
 	}
 }
 
@@ -69,7 +68,6 @@ async function waitForHealth(url: string, timeoutMs = 10_000): Promise<Response>
 function startApiServer(port: number): SpawnedProcess {
 	return spawn('node', [API_INDEX], {
 		cwd: ROOT,
-		encoding: 'utf-8',
 		stdio: ['ignore', 'pipe', 'pipe'],
 		env: {
 			...process.env,
@@ -156,7 +154,6 @@ describe('Spec 69: Hono Server Scaffold', () => {
 	it('QA-04: the api package builds successfully with the scaffolded runtime', async () => {
 		const buildResult = spawnSync('pnpm', ['build'], {
 			cwd: API_DIR,
-			encoding: 'utf-8',
 			stdio: ['ignore', 'pipe', 'pipe'],
 			env: {
 				...process.env,


### PR DESCRIPTION
Implements Spec 69 (docs/specs/69_hono_server_scaffold.spec.md) for roadmap step M7-H3.

What changed:
- Added a Hono app factory and reusable /api/health route.
- Wired a Node entrypoint via @hono/node-server with minimal request logging.
- Added black-box coverage for app factory behavior, node bootstrap, and package buildability.
- Marked M7-H3 complete in docs/roadmap.md.

Verification:
- pnpm turbo run build --filter='...[HEAD]'
- pnpm vitest run tests/specs/69_hono_server_scaffold.test.ts
- npx biome check apps/api/src/index.ts apps/api/src/app.ts apps/api/src/routes/health.ts tests/specs/69_hono_server_scaffold.test.ts

Repo-wide npx biome check . still reports an unrelated pre-existing import-order issue in packages/worker/src/runtime.ts.

Closes #171
