### PR TITLE
fix: route pipeline_run jobs through orchestrator

### DIFF
--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -505,18 +505,6 @@ export const dispatchJob: WorkerDispatchFn = async (job, context) => {
 		}
 		case 'pipeline_run': {
 			const payload = parsePipelineRunPayload(job);
-			if (!payload.runId) {
-				const result = await executeExtract(
-					{ sourceId: payload.sourceId, force: payload.force ?? false },
-					config,
-					services,
-					pool,
-					log,
-				);
-				assertStepSucceeded(job, 'pipeline_run', result.status);
-				return;
-			}
-
 			const runOptions: PipelineRunOptions = {
 				sourceIds: [payload.sourceId],
 				force: payload.force ?? false,


### PR DESCRIPTION
## Summary
- remove the extract-only fallback for `pipeline_run` worker jobs
- ensure `pipeline_run` payloads always execute through the orchestrator path
- keep worker and async pipeline API contract coverage green

## Verification
- `pnpm turbo run typecheck --filter=@mulder/worker --filter=@mulder/tests`
- `npx vitest run tests/specs/68_worker_loop.test.ts tests/specs/71_pipeline_api_routes.test.ts --reporter=verbose`
