### PR TITLE
[API] Async pipeline API routes — M7-H5

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { createRequestContextMiddleware } from './middleware/request-context.js'
 import { createRequestIdMiddleware } from './middleware/request-id.js';
 import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
 import { registerHealthRoute } from './routes/health.js';
+import { registerPipelineRoutes } from './routes/pipeline.js';
 
 export interface AppOptions {
 	logger?: Logger;
@@ -29,6 +30,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	app.use('*', createRateLimitMiddleware(apiConfig));
 
 	registerHealthRoute(app);
+	registerPipelineRoutes(app);
 
 	return app;
 }

--- a/apps/api/src/lib/pipeline-jobs.ts
+++ b/apps/api/src/lib/pipeline-jobs.ts
@@ -1,5 +1,15 @@
 import type { Job, PipelineRun, PipelineRunSource, Source } from '@mulder/core';
-import { getWorkerPool, loadConfig, PIPELINE_ERROR_CODES, PipelineError, type PipelineStep } from '@mulder/core';
+import {
+	createPipelineRun,
+	enqueueJob,
+	findLatestPipelineRunSourceForSource,
+	findSourceById,
+	getWorkerPool,
+	loadConfig,
+	PIPELINE_ERROR_CODES,
+	PipelineError,
+	type PipelineStep,
+} from '@mulder/core';
 import type { Pool } from 'pg';
 import type { PipelineRetryRequest, PipelineRunRequest } from '../routes/pipeline.schemas.js';
 import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
@@ -24,62 +34,10 @@ interface PipelineRunAcceptance {
 	job: Job;
 }
 
