### PR TITLE
fix: ignore generated temp fixtures in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,6 +39,7 @@
 			"!**/node_modules",
 			"!**/dist",
 			"!**/.turbo",
+			"!tmp-*",
 			"!fixtures",
 			"!**/demo",
 			"!**/.claude",


### PR DESCRIPTION
Exclude generated root-level `tmp-*` test artifact directories from repo-wide Biome checks.

Why:
- spec-level tests create temporary fixture output under root `tmp-*` directories
- those generated files are not source files and should not participate in `npx biome check .`
- including them caused false-negative verification failures for Spec 68 and adjacent baseline tests

Verification:
- `npx biome check .`
- `pnpm vitest run tests/specs/68_worker_loop.test.ts --reporter=dot`
- `pnpm vitest run tests/specs/14_source_repository.test.ts tests/specs/15_native_text_detection.test.ts tests/specs/22_pdf_metadata_extraction.test.ts --reporter=dot`
