### PR TITLE
fix: restore worker baseline verification

### DIFF
--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -12,7 +12,6 @@
 	},
 	"dependencies": {
 		"@mulder/core": "workspace:*",
-		"@mulder/pipeline": "workspace:*",
-		"@mulder/taxonomy": "workspace:*"
+		"@mulder/pipeline": "workspace:*"
 	}
 }

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -215,19 +215,19 @@ export async function processNextJob(context: WorkerRuntimeContext, workerId: st
 		return { state: 'idle', job: null, error: null };
 	}
 
-	const typedJob = toWorkerJobEnvelope(job);
-
 	const claim = {
-		jobId: typedJob.id,
+		jobId: job.id,
 		workerId,
-		attempts: typedJob.attempts,
+		attempts: job.attempts,
 	};
-	const jobLog = createChildLogger(workerLog, { jobId: typedJob.id, jobType: typedJob.type });
+	const jobLog = createChildLogger(workerLog, { jobId: job.id, jobType: job.type });
 	const dispatch = context.dispatch ?? dispatchJob;
 
-	jobLog.info({ attempts: typedJob.attempts }, 'Job claimed');
+	jobLog.info({ attempts: job.attempts }, 'Job claimed');
 
+	let typedJob: WorkerJobEnvelope | null = null;
 	try {
+		typedJob = toWorkerJobEnvelope(job);
 		await dispatch(typedJob, getWorkerDispatchContext(context, workerId));
 		await markJobCompleted(context.pool, claim);
 		jobLog.info('Job completed');

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -25,8 +25,8 @@ import { dispatchJob } from './dispatch.js';
 import {
 	createWorkerId,
 	describeWorkerError,
-	type WorkerDispatchContext,
 	type WorkerActiveJobSnapshot,
+	type WorkerDispatchContext,
 	type WorkerDispatchFn,
 	type WorkerJobEnvelope,
 	type WorkerJobStatusSnapshot,
@@ -87,11 +87,77 @@ function mapJob(job: Awaited<ReturnType<typeof findJobs>>[number]): WorkerJobSta
 	};
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isWorkerJobEnvelopeType(type: string): type is WorkerJobEnvelope['type'] {
+	return (
+		type === 'extract' ||
+		type === 'segment' ||
+		type === 'enrich' ||
+		type === 'embed' ||
+		type === 'graph' ||
+		type === 'pipeline_run'
+	);
+}
+
+function readOptionalBoolean(payload: Record<string, unknown>, key: string): boolean | undefined {
+	return typeof payload[key] === 'boolean' ? payload[key] : undefined;
+}
+
+function toWorkerJobPayload(job: Job): WorkerJobEnvelope['payload'] {
+	if (!isRecord(job.payload)) {
+		throw new Error(`Job ${job.id} payload must be an object`);
+	}
+
+	if (job.type === 'extract' || job.type === 'segment' || job.type === 'pipeline_run') {
+		const sourceId =
+			typeof job.payload.sourceId === 'string'
+				? job.payload.sourceId
+				: typeof job.payload.source_id === 'string'
+					? job.payload.source_id
+					: null;
+		if (!sourceId) {
+			throw new Error(`Job ${job.id} is missing sourceId`);
+		}
+
+		return {
+			sourceId,
+			force: readOptionalBoolean(job.payload, 'force'),
+			fallbackOnly: readOptionalBoolean(job.payload, 'fallbackOnly'),
+		};
+	}
+
+	if (job.type === 'enrich' || job.type === 'embed' || job.type === 'graph') {
+		const storyId =
+			typeof job.payload.storyId === 'string'
+				? job.payload.storyId
+				: typeof job.payload.story_id === 'string'
+					? job.payload.story_id
+					: null;
+		if (!storyId) {
+			throw new Error(`Job ${job.id} is missing storyId`);
+		}
+
+		return {
+			storyId,
+			force: readOptionalBoolean(job.payload, 'force'),
+		};
+	}
+
+	throw new Error(`Unsupported job type "${job.type}"`);
+}
+
 function toWorkerJobEnvelope(job: Job): WorkerJobEnvelope {
+	if (!isWorkerJobEnvelopeType(job.type)) {
+		throw new Error(`Unsupported job type "${job.type}"`);
+	}
+
 	return {
 		...job,
-		type: job.type as WorkerJobEnvelope['type'],
-		payload: job.payload as unknown as WorkerJobEnvelope['payload'],
+		type: job.type,
+		payload: toWorkerJobPayload(job),
 	};
 }
 

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -5,5 +5,5 @@
 		"rootDir": "src"
 	},
 	"include": ["src"],
-	"references": [{ "path": "../core" }, { "path": "../pipeline" }, { "path": "../taxonomy" }]
+	"references": [{ "path": "../core" }, { "path": "../pipeline" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
       '@mulder/pipeline':
         specifier: workspace:*
         version: link:../pipeline
-      '@mulder/taxonomy':
-        specifier: workspace:*
-        version: link:../taxonomy
 
   tests:
     devDependencies:

--- a/tests/specs/02_monorepo_setup.test.ts
+++ b/tests/specs/02_monorepo_setup.test.ts
@@ -55,8 +55,9 @@ describe('Spec 02: Monorepo Setup', () => {
 			'@mulder/pipeline',
 			'@mulder/retrieval',
 			'@mulder/taxonomy',
-			// Additional deps (@mulder/evidence, @mulder/worker) are added
-			// as those packages are implemented.
+			'@mulder/worker',
+			// Additional deps such as @mulder/evidence can be added
+			// as those packages are implemented and wired into the CLI.
 		],
 		'apps/api': ['@mulder/core', '@mulder/retrieval', '@mulder/taxonomy', '@mulder/evidence', '@mulder/worker'],
 	};

--- a/tests/specs/68_worker_loop.test.ts
+++ b/tests/specs/68_worker_loop.test.ts
@@ -162,7 +162,6 @@ function startWorker(args: string[] = []): {
 } {
 	const child = spawn('node', [CLI, 'worker', 'start', ...args], {
 		cwd: ROOT,
-		encoding: 'utf-8',
 		stdio: ['ignore', 'pipe', 'pipe'],
 		env: {
 			...process.env,


### PR DESCRIPTION
Baseline cleanup after M7-H3 to restore green verification on main.

What changed:
- removed an unused `@mulder/taxonomy` dependency/reference from `@mulder/worker`
- replaced casual worker runtime type assertions with validated payload narrowing
- updated Spec 68 child-process typing for current Node typings
- aligned stale Spec 02 dependency expectations with the shipped CLI/worker workspace shape

Verification:
- `pnpm turbo run typecheck`
- `npx biome check .`
- `pnpm vitest run tests/specs/02_monorepo_setup.test.ts --reporter=dot`
- `pnpm vitest run tests/specs/68_worker_loop.test.ts --reporter=dot`
