### PR TITLE
[API] Add middleware stack for M7-H4

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
 		"@mulder/taxonomy": "workspace:*",
 		"@mulder/evidence": "workspace:*",
 		"@mulder/worker": "workspace:*",
-		"hono": "^4.7.11"
+		"hono": "^4.7.11",
+		"zod": "^4.3.6"
 	}
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,33 +1,32 @@
-import { performance } from 'node:perf_hooks';
-import { createChildLogger, createLogger, type Logger } from '@mulder/core';
+import { type ApiConfig, CONFIG_DEFAULTS, createLogger, type Logger } from '@mulder/core';
 import { Hono } from 'hono';
+import { createAuthMiddleware } from './middleware/auth.js';
+import { createBodyLimitMiddleware } from './middleware/body-limit.js';
+import { createErrorHandler } from './middleware/error-handler.js';
+import { createRateLimitMiddleware } from './middleware/rate-limit.js';
+import { createRequestContextMiddleware } from './middleware/request-context.js';
+import { createRequestIdMiddleware } from './middleware/request-id.js';
+import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
 import { registerHealthRoute } from './routes/health.js';
 
 export interface AppOptions {
 	logger?: Logger;
+	config?: ApiConfig;
 }
 
 export function createApp(options: AppOptions = {}): Hono {
 	const rootLogger = options.logger ?? createLogger();
-	const requestLogger = createChildLogger(rootLogger, { module: 'api' });
+	const apiConfig = options.config ?? CONFIG_DEFAULTS.api;
+
 	const app = new Hono();
 
-	app.use('*', async (c, next) => {
-		const startedAt = performance.now();
-		try {
-			await next();
-		} finally {
-			requestLogger.info(
-				{
-					method: c.req.method,
-					path: c.req.path,
-					status: c.res.status,
-					duration_ms: Math.round(performance.now() - startedAt),
-				},
-				'request completed',
-			);
-		}
-	});
+	app.onError(createErrorHandler(rootLogger));
+	app.use('*', createRequestIdMiddleware());
+	app.use('*', createRequestContextMiddleware(rootLogger));
+	app.use('*', createSecureHeadersMiddleware());
+	app.use('*', createBodyLimitMiddleware());
+	app.use('*', createAuthMiddleware(apiConfig));
+	app.use('*', createRateLimitMiddleware(apiConfig));
 
 	registerHealthRoute(app);
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
+import { existsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { serve } from '@hono/node-server';
-import { createLogger } from '@mulder/core';
+import { type ApiConfig, CONFIG_DEFAULTS, createLogger, loadConfig } from '@mulder/core';
 import { createApp } from './app.js';
 
 export const DEFAULT_API_PORT = 8080;
 
-export function resolveApiPort(): number {
+export function resolveApiPort(config?: ApiConfig): number {
 	const rawPort = process.env.MULDER_API_PORT ?? process.env.PORT ?? '';
 	const parsedPort = Number.parseInt(rawPort, 10);
 
@@ -15,13 +16,29 @@ export function resolveApiPort(): number {
 		return parsedPort;
 	}
 
+	const fromConfig = config?.port;
+	if (typeof fromConfig === 'number' && Number.isFinite(fromConfig) && fromConfig > 0) {
+		return fromConfig;
+	}
+
 	return DEFAULT_API_PORT;
+}
+
+function resolveRuntimeApiConfig(): ApiConfig {
+	const configPath = process.env.MULDER_CONFIG ?? 'mulder.config.yaml';
+
+	if (existsSync(configPath)) {
+		return loadConfig(configPath).api;
+	}
+
+	return CONFIG_DEFAULTS.api;
 }
 
 export function startApiServer(): ReturnType<typeof serve> {
 	const logger = createLogger();
-	const app = createApp({ logger });
-	const port = resolveApiPort();
+	const apiConfig = resolveRuntimeApiConfig();
+	const app = createApp({ logger, config: apiConfig });
+	const port = resolveApiPort(apiConfig);
 	const server = serve({ fetch: app.fetch, port });
 
 	logger.info({ port }, 'API server started');

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,44 @@
+import type { ApiConfig } from '@mulder/core';
+import { MulderError } from '@mulder/core';
+import type { MiddlewareHandler } from 'hono';
+
+const PUBLIC_PATHS = new Set(['/api/health', '/doc', '/reference']);
+const RATE_LIMIT_CLIENT_KEY = 'rateLimitClientKey';
+
+declare module 'hono' {
+	interface ContextVariableMap {
+		rateLimitClientKey: string;
+	}
+}
+
+function isPublicRequest(method: string, path: string): boolean {
+	return method.toUpperCase() === 'OPTIONS' || PUBLIC_PATHS.has(path);
+}
+
+function parseBearerToken(headerValue: string | null): string | undefined {
+	if (headerValue === null) {
+		return undefined;
+	}
+
+	const match = /^Bearer\s+(.+)$/i.exec(headerValue.trim());
+	return match?.[1]?.trim();
+}
+
+export function createAuthMiddleware(apiConfig: ApiConfig): MiddlewareHandler {
+	const apiKeys = new Set(apiConfig.auth.api_keys.map((entry) => entry.key));
+
+	return async (c, next) => {
+		if (isPublicRequest(c.req.method, c.req.path)) {
+			await next();
+			return;
+		}
+
+		const bearerToken = parseBearerToken(c.req.header('authorization') ?? null);
+		if (!bearerToken || !apiKeys.has(bearerToken)) {
+			throw new MulderError('A valid API key is required', 'AUTH_UNAUTHORIZED');
+		}
+
+		c.set(RATE_LIMIT_CLIENT_KEY, bearerToken);
+		await next();
+	};
+}

--- a/apps/api/src/middleware/body-limit.ts
+++ b/apps/api/src/middleware/body-limit.ts
@@ -1,0 +1,76 @@
+import { MulderError } from '@mulder/core';
+import type { MiddlewareHandler } from 'hono';
+
+export const MAX_API_BODY_BYTES = 10 * 1024 * 1024;
+
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function parseContentLength(headerValue: string | null): number | undefined {
+	if (headerValue === null) {
+		return undefined;
+	}
+
+	const parsed = Number.parseInt(headerValue, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+async function measureRequestBodyBytes(request: Request, maxBodyBytes: number): Promise<number | undefined> {
+	if (request.body === null) {
+		return undefined;
+	}
+
+	const clonedRequest = request.clone();
+	if (clonedRequest.body === null) {
+		return undefined;
+	}
+
+	const reader = clonedRequest.body.getReader();
+	let totalBytes = 0;
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				return totalBytes;
+			}
+
+			totalBytes += value.byteLength;
+			if (totalBytes > maxBodyBytes) {
+				return totalBytes;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+export function createBodyLimitMiddleware(maxBodyBytes = MAX_API_BODY_BYTES): MiddlewareHandler {
+	return async (c, next) => {
+		if (!BODY_METHODS.has(c.req.method.toUpperCase())) {
+			await next();
+			return;
+		}
+
+		const contentLength = parseContentLength(c.req.header('content-length') ?? null);
+		if (contentLength !== undefined && contentLength > maxBodyBytes) {
+			throw new MulderError('Request body exceeds the API limit', 'REQUEST_BODY_TOO_LARGE', {
+				context: {
+					content_length: contentLength,
+					max_bytes: maxBodyBytes,
+				},
+			});
+		}
+
+		const requestBodyBytes = await measureRequestBodyBytes(c.req.raw, maxBodyBytes);
+		if (requestBodyBytes !== undefined && requestBodyBytes > maxBodyBytes) {
+			throw new MulderError('Request body exceeds the API limit', 'REQUEST_BODY_TOO_LARGE', {
+				context: {
+					content_length: requestBodyBytes,
+					max_bytes: maxBodyBytes,
+				},
+			});
+		}
+
+		await next();
+	};
+}

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -1,0 +1,114 @@
+import { isMulderError, type Logger, type MulderError, ZodError } from '@mulder/core';
+import type { Context, ErrorHandler } from 'hono';
+
+interface ErrorResponseBody {
+	error: {
+		code: string;
+		message: string;
+		details?: unknown;
+	};
+}
+
+type ApiErrorStatus = 400 | 401 | 403 | 404 | 413 | 429 | 500 | 503;
+
+function getLogger(c: Context, fallbackLogger: Logger): Logger {
+	const requestContext = c.get('requestContext');
+	return requestContext?.logger ?? fallbackLogger;
+}
+
+function getRequestId(c: Context): string | undefined {
+	return c.get('requestId');
+}
+
+export function mapErrorToStatus(error: MulderError): ApiErrorStatus {
+	const code = error.code.toUpperCase();
+
+	if (code.includes('RATE_LIMIT')) {
+		return 429;
+	}
+
+	if (code.includes('UNAUTHORIZED') || code.startsWith('AUTH_')) {
+		return 401;
+	}
+
+	if (code.includes('FORBIDDEN')) {
+		return 403;
+	}
+
+	if (code.includes('TOO_LARGE')) {
+		return 413;
+	}
+
+	if (code.includes('NOT_FOUND')) {
+		return 404;
+	}
+
+	if (code.includes('VALIDATION') || code.startsWith('CONFIG_') || code.includes('INVALID')) {
+		return 400;
+	}
+
+	if (code.startsWith('DB_')) {
+		return 503;
+	}
+
+	return 500;
+}
+
+function buildErrorBody(code: string, message: string, details?: unknown): ErrorResponseBody {
+	return {
+		error: {
+			code,
+			message,
+			...(details ? { details } : {}),
+		},
+	};
+}
+
+function isZodValidationError(error: unknown): error is ZodError {
+	return error instanceof ZodError;
+}
+
+export function createErrorHandler(fallbackLogger: Logger): ErrorHandler {
+	return (error, c) => {
+		const logger = getLogger(c, fallbackLogger);
+		const requestId = getRequestId(c);
+
+		if (isMulderError(error)) {
+			const status = mapErrorToStatus(error);
+			const body = buildErrorBody(error.code, error.message, error.context);
+
+			if (status >= 500) {
+				logger.error({ err: error, request_id: requestId, status }, 'API request failed');
+			} else {
+				logger.warn({ err: error, request_id: requestId, status }, 'API request failed');
+			}
+
+			if (error.context && typeof error.context.retry_after_seconds === 'number') {
+				c.header('Retry-After', String(error.context.retry_after_seconds));
+			}
+
+			if (requestId) {
+				c.header('X-Request-Id', requestId);
+			}
+
+			return c.json(body, status);
+		}
+
+		if (isZodValidationError(error)) {
+			logger.warn({ err: error, request_id: requestId }, 'API validation failed');
+			if (requestId) {
+				c.header('X-Request-Id', requestId);
+			}
+
+			const zodError = error as ZodError;
+			return c.json(buildErrorBody('VALIDATION_ERROR', 'Invalid request', zodError.flatten()), 400);
+		}
+
+		logger.error({ err: error, request_id: requestId }, 'Unhandled API error');
+		if (requestId) {
+			c.header('X-Request-Id', requestId);
+		}
+
+		return c.json(buildErrorBody('INTERNAL_ERROR', 'Internal server error'), 500);
+	};
+}

--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -1,0 +1,7 @@
+export { createAuthMiddleware } from './auth.js';
+export { createBodyLimitMiddleware, MAX_API_BODY_BYTES } from './body-limit.js';
+export { createErrorHandler, mapErrorToStatus } from './error-handler.js';
+export { createRateLimitMiddleware } from './rate-limit.js';
+export { createRequestContextMiddleware } from './request-context.js';
+export { createRequestIdMiddleware, REQUEST_ID_HEADER } from './request-id.js';
+export { createSecureHeadersMiddleware, SECURE_HEADERS } from './secure-headers.js';

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,134 @@
+import type { ApiConfig } from '@mulder/core';
+import { MulderError } from '@mulder/core';
+import type { Context, MiddlewareHandler } from 'hono';
+
+type RateLimitTier = 'strict' | 'standard' | 'relaxed';
+
+interface RateLimitBucket {
+	tokens: number;
+	updatedAt: number;
+}
+
+interface RateLimitTierConfig {
+	limitPerMinute: number;
+}
+
+const RATE_LIMIT_TIERS: Record<RateLimitTier, RateLimitTierConfig> = {
+	strict: {
+		limitPerMinute: 10,
+	},
+	standard: {
+		limitPerMinute: 60,
+	},
+	relaxed: {
+		limitPerMinute: 120,
+	},
+};
+
+const NON_RATE_LIMITED_PATHS = new Set(['/doc', '/reference']);
+const ANONYMOUS_CLIENT_KEY = 'anonymous';
+
+function isPublicDocsPath(path: string): boolean {
+	return NON_RATE_LIMITED_PATHS.has(path);
+}
+
+function isHealthPath(path: string): boolean {
+	return path === '/api/health';
+}
+
+function resolveRateLimitTier(method: string, path: string, query: URLSearchParams): RateLimitTier | undefined {
+	const normalizedMethod = method.toUpperCase();
+
+	if (normalizedMethod === 'OPTIONS' || isPublicDocsPath(path)) {
+		return undefined;
+	}
+
+	if (isHealthPath(path)) {
+		return 'relaxed';
+	}
+
+	if (normalizedMethod === 'GET' && (path === '/api/jobs' || path.startsWith('/api/jobs/'))) {
+		return 'relaxed';
+	}
+
+	if (normalizedMethod === 'POST' && path === '/api/search') {
+		const noRerank = query.get('no_rerank') === 'true' || query.get('rerank') === 'false';
+		return noRerank ? 'standard' : 'strict';
+	}
+
+	if (
+		normalizedMethod === 'GET' &&
+		(path.startsWith('/api/entities') || path.startsWith('/api/stories') || path.startsWith('/api/evidence'))
+	) {
+		return 'standard';
+	}
+
+	return undefined;
+}
+
+function computeRetryAfterSeconds(bucket: RateLimitBucket, limitPerMinute: number, now: number): number {
+	const refillPerMs = limitPerMinute / 60_000;
+	const tokensAfterRefill = Math.min(limitPerMinute, bucket.tokens + (now - bucket.updatedAt) * refillPerMs);
+	const missingTokens = Math.max(0, 1 - tokensAfterRefill);
+	return Math.max(1, Math.ceil(missingTokens / refillPerMs / 1000));
+}
+
+function getClientKey(c: Context): string {
+	return c.get('rateLimitClientKey') ?? ANONYMOUS_CLIENT_KEY;
+}
+
+export function createRateLimitMiddleware(apiConfig: ApiConfig): MiddlewareHandler {
+	const buckets = new Map<string, RateLimitBucket>();
+	const enabled = apiConfig.rate_limiting.enabled;
+
+	return async (c, next) => {
+		if (!enabled) {
+			await next();
+			return;
+		}
+
+		const tier = resolveRateLimitTier(c.req.method, c.req.path, new URL(c.req.url).searchParams);
+		if (!tier) {
+			await next();
+			return;
+		}
+
+		const now = Date.now();
+		const { limitPerMinute } = RATE_LIMIT_TIERS[tier];
+		const clientKey = `${tier}:${getClientKey(c)}`;
+		const bucket = buckets.get(clientKey) ?? {
+			tokens: limitPerMinute,
+			updatedAt: now,
+		};
+
+		const refillPerMs = limitPerMinute / 60_000;
+		const replenishedTokens = Math.min(limitPerMinute, bucket.tokens + (now - bucket.updatedAt) * refillPerMs);
+
+		if (replenishedTokens < 1) {
+			const retryAfterSeconds = computeRetryAfterSeconds(bucket, limitPerMinute, now);
+			const requestContext = c.get('requestContext');
+			requestContext.logger.warn(
+				{
+					tier,
+					client: clientKey,
+					retry_after_seconds: retryAfterSeconds,
+				},
+				'API request rate limited',
+			);
+
+			throw new MulderError('Too many requests', 'RATE_LIMIT_EXCEEDED', {
+				context: {
+					retry_after_seconds: retryAfterSeconds,
+					tier,
+				},
+			});
+		}
+
+		buckets.set(clientKey, {
+			tokens: replenishedTokens - 1,
+			updatedAt: now,
+		});
+
+		await next();
+	};
+}

--- a/apps/api/src/middleware/request-context.ts
+++ b/apps/api/src/middleware/request-context.ts
@@ -1,0 +1,46 @@
+import { performance } from 'node:perf_hooks';
+import { createChildLogger, type Logger } from '@mulder/core';
+import type { MiddlewareHandler } from 'hono';
+import { REQUEST_ID_HEADER } from './request-id.js';
+
+export interface RequestContext {
+	requestId: string;
+	logger: Logger;
+}
+
+declare module 'hono' {
+	interface ContextVariableMap {
+		requestContext: RequestContext;
+	}
+}
+
+export function createRequestContextMiddleware(rootLogger: Logger): MiddlewareHandler {
+	return async (c, next) => {
+		const requestId =
+			c.get('requestId') ??
+			c.req.header(REQUEST_ID_HEADER) ??
+			c.req.header(REQUEST_ID_HEADER.toLowerCase()) ??
+			'unknown';
+		const logger = createChildLogger(rootLogger, {
+			module: 'api',
+			request_id: requestId,
+			method: c.req.method,
+			path: c.req.path,
+		});
+
+		c.set('requestContext', { requestId, logger });
+
+		const startedAt = performance.now();
+		try {
+			await next();
+		} finally {
+			logger.info(
+				{
+					status: c.res.status,
+					duration_ms: Math.round(performance.now() - startedAt),
+				},
+				'request completed',
+			);
+		}
+	};
+}

--- a/apps/api/src/middleware/request-id.ts
+++ b/apps/api/src/middleware/request-id.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'node:crypto';
+import type { MiddlewareHandler } from 'hono';
+
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+
+function resolveRequestId(headerValue: string | null | undefined): string {
+	const trimmed = headerValue?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : randomUUID();
+}
+
+declare module 'hono' {
+	interface ContextVariableMap {
+		requestId: string;
+	}
+}
+
+export function createRequestIdMiddleware(): MiddlewareHandler {
+	return async (c, next) => {
+		const requestId = resolveRequestId(
+			c.req.header(REQUEST_ID_HEADER) ?? c.req.header(REQUEST_ID_HEADER.toLowerCase()),
+		);
+		c.set('requestId', requestId);
+		c.header(REQUEST_ID_HEADER, requestId);
+		await next();
+	};
+}

--- a/apps/api/src/middleware/secure-headers.ts
+++ b/apps/api/src/middleware/secure-headers.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareHandler } from 'hono';
+
+export const SECURE_HEADERS = {
+	'Cross-Origin-Resource-Policy': 'same-origin',
+	'Referrer-Policy': 'no-referrer',
+	'X-Content-Type-Options': 'nosniff',
+	'X-DNS-Prefetch-Control': 'off',
+	'X-Frame-Options': 'DENY',
+} as const;
+
+export function createSecureHeadersMiddleware(): MiddlewareHandler {
+	return async (c, next) => {
+		for (const [name, value] of Object.entries(SECURE_HEADERS)) {
+			c.header(name, value);
+		}
+
+		await next();
+	};
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H1 | Job queue repository — enqueue/dequeue/reap | §4.3 (jobs table), §10.2, §10.3 |
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
-| ⚪ | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
+| 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | ⚪ | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |
 | ⚪ | H7 | Search API routes (sync) | §10.6, §5 |

--- a/docs/specs/70_api_middleware_stack.spec.md
+++ b/docs/specs/70_api_middleware_stack.spec.md
@@ -1,0 +1,136 @@
+---
+spec: "70"
+title: "API Middleware Stack"
+roadmap_step: M7-H4
+functional_spec: ["§10.6"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/176"
+created: 2026-04-14
+---
+
+# Spec 70: API Middleware Stack
+
+## 1. Objective
+
+Introduce the shared HTTP middleware layer for Mulder's Hono API so every later M7 route lands on a consistent request pipeline instead of re-implementing auth, rate limiting, or error handling per endpoint. Per `§10.6`, the API must stay a clean job producer/read interface with tiered rate limiting, structured error responses, and clear separation between public and protected surfaces. This step also aligns the runtime with `docs/api-architecture.md` by establishing request IDs, request-scoped logging/context, API-key auth, body limits, and public-path exceptions that H5-H10 can reuse unchanged.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H4` — Middleware — auth, rate limiting, error handling, request context
+- **Target:** `packages/core/src/config/schema.ts`, `packages/core/src/config/types.ts`, `mulder.config.example.yaml`, `apps/api/src/app.ts`, `apps/api/src/middleware/request-id.ts`, `apps/api/src/middleware/request-context.ts`, `apps/api/src/middleware/secure-headers.ts`, `apps/api/src/middleware/body-limit.ts`, `apps/api/src/middleware/rate-limit.ts`, `apps/api/src/middleware/auth.ts`, `apps/api/src/middleware/error-handler.ts`, `tests/specs/70_api_middleware_stack.test.ts`
+- **In scope:** API config surface for auth/rate-limiting/CORS-friendly public path handling where needed by middleware; deterministic request ID generation; request-scoped context/logger plumbing; security headers and request body limits; API-key bearer auth with explicit public exceptions for health/OpenAPI/explorer paths; tiered in-memory rate limiting with `Retry-After`; centralized mapping of Mulder/Zod/unexpected errors to Mulder's error envelope; and black-box tests covering public access, protected access, throttling, body-size rejection, and structured errors
+- **Out of scope:** pipeline/job/search/entity/evidence/document route implementations (`M7-H5` through `M7-H10`); OpenAPI or Scalar registration; persistent/shared rate limiting across instances; user/session auth beyond static API keys; database-backed auth or ACLs; and UI work (`M7-H11`)
+- **Constraints:** preserve the app/server split from Spec 69; keep middleware order explicit and reusable; keep unauthenticated liveness/docs routes public while protecting application data surfaces; do not bypass Mulder's existing config loader or logger; do not require Redis or any new infrastructure; and keep the middleware behavior shell-observable for the verification worker
+
+## 3. Dependencies
+
+- **Requires:** Spec 03 (`M1-A2`) config loader + schema defaults, Spec 04 (`M1-A3`) Mulder error hierarchy, Spec 05 (`M1-A4`) centralized logging, and Spec 69 (`M7-H3`) Hono server scaffold
+- **Blocks:** `M7-H5` pipeline API routes, `M7-H6` job status API, `M7-H7` search API routes, `M7-H8` entity API routes, `M7-H9` evidence API routes, `M7-H10` document retrieval routes, and `M7-H11` viewer integration work that depends on stable auth/public-path behavior
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/core/src/config/schema.ts`** — adds the `api` config surface for API keys, explorer toggle, and rate-limiting defaults
+2. **`packages/core/src/config/types.ts`** — exports the derived API config types used by the server runtime
+3. **`mulder.config.example.yaml`** — documents the new API config keys and safe defaults
+4. **`apps/api/src/app.ts`** — composes the middleware stack in the correct order around the Hono app
+5. **`apps/api/src/middleware/request-id.ts`** — ensures each request carries a stable request ID header/context value
+6. **`apps/api/src/middleware/request-context.ts`** — attaches request-scoped metadata/logger state for downstream handlers
+7. **`apps/api/src/middleware/secure-headers.ts`** — applies baseline HTTP safety headers
+8. **`apps/api/src/middleware/body-limit.ts`** — rejects oversized API request bodies before handler execution
+9. **`apps/api/src/middleware/rate-limit.ts`** — implements the strict/standard/relaxed token-bucket tiers from `§10.6`
+10. **`apps/api/src/middleware/auth.ts`** — enforces bearer-token auth except on explicitly public endpoints
+11. **`apps/api/src/middleware/error-handler.ts`** — maps known application/validation failures to Mulder's error envelope
+12. **`tests/specs/70_api_middleware_stack.test.ts`** — black-box coverage for middleware behavior
+
+### 4.2 Runtime Changes
+
+The Hono app should gain a reusable middleware pipeline with this effective behavior:
+
+- a request ID is generated when the client does not send one
+- the request context exposes the request ID and a child logger for downstream route handlers
+- public paths remain callable without auth:
+  - `GET /api/health`
+  - `/doc`
+  - `/reference`
+- protected API routes require `Authorization: Bearer <key>` where the key matches configured API keys
+- requests are rate-limited by endpoint tier, returning `429` plus `Retry-After`
+- request bodies above the configured cap are rejected before business logic runs
+- known errors return Mulder's JSON error envelope instead of raw stacks or framework defaults
+
+Middleware order matters. The stack should establish request metadata before auth/rate limiting/logging decisions, and the global error handler must wrap the composed app so downstream failures stay normalized.
+
+### 4.3 Config Changes
+
+Add an `api` section to Mulder's config schema with defaults that keep local development ergonomic while still enabling middleware behavior:
+
+- `port`
+- `auth.api_keys[]`
+- `rate_limiting.enabled`
+- `explorer.enabled`
+
+The schema must allow local/test overrides without requiring users to define an API block for non-API workflows.
+
+### 4.4 Integration Points
+
+- later route specs consume the request context/logger instead of rebuilding per-request state
+- H5-H10 can opt into rate-limit tiers declaratively based on route surface
+- auth/public-path rules remain centralized in middleware rather than duplicated in route handlers
+- the global error handler becomes the single HTTP translation point for `MulderError` and validation failures
+- the viewer work in H11 can rely on a stable public-vs-protected contract once document routes exist
+
+### 4.5 Implementation Phases
+
+**Phase 1: Config and middleware primitives**
+- add the API config schema and documented defaults
+- implement request ID, request context, secure headers, and body-limit middleware
+
+**Phase 2: Protection and normalization**
+- implement API-key auth with explicit public-path bypasses
+- implement tiered in-memory rate limiting with `Retry-After`
+- implement the global error handler and wire it into the app
+
+**Phase 3: Composition and QA**
+- update the Hono app to compose middleware in the intended order
+- add black-box tests for auth, throttling, size limits, public paths, and error envelopes
+
+## 5. QA Contract
+
+1. **QA-01: Public health checks stay unauthenticated and traceable**
+   - Given: the API app is started with middleware enabled and no `Authorization` header
+   - When: `GET /api/health` is requested
+   - Then: the response is `200`, includes a request ID header, and succeeds without database or GCP access
+
+2. **QA-02: Protected routes reject missing or invalid bearer tokens**
+   - Given: a protected API route and middleware configured with at least one API key
+   - When: the route is requested without a valid `Authorization: Bearer <key>` header
+   - Then: the response is `401` with Mulder's JSON error envelope and no handler-side business logic executes
+
+3. **QA-03: Rate-limited routes return `429` with retry guidance**
+   - Given: a route assigned to one of the `§10.6` rate-limit tiers
+   - When: requests exceed that tier's allowed burst/window
+   - Then: the API responds with `429 Too Many Requests` and includes a `Retry-After` header
+
+4. **QA-04: Oversized request bodies are rejected before handler logic**
+   - Given: a route expecting JSON input and a request body above the configured maximum
+   - When: the request is sent
+   - Then: the API returns an explicit client error for body size and the handler is not invoked
+
+5. **QA-05: Known application and validation errors are normalized**
+   - Given: a route that raises a `MulderError` or request validation failure
+   - When: the request is processed
+   - Then: the response uses Mulder's JSON error envelope with the expected HTTP status code and request traceability
+
+6. **QA-06: The API package still compiles with the middleware stack enabled**
+   - Given: the new middleware modules and config schema are wired into `@mulder/api`
+   - When: the API package build/typecheck runs
+   - Then: the package compiles successfully and exports a bootable app/server surface
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+This step should not add direct third-party spend on its own, but it is cost-sensitive because the middleware tiering protects future synchronous LLM-backed routes from accidental token burn. Rate limiting must therefore ship with deterministic defaults rather than being left for later route work.

--- a/mulder.config.example.yaml
+++ b/mulder.config.example.yaml
@@ -8,6 +8,18 @@ project:
   description: "Domain-specific document intelligence"
   supported_locales: ["en"]          # UI + prompt language (entity resolution works across ALL languages)
 
+# --- API ---
+api:
+  port: 8080
+  auth:
+    api_keys:
+      - name: "cli"
+        key: "${MULDER_API_KEY}"      # Bearer token accepted by protected routes
+  rate_limiting:
+    enabled: true                     # In-memory token buckets per Cloud Run instance
+  explorer:
+    enabled: true                     # Scalar /reference UI
+
 # --- GCP ---
 gcp:
   project_id: "my-gcp-project"

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -5,12 +5,29 @@
  * serves as documentation and test reference.
  */
 
+import type { ApiConfig } from './types.js';
+
+const apiDefaults: ApiConfig = {
+	port: 8080,
+	auth: {
+		api_keys: [],
+	},
+	rate_limiting: {
+		enabled: true,
+	},
+	explorer: {
+		enabled: true,
+	},
+};
+
 export const CONFIG_DEFAULTS = {
 	dev_mode: false,
 
 	project: {
 		supported_locales: ['en'],
 	},
+
+	api: apiDefaults,
 
 	gcp: {
 		cloud_sql: {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -10,6 +10,11 @@ export { loadConfig } from './loader.js';
 export { mulderConfigSchema } from './schema.js';
 export type {
 	AnalysisConfig,
+	ApiAuthConfig,
+	ApiAuthKeyConfig,
+	ApiConfig,
+	ApiExplorerConfig,
+	ApiRateLimitingConfig,
 	CloudSqlConfig,
 	DeduplicationConfig,
 	DocumentAiConfig,

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -51,6 +51,33 @@ const projectSchema = z.object({
 	supported_locales: z.array(z.string().min(1)).default(['en']),
 });
 
+// --- API ---
+
+const apiAuthKeySchema = z.object({
+	name: z.string().min(1),
+	key: z.string().min(1),
+});
+
+const apiAuthSchema = z.object({
+	api_keys: z.array(apiAuthKeySchema).default([]),
+});
+
+const apiRateLimitingSchema = z.object({
+	enabled: z.boolean().default(true),
+});
+
+const apiExplorerSchema = z.object({
+	enabled: z.boolean().default(true),
+});
+
+const apiObj = z.object({
+	port: z.number().int().positive().default(8080),
+	auth: apiAuthSchema.default(defaults(apiAuthSchema)),
+	rate_limiting: apiRateLimitingSchema.default(defaults(apiRateLimitingSchema)),
+	explorer: apiExplorerSchema.default(defaults(apiExplorerSchema)),
+});
+const apiSchema = apiObj.default(defaults(apiObj));
+
 // --- GCP ---
 
 const cloudSqlSchema = z.object({
@@ -358,6 +385,7 @@ const patternDiscoverySchema = patternDiscoveryObj.default(defaults(patternDisco
  */
 const baseMulderConfigSchema = z.object({
 	project: projectSchema,
+	api: apiSchema,
 	gcp: gcpSchema.optional(),
 	dev_mode: z.boolean().default(false),
 	ontology: ontologySchema,
@@ -424,6 +452,7 @@ export const mulderConfigSchema = baseMulderConfigSchema.superRefine((data, ctx)
 // Export section schemas for reuse
 export {
 	analysisSchema,
+	apiSchema,
 	cloudSqlSchema,
 	deduplicationSchema,
 	documentAiSchema,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -6,6 +6,7 @@
 import type { z } from 'zod';
 import type {
 	analysisSchema,
+	apiSchema,
 	cloudSqlSchema,
 	deduplicationSchema,
 	documentAiSchema,
@@ -35,6 +36,11 @@ import type {
 // --- Section Types ---
 
 export type ProjectConfig = z.infer<typeof projectSchema>;
+export type ApiConfig = z.infer<typeof apiSchema>;
+export type ApiAuthKeyConfig = ApiConfig['auth']['api_keys'][number];
+export type ApiAuthConfig = ApiConfig['auth'];
+export type ApiRateLimitingConfig = ApiConfig['rate_limiting'];
+export type ApiExplorerConfig = ApiConfig['explorer'];
 export type GcpConfig = z.infer<typeof gcpSchema>;
 export type CloudSqlConfig = z.infer<typeof cloudSqlSchema>;
 export type StorageConfig = z.infer<typeof storageSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,13 @@
 // ── Shared error hierarchy ──────────────────────────────────
 
+export { ZodError } from 'zod';
 export type {
 	AnalysisConfig,
+	ApiAuthConfig,
+	ApiAuthKeyConfig,
+	ApiConfig,
+	ApiExplorerConfig,
+	ApiRateLimitingConfig,
 	CloudSqlConfig,
 	ConfigIssue,
 	DeduplicationConfig,

--- a/tests/specs/70_api_middleware_stack.test.ts
+++ b/tests/specs/70_api_middleware_stack.test.ts
@@ -1,0 +1,365 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const API_DIR = resolve(ROOT, 'apps/api');
+const API_DIST = resolve(API_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function writeTempConfig(dir: string, yaml: string): string {
+	const filePath = resolve(dir, 'mulder.config.yaml');
+	writeFileSync(filePath, yaml, 'utf-8');
+	return filePath;
+}
+
+describe('Spec 70: API Middleware Stack', () => {
+	let tmpDir = '';
+	let loadConfig!: (path?: string) => unknown;
+	let createApp!: (options?: { config?: unknown }) => Hono;
+	let MulderError!: new (message: string, code: string, options?: { context?: Record<string, unknown> }) => Error;
+
+	beforeAll(async () => {
+		process.env.MULDER_LOG_LEVEL = 'silent';
+		buildPackage(CORE_DIR);
+		buildPackage(API_DIR);
+
+		const core = await import(pathToFileURL(CORE_DIST).href);
+		const api = await import(pathToFileURL(API_DIST).href);
+		const apiApp = await import(pathToFileURL(API_APP_DIST).href);
+
+		loadConfig = core.loadConfig;
+		MulderError = core.MulderError;
+		createApp = apiApp.createApp ?? api.createApp;
+
+		tmpDir = mkdtempSync(resolve(tmpdir(), 'mulder-qa-70-'));
+	});
+
+	afterAll(() => {
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('QA-01: public health checks stay unauthenticated and traceable', async () => {
+		const app = createApp();
+		const response = await app.request('http://localhost/api/health');
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('x-request-id')).toMatch(/.+/);
+		expect(await response.json()).toEqual({ status: 'ok', version: '0.0.0' });
+	});
+
+	it('QA-02: protected routes reject missing or invalid bearer tokens', async () => {
+		const app = createApp({
+			config: {
+				port: 8080,
+				auth: {
+					api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				},
+				rate_limiting: {
+					enabled: true,
+				},
+				explorer: {
+					enabled: true,
+				},
+			},
+		});
+
+		app.get('/api/protected', (c) => c.json({ ok: true }, 200));
+
+		const missingAuth = await app.request('http://localhost/api/protected');
+		expect(missingAuth.status).toBe(401);
+		expect(await missingAuth.json()).toEqual({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+
+		const invalidAuth = await app.request('http://localhost/api/protected', {
+			headers: {
+				Authorization: 'Bearer wrong-key',
+			},
+		});
+		expect(invalidAuth.status).toBe(401);
+	});
+
+	it('QA-03: rate-limited routes return 429 with retry guidance', async () => {
+		const app = createApp({
+			config: {
+				port: 8080,
+				auth: {
+					api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				},
+				rate_limiting: {
+					enabled: true,
+				},
+				explorer: {
+					enabled: true,
+				},
+			},
+		});
+
+		app.post('/api/search', (c) => c.json({ ok: true }, 200));
+
+		for (let index = 0; index < 10; index += 1) {
+			const response = await app.request('http://localhost/api/search', {
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-api-key',
+					'X-Forwarded-For': `203.0.113.${index + 1}`,
+				},
+			});
+
+			expect(response.status).toBe(200);
+		}
+
+		const throttled = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer test-api-key',
+				'X-Forwarded-For': '198.51.100.250',
+			},
+		});
+
+		expect(throttled.status).toBe(429);
+		expect(throttled.headers.get('retry-after')).toMatch(/^[1-9]\d*$/);
+		expect(await throttled.json()).toEqual({
+			error: {
+				code: 'RATE_LIMIT_EXCEEDED',
+				message: 'Too many requests',
+				details: {
+					retry_after_seconds: expect.any(Number),
+					tier: 'strict',
+				},
+			},
+		});
+	});
+
+	it('QA-04: oversized request bodies are rejected before handler logic', async () => {
+		const app = createApp({
+			config: {
+				port: 8080,
+				auth: {
+					api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				},
+				rate_limiting: {
+					enabled: true,
+				},
+				explorer: {
+					enabled: true,
+				},
+			},
+		});
+
+		let handlerInvoked = false;
+		app.post('/api/search', () => {
+			handlerInvoked = true;
+			return new Response('should not run', { status: 200 });
+		});
+
+		const oversizedBody = new TextEncoder().encode('x'.repeat(MAX_BODY_BYTES + 1));
+		const request = new Request('http://localhost/api/search', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer test-api-key',
+				'Content-Type': 'text/plain',
+			},
+			body: new ReadableStream({
+				start(controller) {
+					controller.enqueue(oversizedBody);
+					controller.close();
+				},
+			}),
+			duplex: 'half',
+		});
+		const response = await app.request(request);
+
+		expect(response.status).toBe(413);
+		expect(handlerInvoked).toBe(false);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'REQUEST_BODY_TOO_LARGE',
+				message: 'Request body exceeds the API limit',
+				details: {
+					content_length: MAX_BODY_BYTES + 1,
+					max_bytes: MAX_BODY_BYTES,
+				},
+			},
+		});
+	});
+
+	it('QA-05: known application and validation errors are normalized', async () => {
+		const app = createApp({
+			config: {
+				port: 8080,
+				auth: {
+					api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				},
+				rate_limiting: {
+					enabled: true,
+				},
+				explorer: {
+					enabled: true,
+				},
+			},
+		});
+
+		app.get('/api/mulder-error', () => {
+			throw new MulderError('boom', 'CONFIG_INVALID', {
+				context: {
+					field: 'api.port',
+				},
+			});
+		});
+
+		app.get('/api/config-validation-error', () => {
+			const invalidConfigPath = writeTempConfig(
+				tmpDir,
+				`
+project:
+  description: "missing required project name"
+
+gcp:
+  project_id: "test-gcp-project"
+  region: "europe-west1"
+  cloud_sql:
+    instance_name: "test-db"
+    database: "testdb"
+  storage:
+    bucket: "test-bucket"
+  document_ai:
+    processor_id: "test-processor"
+
+ontology:
+  entity_types:
+    - name: "person"
+      description: "A named individual"
+  relationships: []
+`,
+			);
+
+			loadConfig(invalidConfigPath);
+			return new Response('unreachable', { status: 200 });
+		});
+
+		app.get('/api/unexpected-error', () => {
+			throw new Error('kaboom');
+		});
+
+		const authHeaders = {
+			Authorization: 'Bearer test-api-key',
+		};
+
+		const mulderErrorResponse = await app.request('http://localhost/api/mulder-error', {
+			headers: authHeaders,
+		});
+		expect(mulderErrorResponse.status).toBe(400);
+		expect(await mulderErrorResponse.json()).toEqual({
+			error: {
+				code: 'CONFIG_INVALID',
+				message: 'boom',
+				details: {
+					field: 'api.port',
+				},
+			},
+		});
+
+		const validationErrorResponse = await app.request('http://localhost/api/config-validation-error', {
+			headers: authHeaders,
+		});
+		expect(validationErrorResponse.status).toBe(400);
+		expect(validationErrorResponse.headers.get('x-request-id')).toMatch(/.+/);
+		expect(await validationErrorResponse.json()).toEqual({
+			error: {
+				code: 'CONFIG_INVALID',
+				message: expect.any(String),
+				details: {
+					issueCount: 1,
+				},
+			},
+		});
+
+		const unexpectedErrorResponse = await app.request('http://localhost/api/unexpected-error', {
+			headers: authHeaders,
+		});
+		expect(unexpectedErrorResponse.status).toBe(500);
+		expect(await unexpectedErrorResponse.json()).toEqual({
+			error: {
+				code: 'INTERNAL_ERROR',
+				message: 'Internal server error',
+			},
+		});
+	});
+
+	it('QA-06: the API config schema supplies api defaults without requiring an api block', () => {
+		const configDir = mkdtempSync(resolve(tmpdir(), 'mulder-qa-70-config-'));
+		try {
+			const configPath = writeTempConfig(
+				configDir,
+				`
+project:
+  name: "test-project"
+
+gcp:
+  project_id: "test-gcp-project"
+  region: "europe-west1"
+  cloud_sql:
+    instance_name: "test-db"
+    database: "testdb"
+  storage:
+    bucket: "test-bucket"
+  document_ai:
+    processor_id: "test-processor"
+
+ontology:
+  entity_types:
+    - name: "person"
+      description: "A named individual"
+  relationships: []
+`,
+			);
+
+			const config = loadConfig(configPath) as {
+				api: {
+					port: number;
+					auth: { api_keys: Array<{ name: string; key: string }> };
+					rate_limiting: { enabled: boolean };
+					explorer: { enabled: boolean };
+				};
+			};
+			expect(config.api.port).toBe(8080);
+			expect(config.api.auth.api_keys).toEqual([]);
+			expect(config.api.rate_limiting.enabled).toBe(true);
+			expect(config.api.explorer.enabled).toBe(true);
+		} finally {
+			rmSync(configDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Add the shared API middleware stack for `M7-H4`, including request IDs, request context, API-key auth, body-size guards, secure headers, rate limiting, and normalized HTTP error handling.

## Spec

- `docs/specs/70_api_middleware_stack.spec.md`

## Verification

- `pnpm exec vitest run tests/specs/70_api_middleware_stack.test.ts --reporter=verbose`
- Auto-pilot QA worker: `TOTAL: 16`, `PASSED: 16`, `FAILED: 0`, `SKIPPED: 0`, `VERDICT: PASS`
- Auto-pilot review worker: `REVIEW_VERDICT: APPROVED`

Closes #176