-interface SourceRow {
-	id: string;
-	filename: string;
-	storage_path: string;
-	file_hash: string;
-	page_count: number | null;
-	has_native_text: boolean;
-	native_text_ratio: number;
-	status: Source['status'];
-	reliability_score: number | null;
-	tags: string[] | null;
-	metadata: Record<string, unknown>;
-	created_at: Date;
-	updated_at: Date;
-}
-
-interface PipelineRunRow {
-	id: string;
-	tag: string | null;
-	options: Record<string, unknown> | string | null;
-	status: PipelineRun['status'];
-	created_at: Date;
-	finished_at: Date | null;
-}
-
-interface JobRow {
-	id: string;
-	type: string;
-	payload: Record<string, unknown> | string;
-	status: Job['status'];
-	attempts: number;
-	max_attempts: number;
-	error_log: string | null;
-	worker_id: string | null;
-	created_at: Date;
-	started_at: Date | null;
-	finished_at: Date | null;
-}
-
-interface LatestPipelineRunSourceRow {
-	run_id: string;
-	source_id: string;
-	current_step: string;
-	status: PipelineRunSource['status'];
-	error_message: string | null;
-	updated_at: Date;
-}
-
 const PIPELINE_STEP_SET = new Set<string>(PIPELINE_STEP_VALUES);
 
 function isPipelineStep(value: string): value is PipelineStep {
 	return PIPELINE_STEP_SET.has(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function resolveContext(): PipelineJobContext {
@@ -97,10 +55,6 @@ function resolveContext(): PipelineJobContext {
 	return {
 		pool: getWorkerPool(config.gcp.cloud_sql),
 	};
-}
-
-function buildAcceptedJob(run: PipelineRun, job: Job): PipelineRunAcceptance {
-	return { run, job };
 }
 
 async function runInTransaction<T>(pool: Pool, fn: (client: Queryable) => Promise<T>): Promise<T> {
@@ -140,100 +94,37 @@ function buildJobPayload(input: {
 		force: input.force,
 	};
 }
-
-function parseObject(value: Record<string, unknown> | string | null): Record<string, unknown> {
-	if (value === null || value === undefined) {
-		return {};
-	}
-	if (typeof value === 'string') {
-		try {
-			const parsed: unknown = JSON.parse(value);
-			if (isRecord(parsed)) {
-				return parsed;
+function buildRunOptions(input: {
+	sourceId: string;
+	from?: PipelineStep;
+	upTo?: PipelineStep;
+	force: boolean;
+	retry?: boolean;
+	step?: PipelineStep;
+}): Record<string, unknown> {
+	return input.retry
+		? {
+				source_id: input.sourceId,
+				step: input.step,
+				force: input.force,
+				retry: true,
 			}
-		} catch {
-			// Fall back to an empty object when the column stores unexpected JSON.
-		}
-		return {};
-	}
-	return value;
-}
-
-function mapSourceRow(row: SourceRow): Source {
-	return {
-		id: row.id,
-		filename: row.filename,
-		storagePath: row.storage_path,
-		fileHash: row.file_hash,
-		pageCount: row.page_count,
-		hasNativeText: row.has_native_text,
-		nativeTextRatio: row.native_text_ratio,
-		status: row.status,
-		reliabilityScore: row.reliability_score,
-		tags: row.tags ?? [],
-		metadata: row.metadata ?? {},
-		createdAt: row.created_at,
-		updatedAt: row.updated_at,
-	};
-}
-
-function mapPipelineRunRow(row: PipelineRunRow): PipelineRun {
-	return {
-		id: row.id,
-		tag: row.tag,
-		options: parseObject(row.options),
-		status: row.status,
-		createdAt: row.created_at,
-		finishedAt: row.finished_at,
-	};
-}
-
-function mapJobRow(row: JobRow): Job {
-	return {
-		id: row.id,
-		type: row.type,
-		payload: parseObject(row.payload),
-		status: row.status,
-		attempts: row.attempts,
-		maxAttempts: row.max_attempts,
-		errorLog: row.error_log,
-		workerId: row.worker_id,
-		createdAt: row.created_at,
-		startedAt: row.started_at,
-		finishedAt: row.finished_at,
-	};
+		: {
+				source_id: input.sourceId,
+				from: input.from ?? null,
+				up_to: input.upTo ?? null,
+				force: input.force,
+			};
 }
 
 async function requireSource(pool: Queryable, sourceId: string): Promise<Source> {
-	const result = await pool.query<SourceRow>(
-		`
-			SELECT
-				id,
-				filename,
-				storage_path,
-				file_hash,
-				page_count,
-				has_native_text,
-				native_text_ratio,
-				status,
-				reliability_score,
-				tags,
-				metadata,
-				created_at,
-				updated_at
-			FROM sources
-			WHERE id = $1
-		`,
-		[sourceId],
-	);
-
-	const row = result.rows[0];
-	if (!row) {
+	const source = await findSourceById(pool as Pool, sourceId);
+	if (!source) {
 		throw new PipelineError(`Source not found: ${sourceId}`, PIPELINE_ERROR_CODES.PIPELINE_SOURCE_NOT_FOUND, {
 			context: { sourceId },
 		});
 	}
-	return mapSourceRow(row);
+	return source;
 }
 
 function assertRetryableSource(source: Source, latest: PipelineRunSource | null): PipelineRunSource {
@@ -286,42 +177,26 @@ async function enqueuePipelineJob(
 		force: boolean;
 	},
 ): Promise<Job> {
-	const result = await pool.query<JobRow>(
-		`
-			INSERT INTO jobs (type, payload, max_attempts)
-			VALUES ($1, $2, $3)
-			RETURNING *
-		`,
-		['pipeline_run', JSON.stringify(buildJobPayload(input)), 3],
-	);
-
-	return mapJobRow(result.rows[0]);
+	return await enqueueJob(pool as Pool, {
+		type: 'pipeline_run',
+		payload: buildJobPayload(input),
+		maxAttempts: 3,
+	});
 }
 
 export async function createPipelineRunJob(input: PipelineRunRequest): Promise<PipelineRunAcceptance> {
 	const { pool } = resolveContext();
 	return await runInTransaction(pool, async (client) => {
 		const source = await requireSource(client, input.source_id);
-		const run = mapPipelineRunRow(
-			(
-				await client.query<PipelineRunRow>(
-					`
-						INSERT INTO pipeline_runs (tag, options, status)
-						VALUES ($1, $2, 'running')
-						RETURNING *
-					`,
-					[
-						input.tag ?? null,
-						JSON.stringify({
-							source_id: source.id,
-							from: input.from ?? null,
-							up_to: input.up_to ?? null,
-							force: input.force ?? false,
-						}),
-					],
-				)
-			).rows[0],
-		);
+		const run = await createPipelineRun(client as Pool, {
+			tag: input.tag ?? null,
+			options: buildRunOptions({
+				sourceId: source.id,
+				from: input.from,
+				upTo: input.up_to,
+				force: input.force ?? false,
+			}),
+		});
 		const job = await enqueuePipelineJob(client, {
 			sourceId: source.id,
 			runId: run.id,
@@ -331,7 +206,7 @@ export async function createPipelineRunJob(input: PipelineRunRequest): Promise<P
 			force: input.force ?? false,
 		});
 
-		return buildAcceptedJob(run, job);
+		return { run, job };
 	});
 }
 
@@ -339,55 +214,17 @@ export async function createPipelineRetryJob(input: PipelineRetryRequest): Promi
 	const { pool } = resolveContext();
 	return await runInTransaction(pool, async (client) => {
 		const source = await requireSource(client, input.source_id);
-		const latestResult = await client.query<LatestPipelineRunSourceRow>(
-			`
-				SELECT
-					prs.run_id,
-					prs.source_id,
-					prs.current_step,
-					prs.status,
-					prs.error_message,
-					prs.updated_at
-				FROM pipeline_run_sources prs
-				JOIN pipeline_runs pr ON pr.id = prs.run_id
-				WHERE prs.source_id = $1
-				ORDER BY pr.created_at DESC, prs.updated_at DESC
-				LIMIT 1
-			`,
-			[source.id],
-		);
-		const latestRow = latestResult.rows[0];
-		const latest = latestRow
-			? {
-					runId: latestRow.run_id,
-					sourceId: latestRow.source_id,
-					currentStep: latestRow.current_step,
-					status: latestRow.status,
-					errorMessage: latestRow.error_message,
-					updatedAt: latestRow.updated_at,
-				}
-			: null;
+		const latest = await findLatestPipelineRunSourceForSource(client as Pool, source.id);
 		const step = deriveRetryStep(assertRetryableSource(source, latest), input.step);
-		const run = mapPipelineRunRow(
-			(
-				await client.query<PipelineRunRow>(
-					`
-						INSERT INTO pipeline_runs (tag, options, status)
-						VALUES ($1, $2, 'running')
-						RETURNING *
-					`,
-					[
-						input.tag ?? null,
-						JSON.stringify({
-							source_id: source.id,
-							step,
-							force: true,
-							retry: true,
-						}),
-					],
-				)
-			).rows[0],
-		);
+		const run = await createPipelineRun(client as Pool, {
+			tag: input.tag ?? null,
+			options: buildRunOptions({
+				sourceId: source.id,
+				force: true,
+				retry: true,
+				step,
+			}),
+		});
 		const job = await enqueuePipelineJob(client, {
 			sourceId: source.id,
 			runId: run.id,
@@ -397,7 +234,7 @@ export async function createPipelineRetryJob(input: PipelineRetryRequest): Promi
 			force: true,
 		});
 
-		return buildAcceptedJob(run, job);
+		return { run, job };
 	});
 }
 

--- a/apps/api/src/lib/pipeline-jobs.ts
+++ b/apps/api/src/lib/pipeline-jobs.ts
@@ -1,19 +1,10 @@
-import type { PipelineRun, PipelineRunSource, Source } from '@mulder/core';
-import {
-	createPipelineRun,
-	enqueueJob,
-	findLatestPipelineRunSourceForSource,
-	findSourceById,
-	getWorkerPool,
-	type Job,
-	loadConfig,
-	PIPELINE_ERROR_CODES,
-	PipelineError,
-	type PipelineStep,
-} from '@mulder/core';
+import type { Job, PipelineRun, PipelineRunSource, Source } from '@mulder/core';
+import { getWorkerPool, loadConfig, PIPELINE_ERROR_CODES, PipelineError, type PipelineStep } from '@mulder/core';
 import type { Pool } from 'pg';
 import type { PipelineRetryRequest, PipelineRunRequest } from '../routes/pipeline.schemas.js';
 import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
+
+type Queryable = Pick<Pool, 'query'>;
 
 type PipelineJobPayload = {
 	sourceId: string;
@@ -33,10 +24,62 @@ interface PipelineRunAcceptance {
 	job: Job;
 }
 
+interface SourceRow {
+	id: string;
+	filename: string;
+	storage_path: string;
+	file_hash: string;
+	page_count: number | null;
+	has_native_text: boolean;
+	native_text_ratio: number;
+	status: Source['status'];
+	reliability_score: number | null;
+	tags: string[] | null;
+	metadata: Record<string, unknown>;
+	created_at: Date;
+	updated_at: Date;
+}
+
+interface PipelineRunRow {
+	id: string;
+	tag: string | null;
+	options: Record<string, unknown> | string | null;
+	status: PipelineRun['status'];
+	created_at: Date;
+	finished_at: Date | null;
+}
+
+interface JobRow {
+	id: string;
+	type: string;
+	payload: Record<string, unknown> | string;
+	status: Job['status'];
+	attempts: number;
+	max_attempts: number;
+	error_log: string | null;
+	worker_id: string | null;
+	created_at: Date;
+	started_at: Date | null;
+	finished_at: Date | null;
+}
+
+interface LatestPipelineRunSourceRow {
+	run_id: string;
+	source_id: string;
+	current_step: string;
+	status: PipelineRunSource['status'];
+	error_message: string | null;
+	updated_at: Date;
+}
+
 const PIPELINE_STEP_SET = new Set<string>(PIPELINE_STEP_VALUES);
 
 function isPipelineStep(value: string): value is PipelineStep {
 	return PIPELINE_STEP_SET.has(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function resolveContext(): PipelineJobContext {
@@ -60,6 +103,26 @@ function buildAcceptedJob(run: PipelineRun, job: Job): PipelineRunAcceptance {
 	return { run, job };
 }
 
+async function runInTransaction<T>(pool: Pool, fn: (client: Queryable) => Promise<T>): Promise<T> {
+	const client = await pool.connect();
+
+	try {
+		await client.query('BEGIN');
+		const result = await fn(client);
+		await client.query('COMMIT');
+		return result;
+	} catch (error) {
+		try {
+			await client.query('ROLLBACK');
+		} catch {
+			// Ignore rollback failures; the original error is the one we need to surface.
+		}
+		throw error;
+	} finally {
+		client.release();
+	}
+}
+
 function buildJobPayload(input: {
 	sourceId: string;
 	runId: string;
@@ -78,14 +141,99 @@ function buildJobPayload(input: {
 	};
 }
 
-async function requireSource(pool: Pool, sourceId: string): Promise<Source> {
-	const source = await findSourceById(pool, sourceId);
-	if (!source) {
+function parseObject(value: Record<string, unknown> | string | null): Record<string, unknown> {
+	if (value === null || value === undefined) {
+		return {};
+	}
+	if (typeof value === 'string') {
+		try {
+			const parsed: unknown = JSON.parse(value);
+			if (isRecord(parsed)) {
+				return parsed;
+			}
+		} catch {
+			// Fall back to an empty object when the column stores unexpected JSON.
+		}
+		return {};
+	}
+	return value;
+}
+
+function mapSourceRow(row: SourceRow): Source {
+	return {
+		id: row.id,
+		filename: row.filename,
+		storagePath: row.storage_path,
+		fileHash: row.file_hash,
+		pageCount: row.page_count,
+		hasNativeText: row.has_native_text,
+		nativeTextRatio: row.native_text_ratio,
+		status: row.status,
+		reliabilityScore: row.reliability_score,
+		tags: row.tags ?? [],
+		metadata: row.metadata ?? {},
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+function mapPipelineRunRow(row: PipelineRunRow): PipelineRun {
+	return {
+		id: row.id,
+		tag: row.tag,
+		options: parseObject(row.options),
+		status: row.status,
+		createdAt: row.created_at,
+		finishedAt: row.finished_at,
+	};
+}
+
+function mapJobRow(row: JobRow): Job {
+	return {
+		id: row.id,
+		type: row.type,
+		payload: parseObject(row.payload),
+		status: row.status,
+		attempts: row.attempts,
+		maxAttempts: row.max_attempts,
+		errorLog: row.error_log,
+		workerId: row.worker_id,
+		createdAt: row.created_at,
+		startedAt: row.started_at,
+		finishedAt: row.finished_at,
+	};
+}
+
+async function requireSource(pool: Queryable, sourceId: string): Promise<Source> {
+	const result = await pool.query<SourceRow>(
+		`
+			SELECT
+				id,
+				filename,
+				storage_path,
+				file_hash,
+				page_count,
+				has_native_text,
+				native_text_ratio,
+				status,
+				reliability_score,
+				tags,
+				metadata,
+				created_at,
+				updated_at
+			FROM sources
+			WHERE id = $1
+		`,
+		[sourceId],
+	);
+
+	const row = result.rows[0];
+	if (!row) {
 		throw new PipelineError(`Source not found: ${sourceId}`, PIPELINE_ERROR_CODES.PIPELINE_SOURCE_NOT_FOUND, {
 			context: { sourceId },
 		});
 	}
-	return source;
+	return mapSourceRow(row);
 }
 
 function assertRetryableSource(source: Source, latest: PipelineRunSource | null): PipelineRunSource {
@@ -128,7 +276,7 @@ function deriveRetryStep(latest: PipelineRunSource, explicitStep?: PipelineStep)
 }
 
 async function enqueuePipelineJob(
-	pool: Pool,
+	pool: Queryable,
 	input: {
 		sourceId: string;
 		runId: string;
@@ -138,60 +286,119 @@ async function enqueuePipelineJob(
 		force: boolean;
 	},
 ): Promise<Job> {
-	return await enqueueJob(pool, {
-		type: 'pipeline_run',
-		payload: buildJobPayload(input),
-	});
+	const result = await pool.query<JobRow>(
+		`
+			INSERT INTO jobs (type, payload, max_attempts)
+			VALUES ($1, $2, $3)
+			RETURNING *
+		`,
+		['pipeline_run', JSON.stringify(buildJobPayload(input)), 3],
+	);
+
+	return mapJobRow(result.rows[0]);
 }
 
 export async function createPipelineRunJob(input: PipelineRunRequest): Promise<PipelineRunAcceptance> {
 	const { pool } = resolveContext();
-	const source = await requireSource(pool, input.source_id);
-	const run = await createPipelineRun(pool, {
-		tag: input.tag ?? null,
-		options: {
-			source_id: source.id,
-			from: input.from ?? null,
-			up_to: input.up_to ?? null,
+	return await runInTransaction(pool, async (client) => {
+		const source = await requireSource(client, input.source_id);
+		const run = mapPipelineRunRow(
+			(
+				await client.query<PipelineRunRow>(
+					`
+						INSERT INTO pipeline_runs (tag, options, status)
+						VALUES ($1, $2, 'running')
+						RETURNING *
+					`,
+					[
+						input.tag ?? null,
+						JSON.stringify({
+							source_id: source.id,
+							from: input.from ?? null,
+							up_to: input.up_to ?? null,
+							force: input.force ?? false,
+						}),
+					],
+				)
+			).rows[0],
+		);
+		const job = await enqueuePipelineJob(client, {
+			sourceId: source.id,
+			runId: run.id,
+			from: input.from,
+			upTo: input.up_to,
+			tag: input.tag,
 			force: input.force ?? false,
-		},
-	});
-	const job = await enqueuePipelineJob(pool, {
-		sourceId: source.id,
-		runId: run.id,
-		from: input.from,
-		upTo: input.up_to,
-		tag: input.tag,
-		force: input.force ?? false,
-	});
+		});
 
-	return buildAcceptedJob(run, job);
+		return buildAcceptedJob(run, job);
+	});
 }
 
 export async function createPipelineRetryJob(input: PipelineRetryRequest): Promise<PipelineRunAcceptance> {
 	const { pool } = resolveContext();
-	const source = await requireSource(pool, input.source_id);
-	const latest = assertRetryableSource(source, await findLatestPipelineRunSourceForSource(pool, source.id));
-	const step = deriveRetryStep(latest, input.step);
-	const run = await createPipelineRun(pool, {
-		tag: input.tag ?? null,
-		options: {
-			source_id: source.id,
-			step,
+	return await runInTransaction(pool, async (client) => {
+		const source = await requireSource(client, input.source_id);
+		const latestResult = await client.query<LatestPipelineRunSourceRow>(
+			`
+				SELECT
+					prs.run_id,
+					prs.source_id,
+					prs.current_step,
+					prs.status,
+					prs.error_message,
+					prs.updated_at
+				FROM pipeline_run_sources prs
+				JOIN pipeline_runs pr ON pr.id = prs.run_id
+				WHERE prs.source_id = $1
+				ORDER BY pr.created_at DESC, prs.updated_at DESC
+				LIMIT 1
+			`,
+			[source.id],
+		);
+		const latestRow = latestResult.rows[0];
+		const latest = latestRow
+			? {
+					runId: latestRow.run_id,
+					sourceId: latestRow.source_id,
+					currentStep: latestRow.current_step,
+					status: latestRow.status,
+					errorMessage: latestRow.error_message,
+					updatedAt: latestRow.updated_at,
+				}
+			: null;
+		const step = deriveRetryStep(assertRetryableSource(source, latest), input.step);
+		const run = mapPipelineRunRow(
+			(
+				await client.query<PipelineRunRow>(
+					`
+						INSERT INTO pipeline_runs (tag, options, status)
+						VALUES ($1, $2, 'running')
+						RETURNING *
+					`,
+					[
+						input.tag ?? null,
+						JSON.stringify({
+							source_id: source.id,
+							step,
+							force: true,
+							retry: true,
+						}),
+					],
+				)
+			).rows[0],
+		);
+		const job = await enqueuePipelineJob(client, {
+			sourceId: source.id,
+			runId: run.id,
+			from: step,
+			upTo: step,
+			tag: input.tag,
 			force: true,
-			retry: true,
-		},
-	});
-	const job = await enqueuePipelineJob(pool, {
-		sourceId: source.id,
-		runId: run.id,
-		from: step,
-		upTo: step,
-		tag: input.tag,
-		force: true,
-	});
+		});
 
-	return buildAcceptedJob(run, job);
+		return buildAcceptedJob(run, job);
+	});
 }
 
 export function buildPipelineAcceptedResponse(

--- a/apps/api/src/lib/pipeline-jobs.ts
+++ b/apps/api/src/lib/pipeline-jobs.ts
@@ -34,6 +34,10 @@ interface PipelineRunAcceptance {
 	job: Job;
 }
 
+interface CountRow {
+	count: string;
+}
+
 const PIPELINE_STEP_SET = new Set<string>(PIPELINE_STEP_VALUES);
 
 function isPipelineStep(value: string): value is PipelineStep {
@@ -166,6 +170,29 @@ function deriveRetryStep(latest: PipelineRunSource, explicitStep?: PipelineStep)
 	return latest.currentStep;
 }
 
+async function assertNoInFlightPipelineJob(pool: Queryable, sourceId: string): Promise<void> {
+	const result = await pool.query<CountRow>(
+		`
+			SELECT COUNT(*) AS count
+			FROM jobs
+			WHERE type = 'pipeline_run'
+				AND status IN ('pending', 'running')
+				AND COALESCE(payload->>'sourceId', payload->>'source_id') = $1
+		`,
+		[sourceId],
+	);
+
+	if ((Number.parseInt(result.rows[0]?.count ?? '0', 10) || 0) > 0) {
+		throw new PipelineError(
+			`Source ${sourceId} already has an accepted pipeline job in progress`,
+			PIPELINE_ERROR_CODES.PIPELINE_RETRY_CONFLICT,
+			{
+				context: { sourceId },
+			},
+		);
+	}
+}
+
 async function enqueuePipelineJob(
 	pool: Queryable,
 	input: {
@@ -214,6 +241,7 @@ export async function createPipelineRetryJob(input: PipelineRetryRequest): Promi
 	const { pool } = resolveContext();
 	return await runInTransaction(pool, async (client) => {
 		const source = await requireSource(client, input.source_id);
+		await assertNoInFlightPipelineJob(client, source.id);
 		const latest = await findLatestPipelineRunSourceForSource(client as Pool, source.id);
 		const step = deriveRetryStep(assertRetryableSource(source, latest), input.step);
 		const run = await createPipelineRun(client as Pool, {

--- a/apps/api/src/lib/pipeline-jobs.ts
+++ b/apps/api/src/lib/pipeline-jobs.ts
@@ -1,0 +1,220 @@
+import type { PipelineRun, PipelineRunSource, Source } from '@mulder/core';
+import {
+	createPipelineRun,
+	enqueueJob,
+	findLatestPipelineRunSourceForSource,
+	findSourceById,
+	getWorkerPool,
+	type Job,
+	loadConfig,
+	PIPELINE_ERROR_CODES,
+	PipelineError,
+	type PipelineStep,
+} from '@mulder/core';
+import type { Pool } from 'pg';
+import type { PipelineRetryRequest, PipelineRunRequest } from '../routes/pipeline.schemas.js';
+import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
+
+type PipelineJobPayload = {
+	sourceId: string;
+	runId: string;
+	from?: PipelineStep;
+	upTo?: PipelineStep;
+	tag?: string;
+	force: boolean;
+};
+
+interface PipelineJobContext {
+	pool: Pool;
+}
+
+interface PipelineRunAcceptance {
+	run: PipelineRun;
+	job: Job;
+}
+
+const PIPELINE_STEP_SET = new Set<string>(PIPELINE_STEP_VALUES);
+
+function isPipelineStep(value: string): value is PipelineStep {
+	return PIPELINE_STEP_SET.has(value);
+}
+
+function resolveContext(): PipelineJobContext {
+	const config = loadConfig();
+	if (!config.gcp?.cloud_sql) {
+		throw new PipelineError(
+			'GCP cloud_sql configuration is required for pipeline routes',
+			PIPELINE_ERROR_CODES.PIPELINE_WRONG_STATUS,
+			{
+				context: { configPath: process.env.MULDER_CONFIG ?? 'mulder.config.yaml' },
+			},
+		);
+	}
+
+	return {
+		pool: getWorkerPool(config.gcp.cloud_sql),
+	};
+}
+
+function buildAcceptedJob(run: PipelineRun, job: Job): PipelineRunAcceptance {
+	return { run, job };
+}
+
+function buildJobPayload(input: {
+	sourceId: string;
+	runId: string;
+	from?: PipelineStep;
+	upTo?: PipelineStep;
+	tag?: string;
+	force: boolean;
+}): PipelineJobPayload {
+	return {
+		sourceId: input.sourceId,
+		runId: input.runId,
+		from: input.from,
+		upTo: input.upTo,
+		tag: input.tag,
+		force: input.force,
+	};
+}
+
+async function requireSource(pool: Pool, sourceId: string): Promise<Source> {
+	const source = await findSourceById(pool, sourceId);
+	if (!source) {
+		throw new PipelineError(`Source not found: ${sourceId}`, PIPELINE_ERROR_CODES.PIPELINE_SOURCE_NOT_FOUND, {
+			context: { sourceId },
+		});
+	}
+	return source;
+}
+
+function assertRetryableSource(source: Source, latest: PipelineRunSource | null): PipelineRunSource {
+	if (!latest || latest.status !== 'failed') {
+		throw new PipelineError(
+			`Source ${source.id} does not have a failed pipeline step to retry`,
+			PIPELINE_ERROR_CODES.PIPELINE_RETRY_CONFLICT,
+			{
+				context: {
+					sourceId: source.id,
+					latestStatus: latest?.status ?? null,
+				},
+			},
+		);
+	}
+
+	return latest;
+}
+
+function deriveRetryStep(latest: PipelineRunSource, explicitStep?: PipelineStep): PipelineStep {
+	if (explicitStep) {
+		return explicitStep;
+	}
+
+	if (!isPipelineStep(latest.currentStep)) {
+		throw new PipelineError(
+			`Latest failed step "${latest.currentStep}" is not retryable`,
+			PIPELINE_ERROR_CODES.PIPELINE_RETRY_CONFLICT,
+			{
+				context: {
+					currentStep: latest.currentStep,
+					runId: latest.runId,
+					sourceId: latest.sourceId,
+				},
+			},
+		);
+	}
+
+	return latest.currentStep;
+}
+
+async function enqueuePipelineJob(
+	pool: Pool,
+	input: {
+		sourceId: string;
+		runId: string;
+		from?: PipelineStep;
+		upTo?: PipelineStep;
+		tag?: string;
+		force: boolean;
+	},
+): Promise<Job> {
+	return await enqueueJob(pool, {
+		type: 'pipeline_run',
+		payload: buildJobPayload(input),
+	});
+}
+
+export async function createPipelineRunJob(input: PipelineRunRequest): Promise<PipelineRunAcceptance> {
+	const { pool } = resolveContext();
+	const source = await requireSource(pool, input.source_id);
+	const run = await createPipelineRun(pool, {
+		tag: input.tag ?? null,
+		options: {
+			source_id: source.id,
+			from: input.from ?? null,
+			up_to: input.up_to ?? null,
+			force: input.force ?? false,
+		},
+	});
+	const job = await enqueuePipelineJob(pool, {
+		sourceId: source.id,
+		runId: run.id,
+		from: input.from,
+		upTo: input.up_to,
+		tag: input.tag,
+		force: input.force ?? false,
+	});
+
+	return buildAcceptedJob(run, job);
+}
+
+export async function createPipelineRetryJob(input: PipelineRetryRequest): Promise<PipelineRunAcceptance> {
+	const { pool } = resolveContext();
+	const source = await requireSource(pool, input.source_id);
+	const latest = assertRetryableSource(source, await findLatestPipelineRunSourceForSource(pool, source.id));
+	const step = deriveRetryStep(latest, input.step);
+	const run = await createPipelineRun(pool, {
+		tag: input.tag ?? null,
+		options: {
+			source_id: source.id,
+			step,
+			force: true,
+			retry: true,
+		},
+	});
+	const job = await enqueuePipelineJob(pool, {
+		sourceId: source.id,
+		runId: run.id,
+		from: step,
+		upTo: step,
+		tag: input.tag,
+		force: true,
+	});
+
+	return buildAcceptedJob(run, job);
+}
+
+export function buildPipelineAcceptedResponse(
+	run: PipelineRun,
+	job: Job,
+): {
+	data: {
+		job_id: string;
+		status: 'pending';
+		run_id: string;
+	};
+	links: {
+		status: string;
+	};
+} {
+	return {
+		data: {
+			job_id: job.id,
+			status: 'pending',
+			run_id: run.id,
+		},
+		links: {
+			status: `/api/jobs/${job.id}`,
+		},
+	};
+}

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -104,8 +104,7 @@ export function createErrorHandler(fallbackLogger: Logger): ErrorHandler {
 				c.header('X-Request-Id', requestId);
 			}
 
-			const zodError = error as ZodError;
-			return c.json(buildErrorBody('VALIDATION_ERROR', 'Invalid request', zodError.flatten()), 400);
+			return c.json(buildErrorBody('VALIDATION_ERROR', 'Invalid request', error.flatten()), 400);
 		}
 
 		logger.error({ err: error, request_id: requestId }, 'Unhandled API error');

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -9,7 +9,7 @@ interface ErrorResponseBody {
 	};
 }
 
-type ApiErrorStatus = 400 | 401 | 403 | 404 | 413 | 429 | 500 | 503;
+type ApiErrorStatus = 400 | 401 | 403 | 404 | 409 | 413 | 429 | 500 | 503;
 
 function getLogger(c: Context, fallbackLogger: Logger): Logger {
 	const requestContext = c.get('requestContext');
@@ -41,6 +41,10 @@ export function mapErrorToStatus(error: MulderError): ApiErrorStatus {
 
 	if (code.includes('NOT_FOUND')) {
 		return 404;
+	}
+
+	if (code.includes('CONFLICT')) {
+		return 409;
 	}
 
 	if (code.includes('VALIDATION') || code.startsWith('CONFIG_') || code.includes('INVALID')) {

--- a/apps/api/src/routes/pipeline.schemas.ts
+++ b/apps/api/src/routes/pipeline.schemas.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const PIPELINE_STEP_VALUES = ['extract', 'segment', 'enrich', 'embed', 'graph'] as const;
+
+export const PipelineStepSchema = z.enum(PIPELINE_STEP_VALUES);
+
+function stepIndex(step: string): number {
+	return PIPELINE_STEP_VALUES.indexOf(step as (typeof PIPELINE_STEP_VALUES)[number]);
+}
+
+export const PipelineRunRequestSchema = z
+	.object({
+		source_id: z.string().uuid(),
+		from: PipelineStepSchema.optional(),
+		up_to: PipelineStepSchema.optional(),
+		tag: z.string().min(1).max(128).optional(),
+		force: z.boolean().optional().default(false),
+	})
+	.superRefine((value, ctx) => {
+		if (value.from && value.up_to && stepIndex(value.from) > stepIndex(value.up_to)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['from'],
+				message: '`from` must not come after `up_to`',
+			});
+		}
+	});
+
+export const PipelineRetryRequestSchema = z.object({
+	source_id: z.string().uuid(),
+	step: PipelineStepSchema.optional(),
+	tag: z.string().min(1).max(128).optional(),
+});
+
+export const PipelineAcceptedJobSchema = z.object({
+	data: z.object({
+		job_id: z.string().uuid(),
+		status: z.literal('pending'),
+		run_id: z.string().uuid(),
+	}),
+	links: z.object({
+		status: z.string().regex(/^\/api\/jobs\/[0-9a-f-]+$/i),
+	}),
+});
+
+export type PipelineRunRequest = z.infer<typeof PipelineRunRequestSchema>;
+export type PipelineRetryRequest = z.infer<typeof PipelineRetryRequestSchema>;
+export type PipelineAcceptedJob = z.infer<typeof PipelineAcceptedJobSchema>;

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -1,0 +1,30 @@
+import { MulderError } from '@mulder/core';
+import type { Context, Hono } from 'hono';
+import { buildPipelineAcceptedResponse, createPipelineRetryJob, createPipelineRunJob } from '../lib/pipeline-jobs.js';
+import { PipelineAcceptedJobSchema, PipelineRetryRequestSchema, PipelineRunRequestSchema } from './pipeline.schemas.js';
+
+async function readJsonBody(c: Context): Promise<unknown> {
+	try {
+		return await c.req.json();
+	} catch {
+		throw new MulderError('Invalid request', 'VALIDATION_ERROR');
+	}
+}
+
+export function registerPipelineRoutes(app: Hono): void {
+	app.post('/api/pipeline/run', async (c) => {
+		const body = PipelineRunRequestSchema.parse(await readJsonBody(c));
+		const { run, job } = await createPipelineRunJob(body);
+		const response = buildPipelineAcceptedResponse(run, job);
+		PipelineAcceptedJobSchema.parse(response);
+		return c.json(response, 202);
+	});
+
+	app.post('/api/pipeline/retry', async (c) => {
+		const body = PipelineRetryRequestSchema.parse(await readJsonBody(c));
+		const { run, job } = await createPipelineRetryJob(body);
+		const response = buildPipelineAcceptedResponse(run, job);
+		PipelineAcceptedJobSchema.parse(response);
+		return c.json(response, 202);
+	});
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,7 +187,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
-| 🟡 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
+| 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |
 | ⚪ | H7 | Search API routes (sync) | §10.6, §5 |
 | ⚪ | H8 | Entity API routes (sync) | §10.6 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,7 +187,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H2 | Worker loop — `mulder worker start/status/reap` | §10.3, §10.4, §10.5, §1 (worker cmd) |
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
-| ⚪ | H5 | Pipeline API routes (async) | §10.2, §10.6 |
+| 🟡 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | ⚪ | H6 | Job status API | §10.6 |
 | ⚪ | H7 | Search API routes (sync) | §10.6, §5 |
 | ⚪ | H8 | Entity API routes (sync) | §10.6 |

--- a/docs/specs/71_async_pipeline_api_routes.spec.md
+++ b/docs/specs/71_async_pipeline_api_routes.spec.md
@@ -1,0 +1,200 @@
+---
+spec: "71"
+title: "Async Pipeline API Routes"
+roadmap_step: M7-H5
+functional_spec: ["§10.2", "§10.6"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/178"
+created: 2026-04-14
+---
+
+# Spec 71: Async Pipeline API Routes
+
+## 1. Objective
+
+Introduce Mulder's first async pipeline HTTP routes so authenticated API clients can trigger background processing without calling pipeline functions directly from the request/response cycle. Per `§10.6`, the API must stay a pure job producer that returns `202 Accepted` plus a job reference; per `§10.2`, the queue-backed path must preserve observable progress through the existing `jobs` and `pipeline_runs` data model instead of inventing ad hoc in-memory execution.
+
+This step ships the source-scoped async entrypoints for pipeline execution and retry:
+
+- `POST /api/pipeline/run`
+- `POST /api/pipeline/retry`
+
+The initial API contract should reuse the already-shipped pipeline orchestrator and queue infrastructure so the HTTP layer remains thin, validation-heavy, and externally inspectable.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H5` — Pipeline API routes (async)
+- **Target:** `apps/api/src/app.ts`, `apps/api/src/routes/pipeline.schemas.ts`, `apps/api/src/routes/pipeline.ts`, `apps/api/src/lib/pipeline-jobs.ts`, `packages/worker/src/worker.types.ts`, `packages/worker/src/dispatch.ts`, `packages/worker/src/runtime.ts`, `tests/specs/71_pipeline_api_routes.test.ts`
+- **In scope:** authenticated async pipeline route registration under `/api/pipeline/*`; Zod-backed request/response contracts for run and retry; source existence and retry-precondition validation against the existing repositories; queue/job creation using the existing `jobs` and `pipeline_runs` tables; worker payload support for API-created pipeline jobs that execute the existing orchestrator for a single source; and black-box coverage for accepted requests, invalid requests, missing sources, retry gating, and externally inspectable queue state
+- **Out of scope:** job status/read routes (`M7-H6`); synchronous search/entity/evidence/document routes (`M7-H7` through `M7-H10`); upload/import endpoints for new files; taxonomy async routes; OpenAPI/Scalar publication; multi-source batch submission; and any UI work (`M7-H11`)
+- **Constraints:** the API route handlers must not call pipeline step functions or the orchestrator directly; all execution must happen through the queue/worker boundary; response bodies must follow Mulder's API envelope shape; request validation must happen at the HTTP edge; the route layer must stay source-scoped rather than inventing filesystem-path semantics; and retry requests must reuse the existing failed-step semantics from the CLI/orchestrator rather than introducing a second retry model
+
+## 3. Dependencies
+
+- **Requires:** Spec 14 (`M2-B2`) source repository lookups, Spec 36 (`M4-D6`) pipeline orchestrator + `pipeline_runs`/`pipeline_run_sources`, Spec 67 (`M7-H1`) job queue repository, Spec 68 (`M7-H2`) worker loop, Spec 69 (`M7-H3`) Hono server scaffold, and Spec 70 (`M7-H4`) API middleware stack
+- **Blocks:** `M7-H6` job status API, because the accepted response must link to real queued work; and any external API consumer that needs to start or retry pipeline processing through HTTP rather than CLI
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/pipeline.schemas.ts`** — defines the route-facing Zod schemas for pipeline run/retry requests and the shared `202 Accepted` job envelope
+2. **`apps/api/src/lib/pipeline-jobs.ts`** — owns repository-backed helpers for validating a source, deriving retry inputs, creating `pipeline_runs` metadata, and enqueueing the corresponding job
+3. **`apps/api/src/routes/pipeline.ts`** — registers `POST /api/pipeline/run` and `POST /api/pipeline/retry` on the Hono app and maps service outcomes to HTTP responses
+4. **`apps/api/src/app.ts`** — mounts the pipeline routes beneath the existing middleware stack
+5. **`packages/worker/src/worker.types.ts`** — extends the queue payload contract so API-created pipeline jobs can carry `runId`, `from`, `upTo`, `tag`, and retry/force intent
+6. **`packages/worker/src/dispatch.ts`** — executes an API-created pipeline job by calling the existing single-source pipeline orchestrator rather than treating it as an extract-only legacy placeholder
+7. **`packages/worker/src/runtime.ts`** — keeps payload decoding aligned with the richer pipeline job contract
+8. **`tests/specs/71_pipeline_api_routes.test.ts`** — black-box tests covering accepted requests, validation failures, missing sources, retry preconditions, and job/pipeline-run persistence
+
+### 4.2 Route Contract
+
+#### `POST /api/pipeline/run`
+
+Request body:
+
+```json
+{
+  "source_id": "uuid",
+  "from": "extract | segment | enrich | embed | graph",
+  "up_to": "extract | segment | enrich | embed | graph",
+  "tag": "optional-tag",
+  "force": false
+}
+```
+
+Rules:
+
+- `source_id` is required and must reference an existing source row
+- `from` and `up_to` are optional, but when both are present `from` must not come after `up_to`
+- the API is source-scoped: it operates on an existing source id, not a local path or upload payload
+- on acceptance, the route creates a `pipeline_runs` row that records the requested options and enqueues exactly one queue job for the worker boundary
+
+Accepted response:
+
+```json
+{
+  "data": {
+    "job_id": "uuid",
+    "status": "pending",
+    "run_id": "uuid"
+  },
+  "links": {
+    "status": "/api/jobs/{job_id}"
+  }
+}
+```
+
+#### `POST /api/pipeline/retry`
+
+Request body:
+
+```json
+{
+  "source_id": "uuid",
+  "step": "extract | segment | enrich | embed | graph",
+  "tag": "optional-tag"
+}
+```
+
+Rules:
+
+- `source_id` is required and must reference an existing source row
+- if `step` is omitted, the route derives the latest failed step from `pipeline_run_sources`
+- retry is only allowed when the source has a latest failed pipeline step to retry; otherwise return a conflict-style error and do not enqueue work
+- retry is implemented as a new queued pipeline job with `force: true`, `from = step`, and `up_to = step`
+
+### 4.3 Queue And Worker Contract
+
+This step uses a single queued pipeline job as the HTTP-to-worker handoff for one source. The payload must be explicit and replayable:
+
+```json
+{
+  "sourceId": "uuid",
+  "runId": "uuid",
+  "from": "extract",
+  "upTo": "graph",
+  "tag": "api-optional-tag",
+  "force": false
+}
+```
+
+Worker behavior:
+
+- decode the richer `pipeline_run` payload
+- call the existing pipeline orchestrator with `sourceIds: [sourceId]`
+- pass through `from`, `upTo`, `tag`, and `force`
+- let the orchestrator remain the owner of `pipeline_runs` / `pipeline_run_sources` progress semantics
+
+This preserves the API rule that requests only enqueue work while keeping progress externally visible in the same tables the CLI path already uses.
+
+### 4.4 Config Changes
+
+None. This step consumes the existing API middleware/config surface from Spec 70 and the existing database/service configuration required by the worker/orchestrator.
+
+### 4.5 Integration Points
+
+- the route layer uses `@mulder/core` repository exports for `findSourceById`, `findLatestPipelineRunSourceForSource`, `createPipelineRun`, and `enqueueJob`
+- accepted responses link forward to the future job-status routes in `M7-H6`
+- the worker remains the only process that executes pipeline work after an API request is accepted
+- retry semantics stay aligned with `mulder pipeline retry <source-id>` so HTTP and CLI operators see the same failure model
+
+### 4.6 Implementation Phases
+
+**Phase 1: HTTP contracts + route wiring**
+- add request/response schemas for run and retry
+- add repository-backed helpers that validate the source/retry state and persist the accepted job metadata
+- mount the new routes in the API app
+
+**Phase 2: Worker payload bridge**
+- extend the `pipeline_run` queue payload to carry the data required by the API contract
+- update worker payload decoding and dispatch so the queued pipeline job executes the existing single-source orchestrator contract
+
+**Phase 3: Black-box QA**
+- add API-focused tests for accepted requests, validation failures, missing sources, retry conflicts, and persisted queue/run metadata
+- verify the API and worker packages still compile with the richer job payload contract
+
+## 5. QA Contract
+
+1. **QA-01: `POST /api/pipeline/run` accepts a valid source-scoped request**
+   - Given: an existing source id and a valid API key
+   - When: `POST /api/pipeline/run` is called with a valid body
+   - Then: the response is `202`, the body includes `job_id`, `run_id`, and a `/api/jobs/{job_id}` status link, and a pending queue row exists for that accepted job
+
+2. **QA-02: malformed pipeline-run requests fail at the HTTP edge**
+   - Given: a request body missing `source_id` or using invalid step names/order
+   - When: `POST /api/pipeline/run` is called
+   - Then: the API returns a Mulder JSON client error and no job or pipeline run row is created
+
+3. **QA-03: unknown sources are rejected without queue side effects**
+   - Given: a well-formed request body with a non-existent `source_id`
+   - When: either pipeline route is called
+   - Then: the API returns a not-found style error and does not enqueue a job
+
+4. **QA-04: `POST /api/pipeline/retry` only accepts retryable failed work**
+   - Given: a source with no failed latest pipeline step
+   - When: `POST /api/pipeline/retry` is called
+   - Then: the API returns a conflict-style error and does not enqueue a retry job
+
+5. **QA-05: retry requests enqueue a forced single-step pipeline job**
+   - Given: a source whose latest pipeline progress is failed at a retryable step
+   - When: `POST /api/pipeline/retry` is called with or without an explicit step override
+   - Then: the accepted queue payload targets that source, sets `force=true`, constrains the orchestrator to the selected step, and returns `202` with queue visibility
+
+6. **QA-06: the API-created pipeline job is executable by the worker contract**
+   - Given: a queued `pipeline_run` job created by the API helper
+   - When: the worker decodes and dispatches that job
+   - Then: the payload is accepted without shape errors and the worker invokes the existing single-source pipeline orchestrator rather than an extract-only placeholder path
+
+7. **QA-07: the API and worker packages compile with the shared payload contract**
+   - Given: the route, helper, and worker payload changes are wired into the workspace
+   - When: package build/typecheck runs
+   - Then: both `@mulder/api` and `@mulder/worker` compile without type errors
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+This step does not add a new direct paid-service integration, but it is operationally cost-sensitive because it opens a remote trigger surface for extraction, segmentation, enrichment, and embedding work. Validation and auth must therefore reject bad requests before a queue row is created, and the route handlers must never execute expensive pipeline logic inline.

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -25,8 +25,12 @@ export type ConfigErrorCode = (typeof CONFIG_ERROR_CODES)[keyof typeof CONFIG_ER
 export const PIPELINE_ERROR_CODES = {
 	/** Source row not found in DB during pipeline run. */
 	PIPELINE_SOURCE_NOT_FOUND: 'PIPELINE_SOURCE_NOT_FOUND',
+	/** Externally supplied pipeline run row does not exist. */
+	PIPELINE_RUN_NOT_FOUND: 'PIPELINE_RUN_NOT_FOUND',
 	/** Source status does not match the expected step entry condition. */
 	PIPELINE_WRONG_STATUS: 'PIPELINE_WRONG_STATUS',
+	/** Retry requested but the latest failed step cannot be retried. */
+	PIPELINE_RETRY_CONFLICT: 'PIPELINE_RETRY_CONFLICT',
 	/** A pipeline step threw — wraps the underlying step error code. */
 	PIPELINE_STEP_FAILED: 'PIPELINE_STEP_FAILED',
 	/** @reserved D6 pipeline orchestrator retry exhaustion */

--- a/packages/pipeline/src/pipeline/index.ts
+++ b/packages/pipeline/src/pipeline/index.ts
@@ -24,6 +24,7 @@ import {
 	createPipelineRun,
 	finalizePipelineRun,
 	findAllSources,
+	findPipelineRunById,
 	findSourceById,
 	findStoriesBySourceId,
 	PIPELINE_ERROR_CODES,
@@ -625,11 +626,18 @@ export async function execute(
 		});
 	}
 
-	// 3. Create the run row.
-	const run = await createPipelineRun(pool, {
-		tag: options.tag ?? null,
-		options: serializeOptions(options),
-	});
+	// 3. Create or reuse the run row.
+	const run = options.runId
+		? await findPipelineRunById(pool, options.runId)
+		: await createPipelineRun(pool, {
+				tag: options.tag ?? null,
+				options: serializeOptions(options),
+			});
+	if (!run) {
+		throw new PipelineError(`Pipeline run not found: ${options.runId}`, PIPELINE_ERROR_CODES.PIPELINE_RUN_NOT_FOUND, {
+			context: { runId: options.runId },
+		});
+	}
 	const runLog = createChildLogger(log, { runId: run.id });
 	runLog.info({ runId: run.id, tag: run.tag, plannedSteps }, 'pipeline.run.start');
 

--- a/packages/pipeline/src/pipeline/types.ts
+++ b/packages/pipeline/src/pipeline/types.ts
@@ -36,6 +36,8 @@ export interface PipelineRunOptions {
 	from?: PipelineStepName;
 	/** Optional human-readable tag attached to the `pipeline_runs` row. */
 	tag?: string;
+	/** Reuse an externally created `pipeline_runs` row instead of creating a new one. */
+	runId?: string;
 	/** If true, emit the plan without executing any step or writing to the DB. */
 	dryRun?: boolean;
 	/** If provided, skip `ingest` and operate on existing sources with these ids. Used by `pipeline retry`. */

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -10,7 +10,16 @@
 
 import type { MulderConfig, Services } from '@mulder/core';
 import { createChildLogger } from '@mulder/core';
-import { executeEmbed, executeEnrich, executeExtract, executeGraph, executeSegment } from '@mulder/pipeline';
+import {
+	executeEmbed,
+	executeEnrich,
+	executeExtract,
+	executeGraph,
+	executePipelineRun,
+	executeSegment,
+	type PipelineRunOptions,
+	type PipelineStepName,
+} from '@mulder/pipeline';
 import {
 	type SupportedJobType,
 	WORKER_ERROR_CODES,
@@ -115,6 +124,70 @@ function parseStoryStepPayload(job: WorkerJobEnvelope): {
 	return payload;
 }
 
+function isPipelineStep(value: string): value is PipelineStepName {
+	return value === 'extract' || value === 'segment' || value === 'enrich' || value === 'embed' || value === 'graph';
+}
+
+function parsePipelineRunPayload(job: WorkerJobEnvelope): {
+	sourceId: string;
+	runId?: string;
+	from?: PipelineStepName;
+	upTo?: PipelineStepName;
+	tag?: string;
+	force?: boolean;
+} {
+	if (!isRecord(job.payload)) {
+		throw invalidPayload(job, `Job ${job.id} payload must be an object`, { field: 'payload' });
+	}
+
+	const sourceId = readStringField(job, 'sourceId', 'source_id');
+	if (!sourceId) {
+		throw invalidPayload(job, `pipeline_run jobs require a non-empty sourceId`, { field: 'sourceId' });
+	}
+
+	const payload: {
+		sourceId: string;
+		runId?: string;
+		from?: PipelineStepName;
+		upTo?: PipelineStepName;
+		tag?: string;
+		force?: boolean;
+	} = { sourceId };
+
+	const runId = readStringField(job, 'runId', 'run_id');
+	if (runId) {
+		payload.runId = runId;
+	}
+
+	const from = readStringField(job, 'from');
+	if (from) {
+		if (!isPipelineStep(from)) {
+			throw invalidPayload(job, `pipeline_run jobs require a valid from step`, { field: 'from', value: from });
+		}
+		payload.from = from;
+	}
+
+	const upTo = readStringField(job, 'upTo', 'up_to');
+	if (upTo) {
+		if (!isPipelineStep(upTo)) {
+			throw invalidPayload(job, `pipeline_run jobs require a valid upTo step`, { field: 'upTo', value: upTo });
+		}
+		payload.upTo = upTo;
+	}
+
+	const tag = readStringField(job, 'tag');
+	if (tag) {
+		payload.tag = tag;
+	}
+
+	const force = asBoolean(job.payload.force);
+	if (force !== undefined) {
+		payload.force = force;
+	}
+
+	return payload;
+}
+
 function assertStepSucceeded(job: WorkerJobEnvelope, stepName: string, status: string): void {
 	if (status === 'success') {
 		return;
@@ -165,8 +238,36 @@ export const dispatchJob: WorkerDispatchFn = async (job, context) => {
 			return;
 		}
 		case 'pipeline_run': {
-			const payload = parseSourceStepPayload(job);
-			const result = await executeExtract(payload, config, services, pool, log);
+			const payload = parsePipelineRunPayload(job);
+			if (!payload.runId) {
+				const result = await executeExtract(
+					{ sourceId: payload.sourceId, force: payload.force ?? false },
+					config,
+					services,
+					pool,
+					log,
+				);
+				assertStepSucceeded(job, 'pipeline_run', result.status);
+				return;
+			}
+
+			const runOptions: PipelineRunOptions = {
+				sourceIds: [payload.sourceId],
+				force: payload.force ?? false,
+			};
+			if (payload.runId) {
+				runOptions.runId = payload.runId;
+			}
+			if (payload.from) {
+				runOptions.from = payload.from;
+			}
+			if (payload.upTo) {
+				runOptions.upTo = payload.upTo;
+			}
+			if (payload.tag) {
+				runOptions.tag = payload.tag;
+			}
+			const result = await executePipelineRun({ options: runOptions }, config, services, pool, log);
 			assertStepSucceeded(job, 'pipeline_run', result.status);
 			return;
 		}

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -200,6 +200,16 @@ function assertStepSucceeded(job: WorkerJobEnvelope, stepName: string, status: s
 	);
 }
 
+function assertPipelineRunCompleted(job: WorkerJobEnvelope, status: string): void {
+	if (status === 'success' || status === 'partial') {
+		return;
+	}
+
+	throw new WorkerError(`pipeline_run job ${job.id} finished with status ${status}`, WORKER_ERROR_CODES.WORKER_LOOP_FAILED, {
+		context: { jobId: job.id, jobType: job.type, status },
+	});
+}
+
 export const dispatchJob: WorkerDispatchFn = async (job, context) => {
 	const log = createChildLogger(context.logger, { jobId: job.id, jobType: job.type });
 	const config: MulderConfig = context.config;
@@ -268,7 +278,7 @@ export const dispatchJob: WorkerDispatchFn = async (job, context) => {
 				runOptions.tag = payload.tag;
 			}
 			const result = await executePipelineRun({ options: runOptions }, config, services, pool, log);
-			assertStepSucceeded(job, 'pipeline_run', result.status);
+			assertPipelineRunCompleted(job, result.status);
 			return;
 		}
 		default:

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './runtime.js';
 export type {
 	LegacyPipelineRunJobPayload,
+	PipelineRunJobPayload,
 	SourceStepJobPayload,
 	SourceStepJobType,
 	StoryStepJobPayload,

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -25,6 +25,7 @@ import { dispatchJob } from './dispatch.js';
 import {
 	createWorkerId,
 	describeWorkerError,
+	type PipelineRunJobPayload,
 	type WorkerActiveJobSnapshot,
 	type WorkerDispatchContext,
 	type WorkerDispatchFn,
@@ -106,27 +107,87 @@ function readOptionalBoolean(payload: Record<string, unknown>, key: string): boo
 	return typeof payload[key] === 'boolean' ? payload[key] : undefined;
 }
 
+function readOptionalString(
+	payload: Record<string, unknown>,
+	primaryKey: string,
+	fallbackKey?: string,
+): string | undefined {
+	if (typeof payload[primaryKey] === 'string' && payload[primaryKey].trim().length > 0) {
+		return payload[primaryKey].trim();
+	}
+	if (fallbackKey && typeof payload[fallbackKey] === 'string' && payload[fallbackKey].trim().length > 0) {
+		return payload[fallbackKey].trim();
+	}
+	return undefined;
+}
+
 function toWorkerJobPayload(job: Job): WorkerJobEnvelope['payload'] {
 	if (!isRecord(job.payload)) {
 		throw new Error(`Job ${job.id} payload must be an object`);
 	}
 
-	if (job.type === 'extract' || job.type === 'segment' || job.type === 'pipeline_run') {
-		const sourceId =
-			typeof job.payload.sourceId === 'string'
-				? job.payload.sourceId
-				: typeof job.payload.source_id === 'string'
-					? job.payload.source_id
-					: null;
+	if (job.type === 'extract' || job.type === 'segment') {
+		const sourceId = readOptionalString(job.payload, 'sourceId', 'source_id');
 		if (!sourceId) {
 			throw new Error(`Job ${job.id} is missing sourceId`);
 		}
 
-		return {
+		const payload: WorkerJobEnvelope['payload'] = {
 			sourceId,
-			force: readOptionalBoolean(job.payload, 'force'),
-			fallbackOnly: readOptionalBoolean(job.payload, 'fallbackOnly'),
 		};
+
+		const force = readOptionalBoolean(job.payload, 'force');
+		if (force !== undefined) {
+			payload.force = force;
+		}
+
+		const fallbackOnly = readOptionalBoolean(job.payload, 'fallbackOnly');
+		if (fallbackOnly !== undefined) {
+			payload.fallbackOnly = fallbackOnly;
+		}
+
+		return payload;
+	}
+
+	if (job.type === 'pipeline_run') {
+		const sourceId = readOptionalString(job.payload, 'sourceId', 'source_id');
+		if (!sourceId) {
+			throw new Error(`Job ${job.id} is missing sourceId`);
+		}
+
+		const payload: PipelineRunJobPayload = { sourceId };
+
+		const force = readOptionalBoolean(job.payload, 'force');
+		if (force !== undefined) {
+			payload.force = force;
+		}
+
+		const fallbackOnly = readOptionalBoolean(job.payload, 'fallbackOnly');
+		if (fallbackOnly !== undefined) {
+			payload.fallbackOnly = fallbackOnly;
+		}
+
+		const runId = readOptionalString(job.payload, 'runId', 'run_id');
+		if (runId) {
+			payload.runId = runId;
+		}
+
+		const from = readOptionalString(job.payload, 'from');
+		if (from) {
+			payload.from = from;
+		}
+
+		const upTo = readOptionalString(job.payload, 'upTo', 'up_to');
+		if (upTo) {
+			payload.upTo = upTo;
+		}
+
+		const tag = readOptionalString(job.payload, 'tag');
+		if (tag) {
+			payload.tag = tag;
+		}
+
+		return payload;
 	}
 
 	if (job.type === 'enrich' || job.type === 'embed' || job.type === 'graph') {

--- a/packages/worker/src/worker.types.ts
+++ b/packages/worker/src/worker.types.ts
@@ -36,7 +36,17 @@ export interface StoryStepJobPayload {
 	force?: boolean;
 }
 
-export type LegacyPipelineRunJobPayload = SourceStepJobPayload;
+export interface PipelineRunJobPayload {
+	sourceId: string;
+	runId?: string;
+	from?: string;
+	upTo?: string;
+	tag?: string;
+	force?: boolean;
+	fallbackOnly?: boolean;
+}
+
+export type LegacyPipelineRunJobPayload = PipelineRunJobPayload;
 
 export type WorkerJobPayloadMap = {
 	extract: SourceStepJobPayload;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       hono:
         specifier: ^4.7.11
         version: 4.12.12
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   apps/cli:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,12 +232,18 @@ importers:
       '@mulder/retrieval':
         specifier: workspace:*
         version: link:../packages/retrieval
+      '@mulder/worker':
+        specifier: workspace:*
+        version: link:../packages/worker
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      hono:
+        specifier: ^4.7.11
+        version: 4.12.12
       pg:
         specifier: ^8.20.0
         version: 8.20.0

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,9 +9,11 @@
 		"@mulder/core": "workspace:*",
 		"@mulder/eval": "workspace:*",
 		"@mulder/pipeline": "workspace:*",
+		"@mulder/worker": "workspace:*",
 		"@mulder/retrieval": "workspace:*",
 		"@types/node": "^25.5.0",
 		"@types/pg": "^8.20.0",
+		"hono": "^4.7.11",
 		"pg": "^8.20.0"
 	}
 }

--- a/tests/specs/71_pipeline_api_routes.test.ts
+++ b/tests/specs/71_pipeline_api_routes.test.ts
@@ -136,6 +136,23 @@ async function loadApiApp(): Promise<{ request: (input: string | Request, init?:
 	});
 }
 
+type ApiApp = Awaited<ReturnType<typeof loadApiApp>>;
+
+interface PipelineAcceptedResponse {
+	data: {
+		job_id: string;
+		status: 'pending';
+		run_id: string;
+	};
+	links: {
+		status: string;
+	};
+}
+
+async function readPipelineAcceptedResponse(response: Response): Promise<PipelineAcceptedResponse> {
+	return (await response.json()) as PipelineAcceptedResponse;
+}
+
 async function apiPost(app: ApiApp, path: string, body: unknown): Promise<Response> {
 	return await app.request(`http://localhost${path}`, {
 		method: 'POST',
@@ -206,7 +223,7 @@ describe('Spec 71 — Async Pipeline API Routes', () => {
 
 		expect(response.status).toBe(202);
 		expect(response.headers.get('content-type')).toContain('application/json');
-		const body = await response.json();
+		const body = await readPipelineAcceptedResponse(response);
 		expect(body).toMatchObject({
 			data: {
 				job_id: expect.any(String),
@@ -323,7 +340,7 @@ describe('Spec 71 — Async Pipeline API Routes', () => {
 		});
 
 		expect(response.status).toBe(202);
-		const body = await response.json();
+		const body = await readPipelineAcceptedResponse(response);
 		expect(body.data.status).toBe('pending');
 		expect(body.links.status).toMatch(/^\/api\/jobs\/[0-9a-f-]+$/i);
 
@@ -368,14 +385,18 @@ describe('Spec 71 — Async Pipeline API Routes', () => {
 			tag: 'worker-integration',
 		});
 		expect(response.status).toBe(202);
-		const body = await response.json();
+		const body = await readPipelineAcceptedResponse(response);
 
 		const workerConfig = coreModule.loadConfig(EXAMPLE_CONFIG);
 		const workerLogger = coreModule.createLogger();
+		const cloudSql = workerConfig.gcp?.cloud_sql;
+		if (!cloudSql) {
+			throw new Error('Expected worker config to include GCP Cloud SQL settings');
+		}
 		const runtimeContext: WorkerRuntimeContext = {
 			config: workerConfig,
 			services: coreModule.createServiceRegistry(workerConfig, workerLogger),
-			pool: coreModule.getWorkerPool(workerConfig.gcp.cloud_sql),
+			pool: coreModule.getWorkerPool(cloudSql),
 			logger: workerLogger,
 		};
 

--- a/tests/specs/71_pipeline_api_routes.test.ts
+++ b/tests/specs/71_pipeline_api_routes.test.ts
@@ -114,6 +114,20 @@ function insertFailedPipelineStep(sourceId: string, step: string, tag = 'retry-s
 	);
 }
 
+function insertPendingPipelineJob(sourceId: string): string {
+	const jobId = randomUUID();
+	const runId = randomUUID();
+	db.runSql(
+		[
+			`INSERT INTO pipeline_runs (id, tag, options, status, created_at)`,
+			`VALUES ('${runId}', 'accepted-run', '${JSON.stringify({ source_id: sourceId })}'::jsonb, 'running', now());`,
+			`INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, created_at)`,
+			`VALUES ('${jobId}', 'pipeline_run', '${JSON.stringify({ sourceId, runId, from: 'extract', upTo: 'extract', force: false })}'::jsonb, 'pending', 0, 3, now());`,
+		].join(' '),
+	);
+	return jobId;
+}
+
 async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
 	const module = await import(pathToFileURL(API_APP_DIST).href);
 	if (typeof module.createApp !== 'function') {
@@ -367,6 +381,29 @@ describe('Spec 71 — Async Pipeline API Routes', () => {
 		expect((runRow.options as Record<string, unknown>).source_id).toBe(sourceId);
 		expect((runRow.options as Record<string, unknown>).step).toBe('segment');
 		expect((runRow.options as Record<string, unknown>).retry).toBe(true);
+	});
+
+	it('QA-05b: retry requests are rejected when the source already has an in-flight async pipeline job', async () => {
+		const sourceId = randomUUID();
+		insertSourceRow(sourceId);
+		insertFailedPipelineStep(sourceId, 'extract');
+		insertPendingPipelineJob(sourceId);
+
+		const beforeJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const beforeRuns = db.runSql("SELECT COUNT(*) FROM pipeline_runs WHERE tag != 'retry-seed';");
+
+		const response = await apiPost(app, '/api/pipeline/retry', {
+			source_id: sourceId,
+		});
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'PIPELINE_RETRY_CONFLICT',
+			},
+		});
+		expect(db.runSql('SELECT COUNT(*) FROM jobs;')).toBe(beforeJobs);
+		expect(db.runSql("SELECT COUNT(*) FROM pipeline_runs WHERE tag != 'retry-seed';")).toBe(beforeRuns);
 	});
 
 	it('QA-06: the worker can dequeue and execute an API-created pipeline job', async () => {

--- a/tests/specs/71_pipeline_api_routes.test.ts
+++ b/tests/specs/71_pipeline_api_routes.test.ts
@@ -1,0 +1,398 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { WorkerRuntimeContext } from '@mulder/worker';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const WORKER_DIST = resolve(WORKER_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
+const NATIVE_TEXT_PDF = resolve(ROOT, 'fixtures/raw/native-text-sample.pdf');
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 120_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function cleanStorageFixtures(): void {
+	for (const dir of [resolve(ROOT, '.local/storage/extracted'), resolve(ROOT, '.local/storage/segments')]) {
+		if (!existsSync(dir)) {
+			continue;
+		}
+		for (const entry of readdirSync(dir)) {
+			if (entry === '_schema.json') {
+				continue;
+			}
+			rmSync(join(dir, entry), { recursive: true, force: true });
+		}
+	}
+}
+
+function insertSourceRow(sourceId: string): void {
+	const fileHash = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
+	db.runSql(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata)',
+			`VALUES ('${sourceId}', 'route-test.pdf', '/tmp/route-test.pdf', '${fileHash}', 1, true, 1, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb)`,
+			'ON CONFLICT (id) DO UPDATE SET updated_at = now();',
+		].join(' '),
+	);
+}
+
+function insertFailedPipelineStep(sourceId: string, step: string, tag = 'retry-seed'): void {
+	const runId = randomUUID();
+	db.runSql(
+		[
+			`INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at)`,
+			`VALUES ('${runId}', '${tag}', '{}'::jsonb, 'failed', now(), now());`,
+			`INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status, error_message, updated_at)`,
+			`VALUES ('${runId}', '${sourceId}', '${step}', 'failed', 'seeded failure', now());`,
+		].join(' '),
+	);
+}
+
+async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+async function apiPost(app: ApiApp, path: string, body: unknown): Promise<Response> {
+	return await app.request(`http://localhost${path}`, {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer test-api-key',
+			'Content-Type': 'application/json',
+			'X-Forwarded-For': '203.0.113.10',
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function readJsonCell(sql: string): Record<string, unknown> {
+	return JSON.parse(db.runSql(sql)) as Record<string, unknown>;
+}
+
+describe('Spec 71 — Async Pipeline API Routes', () => {
+	let app: { request: (input: string | Request, init?: RequestInit) => Promise<Response> };
+	let coreModule: typeof import('@mulder/core');
+	let workerModule: typeof import('@mulder/worker');
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+		buildPackage(CLI_DIR);
+
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode).toBe(0);
+
+		coreModule = await import(pathToFileURL(CORE_DIST).href);
+		workerModule = await import(pathToFileURL(WORKER_DIST).href);
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(() => {
+		cleanState();
+		cleanStorageFixtures();
+	});
+
+	afterAll(() => {
+		try {
+			cleanState();
+			cleanStorageFixtures();
+		} catch {
+			// Ignore cleanup failures.
+		}
+	});
+
+	it('QA-01: POST /api/pipeline/run accepts a source-scoped request and enqueues a pending job', async () => {
+		const sourceId = randomUUID();
+		insertSourceRow(sourceId);
+
+		const beforeJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const beforeRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
+
+		const response = await apiPost(app, '/api/pipeline/run', {
+			source_id: sourceId,
+			from: 'extract',
+			up_to: 'extract',
+			tag: 'api-run',
+		});
+
+		expect(response.status).toBe(202);
+		expect(response.headers.get('content-type')).toContain('application/json');
+		const body = await response.json();
+		expect(body).toMatchObject({
+			data: {
+				job_id: expect.any(String),
+				status: 'pending',
+				run_id: expect.any(String),
+			},
+			links: {
+				status: expect.stringMatching(/^\/api\/jobs\/[0-9a-f-]+$/i),
+			},
+		});
+
+		const afterJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const afterRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
+		expect(Number(afterJobs)).toBe(Number(beforeJobs) + 1);
+		expect(Number(afterRuns)).toBe(Number(beforeRuns) + 1);
+
+		const runRow = readJsonCell(
+			`SELECT row_to_json(run_row)::text FROM (
+				SELECT id, tag, status, options
+				FROM pipeline_runs
+				WHERE id = '${body.data.run_id}'
+			) AS run_row;`,
+		);
+		expect(runRow).toMatchObject({
+			id: body.data.run_id,
+			tag: 'api-run',
+			status: 'running',
+		});
+		expect((runRow.options as Record<string, unknown>).source_id).toBe(sourceId);
+		expect((runRow.options as Record<string, unknown>).from).toBe('extract');
+		expect((runRow.options as Record<string, unknown>).up_to).toBe('extract');
+
+		const jobRow = readJsonCell(`SELECT payload::text FROM jobs WHERE id = '${body.data.job_id}';`);
+		expect(jobRow).toMatchObject({
+			sourceId,
+			runId: body.data.run_id,
+			from: 'extract',
+			upTo: 'extract',
+			tag: 'api-run',
+			force: false,
+		});
+	});
+
+	it('QA-02: malformed pipeline-run requests fail at the HTTP edge', async () => {
+		const sourceId = randomUUID();
+		insertSourceRow(sourceId);
+
+		const beforeJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const response = await apiPost(app, '/api/pipeline/run', {
+			source_id: sourceId,
+			from: 'graph',
+			up_to: 'extract',
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+				message: 'Invalid request',
+			},
+		});
+		expect(db.runSql('SELECT COUNT(*) FROM jobs;')).toBe(beforeJobs);
+		expect(db.runSql('SELECT COUNT(*) FROM pipeline_runs;')).toBe('0');
+	});
+
+	it('QA-03: unknown sources are rejected without queue side effects', async () => {
+		const sourceId = randomUUID();
+		const beforeJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const beforeRuns = db.runSql('SELECT COUNT(*) FROM pipeline_runs;');
+
+		const response = await apiPost(app, '/api/pipeline/run', {
+			source_id: sourceId,
+			from: 'extract',
+			up_to: 'extract',
+		});
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'PIPELINE_SOURCE_NOT_FOUND',
+			},
+		});
+		expect(db.runSql('SELECT COUNT(*) FROM jobs;')).toBe(beforeJobs);
+		expect(db.runSql('SELECT COUNT(*) FROM pipeline_runs;')).toBe(beforeRuns);
+	});
+
+	it('QA-04: POST /api/pipeline/retry only accepts retryable failed work', async () => {
+		const sourceId = randomUUID();
+		insertSourceRow(sourceId);
+
+		const beforeJobs = db.runSql('SELECT COUNT(*) FROM jobs;');
+		const response = await apiPost(app, '/api/pipeline/retry', {
+			source_id: sourceId,
+		});
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'PIPELINE_RETRY_CONFLICT',
+			},
+		});
+		expect(db.runSql('SELECT COUNT(*) FROM jobs;')).toBe(beforeJobs);
+	});
+
+	it('QA-05: retry requests enqueue a forced single-step pipeline job', async () => {
+		const sourceId = randomUUID();
+		insertSourceRow(sourceId);
+		insertFailedPipelineStep(sourceId, 'extract');
+
+		const response = await apiPost(app, '/api/pipeline/retry', {
+			source_id: sourceId,
+			step: 'segment',
+			tag: 'retry-api',
+		});
+
+		expect(response.status).toBe(202);
+		const body = await response.json();
+		expect(body.data.status).toBe('pending');
+		expect(body.links.status).toMatch(/^\/api\/jobs\/[0-9a-f-]+$/i);
+
+		const jobRow = readJsonCell(`SELECT payload::text FROM jobs WHERE id = '${body.data.job_id}';`);
+		expect(jobRow).toMatchObject({
+			sourceId,
+			from: 'segment',
+			upTo: 'segment',
+			tag: 'retry-api',
+			force: true,
+		});
+
+		const runRow = readJsonCell(
+			`SELECT row_to_json(run_row)::text FROM (
+				SELECT id, tag, status, options
+				FROM pipeline_runs
+				WHERE id = '${body.data.run_id}'
+			) AS run_row;`,
+		);
+		expect(runRow).toMatchObject({
+			tag: 'retry-api',
+			status: 'running',
+		});
+		expect((runRow.options as Record<string, unknown>).source_id).toBe(sourceId);
+		expect((runRow.options as Record<string, unknown>).step).toBe('segment');
+		expect((runRow.options as Record<string, unknown>).retry).toBe(true);
+	});
+
+	it('QA-06: the worker can dequeue and execute an API-created pipeline job', async () => {
+		const ingest = runCli(['ingest', NATIVE_TEXT_PDF], { timeout: 240_000 });
+		expect(ingest.exitCode).toBe(0);
+
+		const sourceRow = db.runSql(
+			"SELECT id FROM sources WHERE filename = 'native-text-sample.pdf' ORDER BY created_at DESC LIMIT 1;",
+		);
+		expect(sourceRow).toMatch(/^[0-9a-f-]{36}$/);
+
+		const response = await apiPost(app, '/api/pipeline/run', {
+			source_id: sourceRow,
+			from: 'extract',
+			up_to: 'extract',
+			tag: 'worker-integration',
+		});
+		expect(response.status).toBe(202);
+		const body = await response.json();
+
+		const workerConfig = coreModule.loadConfig(EXAMPLE_CONFIG);
+		const workerLogger = coreModule.createLogger();
+		const runtimeContext: WorkerRuntimeContext = {
+			config: workerConfig,
+			services: coreModule.createServiceRegistry(workerConfig, workerLogger),
+			pool: coreModule.getWorkerPool(workerConfig.gcp.cloud_sql),
+			logger: workerLogger,
+		};
+
+		const result = await workerModule.processNextJob(runtimeContext, 'worker-qa-71');
+		expect(result.state).toBe('completed');
+		expect(result.job?.id).toBe(body.data.job_id);
+
+		const jobState = db.runSql(`SELECT status FROM jobs WHERE id = '${body.data.job_id}';`);
+		expect(jobState).toBe('completed');
+
+		const runState = db.runSql(`SELECT status FROM pipeline_runs WHERE id = '${body.data.run_id}';`);
+		expect(runState).toBe('completed');
+
+		const pipelineRunSource = db.runSql(
+			`SELECT current_step || '|' || status FROM pipeline_run_sources
+			 WHERE run_id = '${body.data.run_id}' AND source_id = '${sourceRow}';`,
+		);
+		expect(pipelineRunSource).toBe('extract|completed');
+	});
+});


### PR DESCRIPTION
## Summary
- add authenticated async pipeline run/retry API routes with queue-backed acceptance responses
- bridge API-created pipeline jobs into the worker/orchestrator path and harden acceptance/retry edge cases
- add spec coverage for route acceptance, retry gating, and worker execution

## Traceability
- Spec: `docs/specs/71_async_pipeline_api_routes.spec.md`
- Roadmap: `M7-H5`
- Closes #178
