### PR TITLE
fix: fail fast when db-backed specs lack postgres

### DIFF
--- a/tests/lib/db.ts
+++ b/tests/lib/db.ts
@@ -38,6 +38,25 @@ export function isPgAvailable(): boolean {
 	return runDbRunner(['ready'], 5_000).exitCode === 0;
 }
 
+export function requirePg(): void {
+	const result = runDbRunner(['ready'], 5_000);
+	if (result.exitCode === 0) {
+		return;
+	}
+
+	const stderr = result.stderr.trim();
+	const stdout = result.stdout.trim();
+	const details = [stderr, stdout].filter(Boolean).join('\n');
+
+	throw new Error(
+		[
+			`PostgreSQL is required for this spec test but is not reachable.`,
+			`Tried ${TEST_PG_USER}@${TEST_PG_HOST}:${TEST_PG_PORT}/${TEST_PG_DATABASE}.`,
+			details ? `pg_isready output:\n${details}` : 'pg_isready returned a non-zero exit code with no output.',
+		].join('\n'),
+	);
+}
+
 export function runSql(sql: string): string {
 	const encodedSql = Buffer.from(sql, 'utf8').toString('base64');
 	const result = runDbRunner(['query', encodedSql], 15_000);

--- a/tests/specs/67_job_queue_repository.test.ts
+++ b/tests/specs/67_job_queue_repository.test.ts
@@ -66,14 +66,11 @@ function cleanJobData(): void {
 }
 
 describe('Spec 67: Job Queue Repository', () => {
-	let pgAvailable: boolean;
+	let pgAvailable = false;
 
 	beforeAll(() => {
-		pgAvailable = db.isPgAvailable();
-		if (!pgAvailable) {
-			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
-			return;
-		}
+		db.requirePg();
+		pgAvailable = true;
 
 		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-67-'));
 
@@ -95,8 +92,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-01: enqueue creates a pending job with the expected defaults', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 
 		const { stdout, stderr, exitCode } = runScript(`
@@ -140,8 +135,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-02: job lookup and filtered listing expose queue state newest-first', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, created_at)
@@ -194,8 +187,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-03: dequeue claims the oldest runnable pending job exactly once', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, created_at)
@@ -239,8 +230,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-04: dequeue skips unrunnable jobs', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at, created_at)
@@ -284,8 +273,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-05: mark completed finalizes the claimed job', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at)
@@ -324,8 +311,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-06: mark failed preserves retry semantics and dead-letters exhausted jobs', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at)
@@ -386,8 +371,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('review blocker: terminal updates require the active claim token', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, created_at)
@@ -488,8 +471,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-07: reaper resets stale running jobs back to pending', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at)
@@ -527,8 +508,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('review blocker: reaper allows one recovery pickup for a stale final-attempt claim without creating infinite retries', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at, created_at)
@@ -594,8 +573,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-08: fresh running jobs are not reaped', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 		db.runSql(`
 			INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, worker_id, started_at)
@@ -631,8 +608,6 @@ describe('Spec 67: Job Queue Repository', () => {
 	});
 
 	it('QA-09: repository exports are available through the public @mulder/core barrel', () => {
-		if (!pgAvailable) return;
-
 		cleanJobData();
 
 		const { stdout, stderr, exitCode } = runScript(`

--- a/tests/specs/68_worker_loop.test.ts
+++ b/tests/specs/68_worker_loop.test.ts
@@ -210,13 +210,11 @@ function expectLabelWithCount(output: string, label: string, count: number): voi
 }
 
 describe('Spec 68: Worker Loop', () => {
-	const pgAvailable = db.isPgAvailable();
+	let pgAvailable = false;
 
 	beforeAll(() => {
-		if (!pgAvailable) {
-			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
-			return;
-		}
+		db.requirePg();
+		pgAvailable = true;
 
 		ensureSchema();
 		cleanTables();
@@ -236,8 +234,6 @@ describe('Spec 68: Worker Loop', () => {
 	});
 
 	it('QA-01: worker start claims and completes a runnable job', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		const ingest = runCli(['ingest', NATIVE_TEXT_PDF], { timeout: 120_000 });
@@ -276,8 +272,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 180_000);
 
 	it('QA-02: failed handlers mark the job failed or dead-letter according to retry state', async () => {
-		if (!pgAvailable) return;
-
 		async function runFailureCase(maxAttempts: number): Promise<JobRecord> {
 			cleanTables();
 
@@ -313,8 +307,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 180_000);
 
 	it('QA-03: idle polling does not mutate the queue', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		const worker = startWorker(['--poll-interval', '100']);
@@ -331,8 +323,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 30_000);
 
 	it('QA-04: the worker never requires a long-lived transaction around step execution', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		const ingest = runCli(['ingest', NATIVE_TEXT_PDF], { timeout: 120_000 });
@@ -368,8 +358,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 180_000);
 
 	it('QA-05: worker status reports running and pending queue state', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		insertJob({
@@ -448,8 +436,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 30_000);
 
 	it('QA-06: worker reap resets stale running jobs and leaves fresh jobs alone', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		const staleJobId = randomUUID();
@@ -492,8 +478,6 @@ describe('Spec 68: Worker Loop', () => {
 	}, 30_000);
 
 	it('QA-07: graceful shutdown stops polling without corrupting the claimed job state', async () => {
-		if (!pgAvailable) return;
-
 		cleanTables();
 
 		const worker = startWorker(['--poll-interval', '100']);


### PR DESCRIPTION
Harden DB-backed black-box contract suites so missing PostgreSQL is an explicit harness failure instead of a silent skip.

What changed:
- added `requirePg()` to `tests/lib/db.ts` with actionable connection details
- converted Spec 67 and Spec 68 to require PostgreSQL in `beforeAll()`
- removed per-test early-return skip paths from those suites

Verification:
- `pnpm --filter @mulder/tests typecheck`
- `npx biome check tests/lib/db.ts tests/specs/67_job_queue_repository.test.ts tests/specs/68_worker_loop.test.ts`
- `pnpm vitest run tests/specs/67_job_queue_repository.test.ts --reporter=verbose` (fails fast with required-Postgres harness error when PG is unavailable)
- `pnpm vitest run tests/specs/68_worker_loop.test.ts --reporter=verbose` (fails fast with required-Postgres harness error when PG is unavailable)
