### PR TITLE
[API] Add job status routes for M7-H6

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { createRequestContextMiddleware } from './middleware/request-context.js'
 import { createRequestIdMiddleware } from './middleware/request-id.js';
 import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
 import { registerHealthRoute } from './routes/health.js';
+import { registerJobRoutes } from './routes/jobs.js';
 import { registerPipelineRoutes } from './routes/pipeline.js';
 
 export interface AppOptions {
@@ -30,6 +31,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	app.use('*', createRateLimitMiddleware(apiConfig));
 
 	registerHealthRoute(app);
+	registerJobRoutes(app);
 	registerPipelineRoutes(app);
 
 	return app;

--- a/apps/api/src/lib/job-status.ts
+++ b/apps/api/src/lib/job-status.ts
@@ -1,0 +1,172 @@
+import type { Job, PipelineRun, PipelineRunSource, PipelineRunSourceStatus } from '@mulder/core';
+import {
+	countJobs,
+	countPipelineRunSourcesByStatus,
+	DATABASE_ERROR_CODES,
+	DatabaseError,
+	findJobById,
+	findJobs,
+	findPipelineRunById,
+	findPipelineRunSourcesByRunId,
+	getWorkerPool,
+	loadConfig,
+	PIPELINE_ERROR_CODES,
+	PipelineError,
+} from '@mulder/core';
+import type { Pool } from 'pg';
+import type { JobDetailResponse, JobListQuery, JobListResponse } from '../routes/jobs.schemas.js';
+
+interface JobStatusContext {
+	pool: Pool;
+}
+
+interface JobProgress {
+	run_id: string;
+	run_status: PipelineRun['status'];
+	source_counts: Record<PipelineRunSourceStatus, number>;
+	sources: Array<{
+		source_id: string;
+		current_step: string;
+		status: PipelineRunSource['status'];
+		error_message: string | null;
+		updated_at: string;
+	}>;
+}
+
+function resolveContext(): JobStatusContext {
+	const config = loadConfig();
+	if (!config.gcp?.cloud_sql) {
+		throw new PipelineError(
+			'GCP cloud_sql configuration is required for job status routes',
+			PIPELINE_ERROR_CODES.PIPELINE_WRONG_STATUS,
+			{
+				context: { configPath: process.env.MULDER_CONFIG ?? 'mulder.config.yaml' },
+			},
+		);
+	}
+
+	return {
+		pool: getWorkerPool(config.gcp.cloud_sql),
+	};
+}
+
+function toIsoString(value: Date | null): string | null {
+	return value ? value.toISOString() : null;
+}
+
+function resolveRunId(payload: Job['payload']): string | null {
+	const candidate = payload.runId ?? payload.run_id;
+	return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
+
+function mapJobSummary(job: Job): JobListResponse['data'][number] {
+	return {
+		id: job.id,
+		type: job.type,
+		status: job.status,
+		attempts: job.attempts,
+		max_attempts: job.maxAttempts,
+		worker_id: job.workerId,
+		created_at: job.createdAt.toISOString(),
+		started_at: toIsoString(job.startedAt),
+		finished_at: toIsoString(job.finishedAt),
+		links: {
+			self: `/api/jobs/${job.id}`,
+		},
+	};
+}
+
+function mapJobDetail(job: Job): JobDetailResponse['data']['job'] {
+	return {
+		id: job.id,
+		type: job.type,
+		status: job.status,
+		attempts: job.attempts,
+		max_attempts: job.maxAttempts,
+		worker_id: job.workerId,
+		created_at: job.createdAt.toISOString(),
+		started_at: toIsoString(job.startedAt),
+		finished_at: toIsoString(job.finishedAt),
+		error_log: job.errorLog,
+		payload: job.payload,
+	};
+}
+
+async function resolveProgress(pool: Pool, job: Job): Promise<JobProgress | null> {
+	if (job.type !== 'pipeline_run') {
+		return null;
+	}
+
+	const runId = resolveRunId(job.payload);
+	if (!runId) {
+		return null;
+	}
+
+	const [run, sourceCounts] = await Promise.all([
+		findPipelineRunById(pool, runId),
+		countPipelineRunSourcesByStatus(pool, runId),
+	]);
+
+	if (!run) {
+		return null;
+	}
+
+	const sources = await findPipelineRunSourcesByRunId(pool, runId);
+
+	return {
+		run_id: run.id,
+		run_status: run.status,
+		source_counts: sourceCounts,
+		sources: sources.map((source) => ({
+			source_id: source.sourceId,
+			current_step: source.currentStep,
+			status: source.status,
+			error_message: source.errorMessage,
+			updated_at: source.updatedAt.toISOString(),
+		})),
+	};
+}
+
+export async function listRecentJobs(input: JobListQuery): Promise<JobListResponse> {
+	const { pool } = resolveContext();
+	const filter = {
+		type: input.type,
+		status: input.status,
+		workerId: input.worker_id,
+	};
+	const [count, jobs] = await Promise.all([
+		countJobs(pool, filter),
+		findJobs(pool, {
+			...filter,
+			limit: input.limit,
+		}),
+	]);
+
+	return {
+		data: jobs.map(mapJobSummary),
+		meta: {
+			count,
+			limit: input.limit,
+		},
+	};
+}
+
+export async function getJobStatusById(id: string): Promise<JobDetailResponse> {
+	const { pool } = resolveContext();
+	const job = await findJobById(pool, id);
+
+	if (!job) {
+		throw new DatabaseError(`Job not found: ${id}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
+			context: { id },
+		});
+	}
+
+	return {
+		data: {
+			job: mapJobDetail(job),
+			progress: await resolveProgress(pool, job),
+		},
+	};
+}
+
+export { mapJobDetail, mapJobSummary };

--- a/apps/api/src/routes/jobs.schemas.ts
+++ b/apps/api/src/routes/jobs.schemas.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+export const JOB_STATUS_VALUES = ['pending', 'running', 'completed', 'failed', 'dead_letter'] as const;
+export const PIPELINE_RUN_STATUS_VALUES = ['running', 'completed', 'partial', 'failed'] as const;
+export const PIPELINE_RUN_SOURCE_STATUS_VALUES = ['pending', 'processing', 'completed', 'failed'] as const;
+
+export const JobStatusSchema = z.enum(JOB_STATUS_VALUES);
+export const PipelineRunStatusSchema = z.enum(PIPELINE_RUN_STATUS_VALUES);
+export const PipelineRunSourceStatusSchema = z.enum(PIPELINE_RUN_SOURCE_STATUS_VALUES);
+
+export const JobListQuerySchema = z.object({
+	status: JobStatusSchema.optional(),
+	type: z.string().min(1).max(128).optional(),
+	worker_id: z.string().min(1).max(128).optional(),
+	limit: z.coerce.number().int().positive().max(100).optional().default(20),
+});
+
+export const JobSummarySchema = z.object({
+	id: z.string().uuid(),
+	type: z.string(),
+	status: JobStatusSchema,
+	attempts: z.number().int().nonnegative(),
+	max_attempts: z.number().int().positive(),
+	worker_id: z.string().nullable(),
+	created_at: z.string(),
+	started_at: z.string().nullable(),
+	finished_at: z.string().nullable(),
+	links: z.object({
+		self: z.string().regex(/^\/api\/jobs\/[0-9a-f-]+$/i),
+	}),
+});
+
+export const JobListResponseSchema = z.object({
+	data: z.array(JobSummarySchema),
+	meta: z.object({
+		count: z.number().int().nonnegative(),
+		limit: z.number().int().positive(),
+	}),
+});
+
+export const JobDetailSchema = z.object({
+	id: z.string().uuid(),
+	type: z.string(),
+	status: JobStatusSchema,
+	attempts: z.number().int().nonnegative(),
+	max_attempts: z.number().int().positive(),
+	worker_id: z.string().nullable(),
+	created_at: z.string(),
+	started_at: z.string().nullable(),
+	finished_at: z.string().nullable(),
+	error_log: z.string().nullable(),
+	payload: z.record(z.string(), z.unknown()),
+});
+
+export const JobProgressSourceSchema = z.object({
+	source_id: z.string().uuid(),
+	current_step: z.string(),
+	status: PipelineRunSourceStatusSchema,
+	error_message: z.string().nullable(),
+	updated_at: z.string(),
+});
+
+export const JobProgressSchema = z.object({
+	run_id: z.string().uuid(),
+	run_status: PipelineRunStatusSchema,
+	source_counts: z.object({
+		pending: z.number().int().nonnegative(),
+		processing: z.number().int().nonnegative(),
+		completed: z.number().int().nonnegative(),
+		failed: z.number().int().nonnegative(),
+	}),
+	sources: z.array(JobProgressSourceSchema),
+});
+
+export const JobDetailResponseSchema = z.object({
+	data: z.object({
+		job: JobDetailSchema,
+		progress: JobProgressSchema.nullable(),
+	}),
+});
+
+export type JobListQuery = z.infer<typeof JobListQuerySchema>;
+export type JobListResponse = z.infer<typeof JobListResponseSchema>;
+export type JobDetailResponse = z.infer<typeof JobDetailResponseSchema>;

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,0 +1,28 @@
+import type { Hono } from 'hono';
+import { getJobStatusById, listRecentJobs } from '../lib/job-status.js';
+import { JobDetailResponseSchema, JobListQuerySchema, JobListResponseSchema } from './jobs.schemas.js';
+
+function readJobListQuery(url: string): Record<string, string | undefined> {
+	const searchParams = new URL(url).searchParams;
+	return {
+		status: searchParams.get('status') ?? undefined,
+		type: searchParams.get('type') ?? undefined,
+		worker_id: searchParams.get('worker_id') ?? undefined,
+		limit: searchParams.get('limit') ?? undefined,
+	};
+}
+
+export function registerJobRoutes(app: Hono): void {
+	app.get('/api/jobs', async (c) => {
+		const query = JobListQuerySchema.parse(readJobListQuery(c.req.url));
+		const response = await listRecentJobs(query);
+		JobListResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/jobs/:id', async (c) => {
+		const response = await getJobStatusById(c.req.param('id'));
+		JobDetailResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -188,7 +188,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
-| ⚪ | H6 | Job status API | §10.6 |
+| 🟢 | H6 | Job status API | §10.6 |
 | ⚪ | H7 | Search API routes (sync) | §10.6, §5 |
 | ⚪ | H8 | Entity API routes (sync) | §10.6 |
 | ⚪ | H9 | Evidence API routes (sync) | §10.6 |

--- a/docs/specs/72_job_status_api.spec.md
+++ b/docs/specs/72_job_status_api.spec.md
@@ -1,0 +1,205 @@
+---
+spec: "72"
+title: "Job Status API"
+roadmap_step: M7-H6
+functional_spec: ["§10.6"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/181"
+created: 2026-04-14
+---
+
+# Spec 72: Job Status API
+
+## 1. Objective
+
+Expose Mulder's queued work state over authenticated HTTP so API clients can poll accepted pipeline jobs and inspect recent queue activity without shelling into the worker CLI. Per `§10.6`, the API stays a pure job producer/read surface: `POST /api/pipeline/*` creates jobs, while `GET /api/jobs` and `GET /api/jobs/:id` report status, progress, and failures from the existing `jobs`, `pipeline_runs`, and `pipeline_run_sources` tables.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H6` — Job status API
+- **Target:** `apps/api/src/app.ts`, `apps/api/src/routes/jobs.schemas.ts`, `apps/api/src/routes/jobs.ts`, `apps/api/src/lib/job-status.ts`, `tests/specs/72_job_status_api.test.ts`
+- **In scope:** authenticated read-only routes for `GET /api/jobs` and `GET /api/jobs/:id`; query validation for recent-job filters; JSON response shaping for queue summaries and per-job detail; pipeline-aware detail enrichment using `runId`/`run_id` payload fields plus the existing pipeline-run repositories when available; not-found handling for unknown jobs; and black-box tests proving list/detail behavior against real queue rows
+- **Out of scope:** creating, retrying, cancelling, or mutating jobs; new worker behavior or queue schema changes; search/entity/evidence/document routes (`M7-H7` through `M7-H10`); streaming/SSE/WebSocket updates; and any UI work (`M7-H11`)
+- **Constraints:** keep both routes protected by the existing middleware/auth stack; reuse the shipped repository layer instead of ad hoc SQL in route handlers; keep the endpoints database-only with no inline pipeline execution; preserve the accepted-response status link contract from Spec 71; and make the detail route externally inspectable even while a worker is currently processing the job
+
+## 3. Dependencies
+
+- **Requires:** Spec 67 (`M7-H1`) job queue repository, Spec 68 (`M7-H2`) worker loop status semantics, Spec 69 (`M7-H3`) Hono server scaffold, Spec 70 (`M7-H4`) API middleware stack, and Spec 71 (`M7-H5`) async pipeline API routes that already return `/api/jobs/{id}` links
+- **Blocks:** no later roadmap step is strictly blocked, but this step completes the async API polling contract promised by `M7-H5` and provides the shared queue-inspection surface future API consumers can rely on
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/jobs.schemas.ts`** — defines the query schemas and response envelopes for job list/detail routes
+2. **`apps/api/src/lib/job-status.ts`** — owns repository-backed helpers that read job rows, derive optional pipeline-run progress, and map them into API-facing DTOs
+3. **`apps/api/src/routes/jobs.ts`** — registers `GET /api/jobs` and `GET /api/jobs/:id` on the Hono app
+4. **`apps/api/src/app.ts`** — mounts the jobs route group beneath the existing middleware stack
+5. **`tests/specs/72_job_status_api.test.ts`** — black-box verification for authenticated list/detail behavior, filters, not-found handling, and pipeline-aware progress output
+
+### 4.2 Route Contract
+
+#### `GET /api/jobs`
+
+Purpose: list recent jobs for polling/inspection.
+
+Query parameters:
+
+- `status` — optional job status filter (`pending | running | completed | failed | dead_letter`)
+- `type` — optional job type filter (for example `pipeline_run`)
+- `worker_id` — optional filter for active worker ownership
+- `limit` — optional integer cap for returned rows; defaults to a safe recent-jobs window
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "type": "pipeline_run",
+      "status": "running",
+      "attempts": 1,
+      "max_attempts": 3,
+      "worker_id": "worker-host-123",
+      "created_at": "2026-04-14T12:00:00.000Z",
+      "started_at": "2026-04-14T12:00:03.000Z",
+      "finished_at": null,
+      "links": {
+        "self": "/api/jobs/uuid"
+      }
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "limit": 20
+  }
+}
+```
+
+Rules:
+
+- rows are ordered newest-first, matching the repository inspection order from Spec 67
+- filters only narrow the result set; they never mutate queue state
+- the list route is intentionally lightweight and does not inline full pipeline-run source arrays for every item
+
+#### `GET /api/jobs/:id`
+
+Purpose: inspect one job's current queue state plus any pipeline progress tied to it.
+
+Response shape:
+
+```json
+{
+  "data": {
+    "job": {
+      "id": "uuid",
+      "type": "pipeline_run",
+      "status": "running",
+      "attempts": 1,
+      "max_attempts": 3,
+      "worker_id": "worker-host-123",
+      "created_at": "2026-04-14T12:00:00.000Z",
+      "started_at": "2026-04-14T12:00:03.000Z",
+      "finished_at": null,
+      "error_log": null,
+      "payload": {
+        "sourceId": "source-uuid",
+        "runId": "run-uuid"
+      }
+    },
+    "progress": {
+      "run_id": "run-uuid",
+      "run_status": "running",
+      "source_counts": {
+        "pending": 0,
+        "processing": 1,
+        "completed": 0,
+        "failed": 0
+      },
+      "sources": [
+        {
+          "source_id": "source-uuid",
+          "current_step": "extract",
+          "status": "processing",
+          "error_message": null,
+          "updated_at": "2026-04-14T12:00:05.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- unknown job IDs return a Mulder not-found response and never leak an empty success envelope
+- when the job payload does not reference a valid pipeline run, `progress` is `null`
+- failed/dead-letter jobs expose `error_log` so clients can see the worker-visible failure reason
+- detail reads remain read-only and must work for pending, running, terminal, and reaped job states
+
+### 4.3 Integration Points
+
+- Spec 71's accepted-response `links.status` path resolves to a real detail endpoint once this step ships
+- queue reads come from the existing `findJobById`, `findJobs`, and `countJobs` repository helpers
+- pipeline progress comes from the existing `findPipelineRunById`, `findPipelineRunSourcesByRunId`, and `countPipelineRunSourcesByStatus` helpers when a job payload carries a pipeline run ID
+- the worker/runtime remains the owner of queue mutations; these routes are inspection-only
+
+### 4.4 Implementation Phases
+
+**Phase 1: DTOs and repository-backed readers**
+- add the list/detail schemas
+- add a small API helper that maps job rows into HTTP-facing summaries and resolves optional pipeline progress
+
+**Phase 2: Route registration**
+- register `GET /api/jobs` and `GET /api/jobs/:id`
+- mount the routes in the Hono app without weakening the existing middleware protections
+
+**Phase 3: Black-box QA**
+- add spec tests for list filtering, detail output, not-found behavior, and pipeline progress enrichment
+- verify the API package still builds with the new route surface
+
+## 5. QA Contract
+
+1. **QA-01: `GET /api/jobs` lists recent jobs newest-first with filter support**
+   - Given: a mix of queued jobs with different `status`, `type`, and `worker_id` values
+   - When: `GET /api/jobs` is called with and without query filters
+   - Then: the response is `200`, rows are ordered newest-first, and the filters narrow the result set correctly
+
+2. **QA-02: `GET /api/jobs/:id` returns exact queue state for a known job**
+   - Given: an existing job row in the `jobs` table
+   - When: `GET /api/jobs/:id` is called with that job ID
+   - Then: the response is `200` and includes the job's status, attempts, worker ownership, timestamps, payload, and error log fields as currently stored
+
+3. **QA-03: pipeline jobs expose run progress from existing tracking tables**
+   - Given: a `pipeline_run` job whose payload references a real `pipeline_runs` row and matching `pipeline_run_sources` rows
+   - When: `GET /api/jobs/:id` is called
+   - Then: the response includes `progress.run_id`, `progress.run_status`, per-status source counts, and the current source-step rows without inventing a second progress store
+
+4. **QA-04: non-pipeline jobs return `progress: null` rather than a broken synthetic object**
+   - Given: a non-`pipeline_run` job or a job whose payload does not resolve to a pipeline run
+   - When: `GET /api/jobs/:id` is called
+   - Then: the response still succeeds for the job detail and reports `progress` as `null`
+
+5. **QA-05: unknown jobs fail with a not-found JSON error**
+   - Given: a UUID that does not exist in the `jobs` table
+   - When: `GET /api/jobs/:id` is called
+   - Then: the API returns a Mulder JSON not-found response and does not emit a success envelope
+
+6. **QA-06: jobs routes stay behind the existing auth middleware**
+   - Given: the jobs routes are mounted in the API app
+   - When: either route is requested without a valid bearer token
+   - Then: the response is `401` and the route does not leak queue data
+
+7. **QA-07: the API package compiles with the new jobs route surface**
+   - Given: the jobs route files are wired into `@mulder/api`
+   - When: the package build/typecheck runs
+   - Then: the API package compiles successfully and the new route group is importable through the bootable app
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+None for direct third-party spend. These are read-only PostgreSQL-backed inspection endpoints, but they are still cost-sensitive operationally because polling can be frequent; the implementation must therefore remain lightweight, stay within the existing relaxed rate-limit tier, and avoid any inline GCP or LLM calls.

--- a/tests/specs/72_job_status_api.test.ts
+++ b/tests/specs/72_job_status_api.test.ts
@@ -1,0 +1,542 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 120_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		['DELETE FROM jobs', 'DELETE FROM pipeline_run_sources', 'DELETE FROM pipeline_runs', 'DELETE FROM sources'].join(
+			'; ',
+		),
+	);
+}
+
+function insertSourceRow(sourceId: string): void {
+	const fileHash = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
+	db.runSql(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata)',
+			`VALUES ('${sourceId}', 'route-test.pdf', '/tmp/route-test.pdf', '${fileHash}', 1, true, 1, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb)`,
+			'ON CONFLICT (id) DO UPDATE SET updated_at = now();',
+		].join(' '),
+	);
+}
+
+function insertPipelineRun(runId: string, status: 'running' | 'completed' | 'partial' | 'failed'): void {
+	db.runSql(
+		[
+			`INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at)`,
+			`VALUES ('${runId}', 'status-test', '{}'::jsonb, '${status}', TIMESTAMPTZ '2026-04-14T12:00:02.000Z',`,
+			status === 'running' ? 'NULL' : `TIMESTAMPTZ '2026-04-14T12:00:06.000Z'`,
+			');',
+		].join(' '),
+	);
+}
+
+function insertPipelineRunSource(input: {
+	runId: string;
+	sourceId: string;
+	currentStep: string;
+	status: 'pending' | 'processing' | 'completed' | 'failed';
+	errorMessage?: string | null;
+	updatedAt: string;
+}): void {
+	db.runSql(
+		[
+			'INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status, error_message, updated_at)',
+			`VALUES ('${input.runId}', '${input.sourceId}', '${input.currentStep}', '${input.status}',`,
+			input.errorMessage === null || input.errorMessage === undefined ? 'NULL' : `'${input.errorMessage}'`,
+			`, TIMESTAMPTZ '${input.updatedAt}')`,
+			'ON CONFLICT (run_id, source_id) DO UPDATE SET current_step = EXCLUDED.current_step, status = EXCLUDED.status, error_message = EXCLUDED.error_message, updated_at = EXCLUDED.updated_at;',
+		].join(' '),
+	);
+}
+
+function insertJob(input: {
+	id: string;
+	type: string;
+	status: 'pending' | 'running' | 'completed' | 'failed' | 'dead_letter';
+	attempts: number;
+	maxAttempts: number;
+	workerId: string | null;
+	createdAt: string;
+	startedAt?: string | null;
+	finishedAt?: string | null;
+	errorLog?: string | null;
+	payload: Record<string, unknown>;
+}): void {
+	const startedAt = input.startedAt === undefined ? null : input.startedAt;
+	const finishedAt = input.finishedAt === undefined ? null : input.finishedAt;
+	const errorLog = input.errorLog === undefined ? null : input.errorLog;
+
+	db.runSql(
+		[
+			'INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, error_log, worker_id, created_at, started_at, finished_at)',
+			`VALUES ('${input.id}', '${input.type}', '${JSON.stringify(input.payload)}'::jsonb, '${input.status}', ${input.attempts}, ${input.maxAttempts},`,
+			errorLog === null ? 'NULL' : `'${errorLog}'`,
+			`, ${input.workerId === null ? 'NULL' : `'${input.workerId}'`}, TIMESTAMPTZ '${input.createdAt}',`,
+			startedAt === null ? 'NULL' : `TIMESTAMPTZ '${startedAt}'`,
+			`, ${finishedAt === null ? 'NULL' : `TIMESTAMPTZ '${finishedAt}'`})`,
+			'ON CONFLICT (id) DO UPDATE SET type = EXCLUDED.type, payload = EXCLUDED.payload, status = EXCLUDED.status, attempts = EXCLUDED.attempts, max_attempts = EXCLUDED.max_attempts, error_log = EXCLUDED.error_log, worker_id = EXCLUDED.worker_id, created_at = EXCLUDED.created_at, started_at = EXCLUDED.started_at, finished_at = EXCLUDED.finished_at;',
+		].join(' '),
+	);
+}
+
+async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+function authorizedHeaders(): HeadersInit {
+	return {
+		Authorization: 'Bearer test-api-key',
+		'X-Forwarded-For': '203.0.113.10',
+	};
+}
+
+describe('Spec 72 — Job Status API', () => {
+	let app: { request: (input: string | Request, init?: RequestInit) => Promise<Response> };
+	let deadLetterJobId: string;
+	let runningJobId: string;
+	let pendingJobId: string;
+	let runId: string;
+	let sourceId: string;
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+		buildPackage(CLI_DIR);
+
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode).toBe(0);
+
+		await import(pathToFileURL(CORE_DIST).href);
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(() => {
+		deadLetterJobId = randomUUID();
+		runningJobId = randomUUID();
+		pendingJobId = randomUUID();
+		runId = randomUUID();
+		sourceId = randomUUID();
+		cleanState();
+		insertSourceRow(sourceId);
+		insertPipelineRun(runId, 'running');
+		insertPipelineRunSource({
+			runId,
+			sourceId,
+			currentStep: 'extract',
+			status: 'processing',
+			updatedAt: '2026-04-14T12:00:05.000Z',
+		});
+		insertJob({
+			id: deadLetterJobId,
+			type: 'manual_review',
+			status: 'dead_letter',
+			attempts: 3,
+			maxAttempts: 3,
+			workerId: 'worker-host-999',
+			createdAt: '2026-04-14T12:03:00.000Z',
+			startedAt: '2026-04-14T12:03:10.000Z',
+			finishedAt: '2026-04-14T12:03:20.000Z',
+			errorLog: 'worker crashed before persisting output',
+			payload: {},
+		});
+		insertJob({
+			id: runningJobId,
+			type: 'pipeline_run',
+			status: 'running',
+			attempts: 1,
+			maxAttempts: 3,
+			workerId: 'worker-host-123',
+			createdAt: '2026-04-14T12:02:00.000Z',
+			startedAt: '2026-04-14T12:02:03.000Z',
+			finishedAt: null,
+			payload: {
+				sourceId,
+				runId,
+			},
+		});
+		insertJob({
+			id: pendingJobId,
+			type: 'pipeline_run',
+			status: 'pending',
+			attempts: 0,
+			maxAttempts: 3,
+			workerId: null,
+			createdAt: '2026-04-14T12:01:00.000Z',
+			payload: {
+				sourceId,
+				runId,
+			},
+		});
+	});
+
+	afterAll(() => {
+		try {
+			cleanState();
+		} catch {
+			// Ignore cleanup failures.
+		}
+	});
+
+	it('QA-01: lists recent jobs newest-first with filter support', async () => {
+		const response = await app.request('http://localhost/api/jobs', {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			data: [
+				{
+					id: deadLetterJobId,
+					type: 'manual_review',
+					status: 'dead_letter',
+					attempts: 3,
+					max_attempts: 3,
+					worker_id: 'worker-host-999',
+					created_at: '2026-04-14T12:03:00.000Z',
+					started_at: '2026-04-14T12:03:10.000Z',
+					finished_at: '2026-04-14T12:03:20.000Z',
+					links: {
+						self: `/api/jobs/${deadLetterJobId}`,
+					},
+				},
+				{
+					id: runningJobId,
+					type: 'pipeline_run',
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					worker_id: 'worker-host-123',
+					created_at: '2026-04-14T12:02:00.000Z',
+					started_at: '2026-04-14T12:02:03.000Z',
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${runningJobId}`,
+					},
+				},
+				{
+					id: pendingJobId,
+					type: 'pipeline_run',
+					status: 'pending',
+					attempts: 0,
+					max_attempts: 3,
+					worker_id: null,
+					created_at: '2026-04-14T12:01:00.000Z',
+					started_at: null,
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${pendingJobId}`,
+					},
+				},
+			],
+			meta: {
+				count: 3,
+				limit: 20,
+			},
+		});
+
+		const limited = await app.request('http://localhost/api/jobs?limit=1', {
+			headers: authorizedHeaders(),
+		});
+
+		expect(limited.status).toBe(200);
+		expect(await limited.json()).toEqual({
+			data: [
+				{
+					id: deadLetterJobId,
+					type: 'manual_review',
+					status: 'dead_letter',
+					attempts: 3,
+					max_attempts: 3,
+					worker_id: 'worker-host-999',
+					created_at: '2026-04-14T12:03:00.000Z',
+					started_at: '2026-04-14T12:03:10.000Z',
+					finished_at: '2026-04-14T12:03:20.000Z',
+					links: {
+						self: `/api/jobs/${deadLetterJobId}`,
+					},
+				},
+			],
+			meta: {
+				count: 3,
+				limit: 1,
+			},
+		});
+
+		const runningOnly = await app.request('http://localhost/api/jobs?status=running', {
+			headers: authorizedHeaders(),
+		});
+		expect(runningOnly.status).toBe(200);
+		expect(await runningOnly.json()).toEqual({
+			data: [
+				{
+					id: runningJobId,
+					type: 'pipeline_run',
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					worker_id: 'worker-host-123',
+					created_at: '2026-04-14T12:02:00.000Z',
+					started_at: '2026-04-14T12:02:03.000Z',
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${runningJobId}`,
+					},
+				},
+			],
+			meta: {
+				count: 1,
+				limit: 20,
+			},
+		});
+
+		const pipelineOnly = await app.request('http://localhost/api/jobs?type=pipeline_run', {
+			headers: authorizedHeaders(),
+		});
+		expect(pipelineOnly.status).toBe(200);
+		expect((await pipelineOnly.json()) as { meta: { count: number } }).toEqual({
+			data: [
+				{
+					id: runningJobId,
+					type: 'pipeline_run',
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					worker_id: 'worker-host-123',
+					created_at: '2026-04-14T12:02:00.000Z',
+					started_at: '2026-04-14T12:02:03.000Z',
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${runningJobId}`,
+					},
+				},
+				{
+					id: pendingJobId,
+					type: 'pipeline_run',
+					status: 'pending',
+					attempts: 0,
+					max_attempts: 3,
+					worker_id: null,
+					created_at: '2026-04-14T12:01:00.000Z',
+					started_at: null,
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${pendingJobId}`,
+					},
+				},
+			],
+			meta: {
+				count: 2,
+				limit: 20,
+			},
+		});
+
+		const workerOnly = await app.request('http://localhost/api/jobs?worker_id=worker-host-123', {
+			headers: authorizedHeaders(),
+		});
+		expect(workerOnly.status).toBe(200);
+		expect(await workerOnly.json()).toEqual({
+			data: [
+				{
+					id: runningJobId,
+					type: 'pipeline_run',
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					worker_id: 'worker-host-123',
+					created_at: '2026-04-14T12:02:00.000Z',
+					started_at: '2026-04-14T12:02:03.000Z',
+					finished_at: null,
+					links: {
+						self: `/api/jobs/${runningJobId}`,
+					},
+				},
+			],
+			meta: {
+				count: 1,
+				limit: 20,
+			},
+		});
+	});
+
+	it('QA-02: returns queue state and pipeline progress for a known job', async () => {
+		const response = await app.request(`http://localhost/api/jobs/${runningJobId}`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			data: {
+				job: {
+					id: runningJobId,
+					type: 'pipeline_run',
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					worker_id: 'worker-host-123',
+					created_at: '2026-04-14T12:02:00.000Z',
+					started_at: '2026-04-14T12:02:03.000Z',
+					finished_at: null,
+					error_log: null,
+					payload: {
+						sourceId,
+						runId,
+					},
+				},
+				progress: {
+					run_id: runId,
+					run_status: 'running',
+					source_counts: {
+						pending: 0,
+						processing: 1,
+						completed: 0,
+						failed: 0,
+					},
+					sources: [
+						{
+							source_id: sourceId,
+							current_step: 'extract',
+							status: 'processing',
+							error_message: null,
+							updated_at: '2026-04-14T12:00:05.000Z',
+						},
+					],
+				},
+			},
+		});
+	});
+
+	it('QA-03: failed and dead-letter jobs expose error_log while remaining inspectable', async () => {
+		const response = await app.request(`http://localhost/api/jobs/${deadLetterJobId}`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			data: {
+				job: {
+					id: deadLetterJobId,
+					type: 'manual_review',
+					status: 'dead_letter',
+					attempts: 3,
+					max_attempts: 3,
+					worker_id: 'worker-host-999',
+					created_at: '2026-04-14T12:03:00.000Z',
+					started_at: '2026-04-14T12:03:10.000Z',
+					finished_at: '2026-04-14T12:03:20.000Z',
+					error_log: 'worker crashed before persisting output',
+					payload: {},
+				},
+				progress: null,
+			},
+		});
+	});
+
+	it('QA-04: unknown jobs return a not-found JSON error', async () => {
+		const missingJobId = randomUUID();
+		const response = await app.request(`http://localhost/api/jobs/${missingJobId}`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'DB_NOT_FOUND',
+				message: `Job not found: ${missingJobId}`,
+				details: {
+					id: missingJobId,
+				},
+			},
+		});
+	});
+
+	it('QA-05: jobs routes stay behind the existing auth middleware', async () => {
+		const response = await app.request('http://localhost/api/jobs');
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- add authenticated `GET /api/jobs` and `GET /api/jobs/:id` routes for queue inspection
- expose pipeline progress for `pipeline_run` jobs via existing run-tracking tables
- add Spec 72 coverage and mark roadmap step `M7-H6` complete

## Verification

- `pnpm --filter @mulder/api build`
- `pnpm vitest run tests/specs/72_job_status_api.test.ts`

Closes #181
