### PR TITLE
Search API routes — M7-H7

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerJobRoutes } from './routes/jobs.js';
 import { registerPipelineRoutes } from './routes/pipeline.js';
+import { registerSearchRoute } from './routes/search.js';
 
 export interface AppOptions {
 	logger?: Logger;
@@ -33,6 +34,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	registerHealthRoute(app);
 	registerJobRoutes(app);
 	registerPipelineRoutes(app);
+	registerSearchRoute(app);
 
 	return app;
 }

--- a/apps/api/src/lib/pipeline-jobs.ts
+++ b/apps/api/src/lib/pipeline-jobs.ts
@@ -10,11 +10,11 @@ import {
 	PipelineError,
 	type PipelineStep,
 } from '@mulder/core';
-import type { Pool } from 'pg';
+import type { Pool, PoolClient } from 'pg';
 import type { PipelineRetryRequest, PipelineRunRequest } from '../routes/pipeline.schemas.js';
 import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
 
-type Queryable = Pick<Pool, 'query'>;
+type Queryable = Pool | PoolClient;
 
 type PipelineJobPayload = {
 	sourceId: string;
@@ -122,7 +122,7 @@ function buildRunOptions(input: {
 }
 
 async function requireSource(pool: Queryable, sourceId: string): Promise<Source> {
-	const source = await findSourceById(pool as Pool, sourceId);
+	const source = await findSourceById(pool, sourceId);
 	if (!source) {
 		throw new PipelineError(`Source not found: ${sourceId}`, PIPELINE_ERROR_CODES.PIPELINE_SOURCE_NOT_FOUND, {
 			context: { sourceId },
@@ -204,7 +204,7 @@ async function enqueuePipelineJob(
 		force: boolean;
 	},
 ): Promise<Job> {
-	return await enqueueJob(pool as Pool, {
+	return await enqueueJob(pool, {
 		type: 'pipeline_run',
 		payload: buildJobPayload(input),
 		maxAttempts: 3,
@@ -215,7 +215,7 @@ export async function createPipelineRunJob(input: PipelineRunRequest): Promise<P
 	const { pool } = resolveContext();
 	return await runInTransaction(pool, async (client) => {
 		const source = await requireSource(client, input.source_id);
-		const run = await createPipelineRun(client as Pool, {
+		const run = await createPipelineRun(client, {
 			tag: input.tag ?? null,
 			options: buildRunOptions({
 				sourceId: source.id,
@@ -242,9 +242,9 @@ export async function createPipelineRetryJob(input: PipelineRetryRequest): Promi
 	return await runInTransaction(pool, async (client) => {
 		const source = await requireSource(client, input.source_id);
 		await assertNoInFlightPipelineJob(client, source.id);
-		const latest = await findLatestPipelineRunSourceForSource(client as Pool, source.id);
+		const latest = await findLatestPipelineRunSourceForSource(client, source.id);
 		const step = deriveRetryStep(assertRetryableSource(source, latest), input.step);
-		const run = await createPipelineRun(client as Pool, {
+		const run = await createPipelineRun(client, {
 			tag: input.tag ?? null,
 			options: buildRunOptions({
 				sourceId: source.id,

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -1,0 +1,184 @@
+import { performance } from 'node:perf_hooks';
+import {
+	createChildLogger,
+	createServiceRegistry,
+	DATABASE_ERROR_CODES,
+	DatabaseError,
+	getQueryPool,
+	type Logger,
+	loadConfig,
+	type MulderConfig,
+	type Services,
+} from '@mulder/core';
+import { type HybridRetrievalResult, type HybridRetrieveOptions, hybridRetrieve } from '@mulder/retrieval';
+import type pg from 'pg';
+import type {
+	SearchConfidence,
+	SearchExplain,
+	SearchRequest,
+	SearchResponse,
+	SearchResult,
+} from '../routes/search.schemas.js';
+
+interface SearchContext {
+	config: MulderConfig;
+	pool: pg.Pool;
+	services: Services;
+}
+
+interface SearchExecutionInput extends SearchRequest {
+	no_rerank: boolean;
+}
+
+let cachedContext: SearchContext | null = null;
+let cachedConfigPath: string | null = null;
+
+function resolveConfigPath(): string {
+	return process.env.MULDER_CONFIG ?? 'mulder.config.yaml';
+}
+
+function resolveSearchContext(logger: Logger): SearchContext {
+	const configPath = resolveConfigPath();
+	if (cachedContext && cachedConfigPath === configPath) {
+		return cachedContext;
+	}
+
+	const config = loadConfig(configPath);
+	if (!config.gcp?.cloud_sql) {
+		throw new DatabaseError(
+			'GCP cloud_sql configuration is required for search routes',
+			DATABASE_ERROR_CODES.DB_CONNECTION_FAILED,
+			{
+				context: {
+					configPath,
+				},
+			},
+		);
+	}
+
+	const services = createServiceRegistry(config, logger);
+	const pool = getQueryPool(config.gcp.cloud_sql);
+
+	cachedContext = {
+		config,
+		pool,
+		services,
+	};
+	cachedConfigPath = configPath;
+
+	return cachedContext;
+}
+
+function mapSearchResultContribution(contribution: HybridRetrievalResult['results'][number]['contributions'][number]) {
+	return {
+		strategy: contribution.strategy,
+		rank: contribution.rank,
+		score: contribution.score,
+	};
+}
+
+function mapSearchResult(result: HybridRetrievalResult['results'][number]): SearchResult {
+	return {
+		chunk_id: result.chunkId,
+		story_id: result.storyId,
+		content: result.content,
+		score: result.score,
+		rerank_score: result.rerankScore,
+		rank: result.rank,
+		contributions: result.contributions.map(mapSearchResultContribution),
+		metadata: result.metadata ?? {},
+	};
+}
+
+function mapSearchConfidence(confidence: HybridRetrievalResult['confidence']): SearchConfidence {
+	return {
+		corpus_size: confidence.corpus_size,
+		taxonomy_status: confidence.taxonomy_status,
+		corroboration_reliability: confidence.corroboration_reliability,
+		graph_density: confidence.graph_density,
+		degraded: confidence.degraded,
+		message: confidence.message ?? null,
+	};
+}
+
+function mapSearchExplain(explain: HybridRetrievalResult['explain']): SearchExplain {
+	return {
+		counts: explain.counts,
+		skipped: explain.skipped,
+		failures: explain.failures,
+		seed_entity_ids: explain.seedEntityIds,
+		contributions:
+			explain.contributions?.map((item) => ({
+				chunk_id: item.chunkId,
+				rerank_score: item.rerankScore,
+				rrf_score: item.rrfScore,
+				strategies: item.strategies.map((strategy) => ({
+					strategy: strategy.strategy,
+					rank: strategy.rank,
+					score: strategy.score,
+				})),
+			})) ?? [],
+	};
+}
+
+export function buildSearchResponse(result: HybridRetrievalResult): SearchResponse {
+	return {
+		data: {
+			query: result.query,
+			strategy: result.strategy,
+			top_k: result.topK,
+			results: result.results.map(mapSearchResult),
+			confidence: mapSearchConfidence(result.confidence),
+			explain: mapSearchExplain(result.explain),
+		},
+	};
+}
+
+function buildRetrieveOptions(input: SearchExecutionInput): HybridRetrieveOptions {
+	return {
+		strategy: input.strategy,
+		topK: input.top_k,
+		noRerank: input.no_rerank,
+		explain: input.explain,
+	};
+}
+
+export async function runSearch(input: SearchExecutionInput, logger: Logger): Promise<SearchResponse> {
+	const requestLogger = createChildLogger(logger, {
+		module: 'api',
+		route: 'search',
+		strategy: input.strategy ?? 'hybrid',
+		top_k: input.top_k ?? null,
+		no_rerank: input.no_rerank,
+		explain: input.explain,
+	});
+	const startedAt = performance.now();
+	const context = resolveSearchContext(requestLogger);
+	const result = await hybridRetrieve(
+		context.pool,
+		context.services.embedding,
+		context.services.llm,
+		context.config,
+		input.query,
+		buildRetrieveOptions(input),
+	);
+	const response = buildSearchResponse(result);
+
+	requestLogger.info(
+		{
+			strategy: response.data.strategy,
+			top_k: response.data.top_k,
+			no_rerank: input.no_rerank,
+			result_count: response.data.results.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'search request completed',
+	);
+
+	return response;
+}
+
+export function resetSearchContextForTests(): void {
+	cachedContext = null;
+	cachedConfigPath = null;
+}

--- a/apps/api/src/routes/search.schemas.ts
+++ b/apps/api/src/routes/search.schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const SEARCH_RETRIEVAL_STRATEGY_VALUES = ['vector', 'fulltext', 'graph'] as const;
+export const SEARCH_STRATEGY_MODE_VALUES = ['vector', 'fulltext', 'graph', 'hybrid'] as const;
+
+export const SearchRetrievalStrategySchema = z.enum(SEARCH_RETRIEVAL_STRATEGY_VALUES);
+export const SearchStrategyModeSchema = z.enum(SEARCH_STRATEGY_MODE_VALUES);
+
+export const SearchRequestSchema = z.object({
+	query: z.string().trim().min(1),
+	strategy: SearchStrategyModeSchema.optional(),
+	top_k: z.number().int().positive().optional(),
+	explain: z.boolean().optional().default(false),
+});
+
+export const SearchResultContributionSchema = z.object({
+	strategy: SearchRetrievalStrategySchema,
+	rank: z.number().int().positive(),
+	score: z.number(),
+});
+
+export const SearchResultSchema = z.object({
+	chunk_id: z.string().uuid(),
+	story_id: z.string().uuid(),
+	content: z.string(),
+	score: z.number(),
+	rerank_score: z.number(),
+	rank: z.number().int().positive(),
+	contributions: z.array(SearchResultContributionSchema),
+	metadata: z.record(z.string(), z.unknown()),
+});
+
+export const SearchConfidenceSchema = z.object({
+	corpus_size: z.number().int().nonnegative(),
+	taxonomy_status: z.enum(['not_started', 'bootstrapping', 'active', 'mature']),
+	corroboration_reliability: z.enum(['insufficient', 'low', 'moderate', 'high']),
+	graph_density: z.number(),
+	degraded: z.boolean(),
+	message: z.string().nullable(),
+});
+
+export const SearchExplainContributionStrategySchema = z.object({
+	strategy: SearchRetrievalStrategySchema,
+	rank: z.number().int().positive(),
+	score: z.number(),
+});
+
+export const SearchExplainContributionSchema = z.object({
+	chunk_id: z.string().uuid(),
+	rerank_score: z.number(),
+	rrf_score: z.number(),
+	strategies: z.array(SearchExplainContributionStrategySchema),
+});
+
+export const SearchExplainSchema = z.object({
+	counts: z.record(z.string(), z.number().int().nonnegative()),
+	skipped: z.array(z.string()),
+	failures: z.record(z.string(), z.string()),
+	seed_entity_ids: z.array(z.string().uuid()),
+	contributions: z.array(SearchExplainContributionSchema),
+});
+
+export const SearchDataSchema = z.object({
+	query: z.string().trim().min(1),
+	strategy: SearchStrategyModeSchema,
+	top_k: z.number().int().positive(),
+	results: z.array(SearchResultSchema),
+	confidence: SearchConfidenceSchema,
+	explain: SearchExplainSchema,
+});
+
+export const SearchResponseSchema = z.object({
+	data: SearchDataSchema,
+});
+
+export type SearchRequest = z.infer<typeof SearchRequestSchema>;
+export type SearchResponse = z.infer<typeof SearchResponseSchema>;
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+export type SearchExplain = z.infer<typeof SearchExplainSchema>;
+export type SearchConfidence = z.infer<typeof SearchConfidenceSchema>;

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -1,0 +1,33 @@
+import { createLogger, MulderError } from '@mulder/core';
+import type { Context, Hono } from 'hono';
+import { runSearch } from '../lib/search.js';
+import { SearchRequestSchema, SearchResponseSchema } from './search.schemas.js';
+
+async function readJsonBody(c: Context): Promise<unknown> {
+	try {
+		return await c.req.json();
+	} catch {
+		throw new MulderError('Invalid request', 'VALIDATION_ERROR');
+	}
+}
+
+function readNoRerankToggle(url: string): boolean {
+	const searchParams = new URL(url).searchParams;
+	return searchParams.get('no_rerank') === 'true' || searchParams.get('rerank') === 'false';
+}
+
+export function registerSearchRoute(app: Hono): void {
+	app.post('/api/search', async (c) => {
+		const body = SearchRequestSchema.parse(await readJsonBody(c));
+		const requestContext = c.get('requestContext');
+		const response = await runSearch(
+			{
+				...body,
+				no_rerank: readNoRerankToggle(c.req.url),
+			},
+			requestContext?.logger ?? createLogger(),
+		);
+		SearchResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,7 +189,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | 🟢 | H6 | Job status API | §10.6 |
-| ⚪ | H7 | Search API routes (sync) | §10.6, §5 |
+| 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
 | ⚪ | H8 | Entity API routes (sync) | §10.6 |
 | ⚪ | H9 | Evidence API routes (sync) | §10.6 |
 | ⚪ | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |

--- a/docs/specs/73_search_api_routes.spec.md
+++ b/docs/specs/73_search_api_routes.spec.md
@@ -1,0 +1,212 @@
+---
+spec: "73"
+title: "Search API Routes"
+roadmap_step: M7-H7
+functional_spec: ["§10.6", "§5"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/183"
+created: 2026-04-15
+---
+
+# Spec 73: Search API Routes
+
+## 1. Objective
+
+Expose Mulder's hybrid retrieval stack over authenticated HTTP so remote clients can run the same synchronous search flow as `mulder query` without shell access or queue handoffs. Per `§10.6`, `POST /api/search` is a direct-response endpoint rather than a job producer; per `§5`, the route must stay a thin adapter over the existing vector, full-text, graph, RRF, and optional Gemini re-ranking pipeline instead of introducing a second retrieval implementation.
+
+This step makes the read-side query surface available under the M7 API while preserving Mulder's existing retrieval semantics: strategy selection, `top_k`, confidence reporting, graph degradation behavior, and optional explain output.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H7` — Search API routes (sync)
+- **Target:** `apps/api/src/app.ts`, `apps/api/src/routes/search.schemas.ts`, `apps/api/src/routes/search.ts`, `apps/api/src/lib/search.ts`, `tests/specs/73_search_api_routes.test.ts`
+- **In scope:** authenticated `POST /api/search`; HTTP request validation for query, strategy, `top_k`, and explain flags; a route-level retrieval bridge that loads Mulder config/services and calls the existing `@mulder/retrieval` orchestrator; API response mapping into Mulder's snake_case HTTP envelope; support for the public `no_rerank` query-string toggle so the middleware can keep strict vs standard rate tiers observable; and black-box tests covering successful search, validation failures, auth protection, empty-result behavior, explain output, and the synchronous no-job contract
+- **Out of scope:** entity, evidence, source, story, taxonomy, or document routes (`M7-H8` through `M7-H10`); OpenAPI/Scalar publishing; pagination or saved search history; changes to the retrieval algorithms, prompt templates, or ranking weights; new query language/filter syntax; and any UI work (`M7-H11`)
+- **Constraints:** keep the route synchronous and read-only; do not enqueue jobs or mutate `pipeline_runs`; call the existing retrieval orchestrator instead of duplicating vector/full-text/graph logic in `apps/api`; preserve the middleware contract from Spec 70, especially auth and `/api/search` rate limiting; and use the query-oriented database/runtime path for read traffic rather than inventing ad hoc connections
+
+## 3. Dependencies
+
+- **Requires:** Spec 37 (`M4-D7`) full-text search retrieval, Spec 39 (`M4-E3`) graph traversal retrieval, Spec 40 (`M4-E4`) RRF fusion, Spec 41 (`M4-E5`) LLM re-ranking, Spec 42 (`M4-E6`) hybrid retrieval orchestrator, Spec 69 (`M7-H3`) Hono server scaffold, and Spec 70 (`M7-H4`) API middleware stack
+- **Blocks:** no later roadmap step is strictly blocked, but this step completes the synchronous query surface promised by `§10.6` and enables remote/API consumers to search the indexed corpus without falling back to CLI-only workflows
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/search.schemas.ts`** — defines the HTTP request/query schemas and the snake_case search response envelope
+2. **`apps/api/src/lib/search.ts`** — owns the route-facing retrieval bridge: load config, build or reuse the service registry, obtain the query pool, call `hybridRetrieve`, and map the result into HTTP DTOs
+3. **`apps/api/src/routes/search.ts`** — registers `POST /api/search`, parses the body + query string, and delegates to the search bridge
+4. **`apps/api/src/app.ts`** — mounts the search route under the existing middleware stack
+5. **`tests/specs/73_search_api_routes.test.ts`** — black-box verification for the synchronous search contract
+
+### 4.2 Route Contract
+
+#### `POST /api/search`
+
+Purpose: run Mulder's synchronous hybrid retrieval flow over HTTP.
+
+Query parameters:
+
+- `no_rerank=true` — optional public toggle that disables Gemini re-ranking for this request
+- `rerank=false` — optional alias for the same behavior
+
+Request body:
+
+```json
+{
+  "query": "ufo sighting",
+  "strategy": "hybrid",
+  "top_k": 10,
+  "explain": false
+}
+```
+
+Rules:
+
+- `query` is required and must be non-empty after trimming
+- `strategy` is optional and must be one of `vector | fulltext | graph | hybrid`
+- `top_k` is optional and must be a positive integer when provided
+- `explain` is optional and defaults to `false`
+- the rerank toggle lives in the query string so the middleware can determine strict vs standard rate-limit tier before the body is parsed
+- the route is synchronous and read-only: it must not create queue jobs, pipeline runs, or any other side-effect rows
+
+Success response:
+
+```json
+{
+  "data": {
+    "query": "ufo sighting",
+    "strategy": "hybrid",
+    "top_k": 10,
+    "results": [
+      {
+        "chunk_id": "uuid",
+        "story_id": "uuid",
+        "content": "Observed lights moved silently across the sky...",
+        "score": 0.82,
+        "rerank_score": 0.91,
+        "rank": 1,
+        "contributions": [
+          {
+            "strategy": "vector",
+            "rank": 1,
+            "score": 0.82
+          }
+        ],
+        "metadata": {}
+      }
+    ],
+    "confidence": {
+      "corpus_size": 12,
+      "taxonomy_status": "bootstrapping",
+      "corroboration_reliability": "low",
+      "graph_density": 0.03,
+      "degraded": false,
+      "message": null
+    },
+    "explain": {
+      "counts": {
+        "vector": 20,
+        "fulltext": 8
+      },
+      "skipped": [],
+      "failures": {},
+      "seed_entity_ids": [],
+      "contributions": []
+    }
+  }
+}
+```
+
+Response rules:
+
+- the HTTP layer uses snake_case even though the retrieval package returns camelCase internals (`topK`, `seedEntityIds`, `rerankScore`, `chunkId`, `storyId`)
+- `results` may be an empty array; that is still a successful `200` response
+- `confidence` and `explain` are always returned so clients can distinguish "no hits" from degraded corpus conditions
+- `explain.contributions` is populated only when `explain=true`; otherwise the field may be omitted or an empty array, but the outer explain block must remain structurally valid
+
+### 4.3 Runtime Bridge
+
+The route must remain a thin adapter over the existing retrieval implementation:
+
+- load Mulder config through the shared loader
+- obtain the API/logger context from the existing middleware contract where helpful for request-scoped logging
+- create or reuse the standard service registry so the route uses the same embedding and LLM abstractions as CLI retrieval
+- use the query-oriented PostgreSQL pool for synchronous search reads
+- call `hybridRetrieve(pool, services.embedding, services.llm, config, query, options)`
+- map the returned `HybridRetrievalResult` into the API response DTO without changing ranking semantics
+
+This preserves the CLI/API parity rule from `CLAUDE.md`: the HTTP layer adapts inputs and outputs, but the retrieval logic lives in `@mulder/retrieval`.
+
+### 4.4 Integration Points
+
+- the route consumes the middleware protections from Spec 70, including auth and `/api/search` rate-limit tiers
+- the retrieval bridge reuses the shipped `@mulder/retrieval` package instead of ad hoc SQL in `apps/api`
+- request-scoped logging should record route-level metadata such as strategy, `top_k`, rerank mode, result count, and duration without inventing a second logging system
+- the route keeps the public response envelope compatible with future OpenAPI/Scalar work, but that publishing work stays out of scope here
+
+### 4.5 Implementation Phases
+
+**Phase 1: HTTP contract + DTO mapping**
+- add the search request schema and snake_case response schemas
+- define the public `no_rerank` query-string contract
+- map retrieval-layer camelCase fields into API-facing snake_case DTOs
+
+**Phase 2: Retrieval bridge + route wiring**
+- implement the route helper that loads config/services/query pool and calls `hybridRetrieve`
+- register `POST /api/search`
+- mount the route in the Hono app without weakening the existing middleware protections
+
+**Phase 3: Black-box QA**
+- add API-focused tests for successful searches, empty-result searches, invalid requests, auth protection, explain output, and the no-job synchronous contract
+- verify the API package still compiles with the new route surface
+
+## 5. QA Contract
+
+1. **QA-01: `POST /api/search` returns a synchronous retrieval response for a valid authenticated request**
+   - Given: an indexed corpus and a valid API key
+   - When: `POST /api/search` is called with a non-empty query body
+   - Then: the response is `200` and returns `data.query`, `data.strategy`, `data.top_k`, `data.results`, `data.confidence`, and `data.explain`
+
+2. **QA-02: malformed search requests fail at the HTTP edge**
+   - Given: a request body missing `query` or using an invalid `strategy` or `top_k`
+   - When: `POST /api/search` is called
+   - Then: the API returns a Mulder JSON client error and does not create queue or pipeline-run rows
+
+3. **QA-03: the search route stays synchronous and read-only**
+   - Given: the search route is mounted and the database already contains retrieval data
+   - When: `POST /api/search` is called successfully
+   - Then: the route performs retrieval directly, returns within the request/response cycle, and leaves `jobs` / `pipeline_runs` counts unchanged
+
+4. **QA-04: `no_rerank` is a public per-request toggle**
+   - Given: a valid search request
+   - When: `POST /api/search?no_rerank=true` is called
+   - Then: the response still succeeds through the same route contract while bypassing the reranker path for that request
+
+5. **QA-05: explain mode exposes strategy provenance**
+   - Given: a valid search request with `explain=true`
+   - When: `POST /api/search` is called against a corpus with at least one hit
+   - Then: the response includes `data.explain.counts`, `data.explain.seed_entity_ids`, and per-result strategy contribution details
+
+6. **QA-06: no-match searches remain successful and observable**
+   - Given: a well-formed query that has no meaningful matches in the indexed corpus
+   - When: `POST /api/search` is called
+   - Then: the API returns `200` with an empty `results` array plus the confidence/explain blocks instead of a not-found or server error
+
+7. **QA-07: the search route stays behind the existing auth middleware**
+   - Given: the search route is mounted in the API app
+   - When: `POST /api/search` is called without a valid bearer token
+   - Then: the response is `401` and no retrieval work is executed
+
+8. **QA-08: the API package compiles with the new search route surface**
+   - Given: the route, schemas, and retrieval bridge are wired into `@mulder/api`
+   - When: the API package build/typecheck runs
+   - Then: the package compiles successfully and exports a bootable app with the search route mounted
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+This step is directly cost-sensitive because reranked search can call Gemini Flash synchronously. The public route must therefore preserve the middleware's strict-vs-standard rate-limit distinction, expose a `no_rerank` path for lower-cost traffic, and reject malformed requests before any embedding, retrieval, or LLM work begins.

--- a/packages/core/src/database/repositories/job.repository.ts
+++ b/packages/core/src/database/repositories/job.repository.ts
@@ -26,6 +26,8 @@ import type {
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'job-repository' });
 
+type Queryable = pg.Pool | pg.PoolClient;
+
 interface JobRow {
 	id: string;
 	type: string;
@@ -101,7 +103,7 @@ function buildJobFilter(filter?: JobFilter): { whereClause: string; params: unkn
 	};
 }
 
-export async function enqueueJob(pool: pg.Pool, input: EnqueueJobInput): Promise<Job> {
+export async function enqueueJob(pool: Queryable, input: EnqueueJobInput): Promise<Job> {
 	const sql = `
     INSERT INTO jobs (type, payload, max_attempts)
     VALUES ($1, $2, $3)

--- a/packages/core/src/database/repositories/pipeline-run.repository.ts
+++ b/packages/core/src/database/repositories/pipeline-run.repository.ts
@@ -27,6 +27,8 @@ import type {
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'pipeline-run-repository' });
 
+type Queryable = pg.Pool | pg.PoolClient;
+
 // ────────────────────────────────────────────────────────────
 // Row mappers (snake_case DB → camelCase TS)
 // ────────────────────────────────────────────────────────────
@@ -104,7 +106,7 @@ function mapPipelineRunSourceRow(row: PipelineRunSourceRow): PipelineRunSource {
  * (skipped on `--dry-run`). The returned `id` becomes the cursor key for
  * all subsequent `upsertPipelineRunSource` calls in this batch.
  */
-export async function createPipelineRun(pool: pg.Pool, input: CreatePipelineRunInput): Promise<PipelineRun> {
+export async function createPipelineRun(pool: Queryable, input: CreatePipelineRunInput): Promise<PipelineRun> {
 	const sql = `
     INSERT INTO pipeline_runs (tag, options, status)
     VALUES ($1, $2, 'running')
@@ -315,7 +317,7 @@ export async function findPipelineRunSourceById(
  * `mulder pipeline retry <source-id>` to find the failed step to retry.
  */
 export async function findLatestPipelineRunSourceForSource(
-	pool: pg.Pool,
+	pool: Queryable,
 	sourceId: string,
 ): Promise<PipelineRunSource | null> {
 	const sql = `

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -28,6 +28,8 @@ import type {
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'source-repository' });
 
+type Queryable = pg.Pool | pg.PoolClient;
+
 // ────────────────────────────────────────────────────────────
 // Row mappers (snake_case DB → camelCase TS)
 // ────────────────────────────────────────────────────────────
@@ -132,7 +134,7 @@ export async function createSource(pool: pg.Pool, input: CreateSourceInput): Pro
  *
  * @returns The source, or `null` if not found.
  */
-export async function findSourceById(pool: pg.Pool, id: string): Promise<Source | null> {
+export async function findSourceById(pool: Queryable, id: string): Promise<Source | null> {
 	const sql = 'SELECT * FROM sources WHERE id = $1';
 
 	try {

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -205,9 +205,13 @@ function assertPipelineRunCompleted(job: WorkerJobEnvelope, status: string): voi
 		return;
 	}
 
-	throw new WorkerError(`pipeline_run job ${job.id} finished with status ${status}`, WORKER_ERROR_CODES.WORKER_LOOP_FAILED, {
-		context: { jobId: job.id, jobType: job.type, status },
-	});
+	throw new WorkerError(
+		`pipeline_run job ${job.id} finished with status ${status}`,
+		WORKER_ERROR_CODES.WORKER_LOOP_FAILED,
+		{
+			context: { jobId: job.id, jobType: job.type, status },
+		},
+	);
 }
 
 export const dispatchJob: WorkerDispatchFn = async (job, context) => {

--- a/tests/specs/70_api_middleware_stack.test.ts
+++ b/tests/specs/70_api_middleware_stack.test.ts
@@ -126,11 +126,11 @@ describe('Spec 70: API Middleware Stack', () => {
 			},
 		});
 
-		app.post('/api/search', (c) => c.json({ ok: true }, 200));
+		app.get('/api/entities', (c) => c.json({ ok: true }, 200));
 
-		for (let index = 0; index < 10; index += 1) {
-			const response = await app.request('http://localhost/api/search', {
-				method: 'POST',
+		for (let index = 0; index < 60; index += 1) {
+			const response = await app.request('http://localhost/api/entities', {
+				method: 'GET',
 				headers: {
 					Authorization: 'Bearer test-api-key',
 					'X-Forwarded-For': `203.0.113.${index + 1}`,
@@ -140,8 +140,8 @@ describe('Spec 70: API Middleware Stack', () => {
 			expect(response.status).toBe(200);
 		}
 
-		const throttled = await app.request('http://localhost/api/search', {
-			method: 'POST',
+		const throttled = await app.request('http://localhost/api/entities', {
+			method: 'GET',
 			headers: {
 				Authorization: 'Bearer test-api-key',
 				'X-Forwarded-For': '198.51.100.250',
@@ -156,7 +156,7 @@ describe('Spec 70: API Middleware Stack', () => {
 				message: 'Too many requests',
 				details: {
 					retry_after_seconds: expect.any(Number),
-					tier: 'strict',
+					tier: 'standard',
 				},
 			},
 		});

--- a/tests/specs/72_job_status_api.test.ts
+++ b/tests/specs/72_job_status_api.test.ts
@@ -156,7 +156,7 @@ async function loadApiApp(): Promise<{ request: (input: string | Request, init?:
 	});
 }
 
-function authorizedHeaders(): HeadersInit {
+function authorizedHeaders(): Record<string, string> {
 	return {
 		Authorization: 'Bearer test-api-key',
 		'X-Forwarded-For': '203.0.113.10',

--- a/tests/specs/73_search_api_routes.test.ts
+++ b/tests/specs/73_search_api_routes.test.ts
@@ -66,7 +66,7 @@ function buildMockServices(): Services {
 		embed: async () => [],
 	};
 	const llm: LlmService = {
-		generateStructured: async () => ({}),
+		generateStructured: async <T>() => ({}) as T,
 		generateText: async () => '',
 		groundedGenerate: async () => ({
 			text: '',
@@ -143,7 +143,7 @@ function createHybridResult(overrides?: Partial<HybridRetrievalResult>): HybridR
 	};
 }
 
-function authorizedHeaders(ip: string): HeadersInit {
+function authorizedHeaders(ip: string): Record<string, string> {
 	return {
 		Authorization: 'Bearer test-api-key',
 		'Content-Type': 'application/json',
@@ -151,7 +151,12 @@ function authorizedHeaders(ip: string): HeadersInit {
 	};
 }
 
-async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
+type ApiApp = {
+	request: (input: string | Request, init?: RequestInit) => Promise<Response>;
+	fetch: (input: string | Request, init?: RequestInit) => Promise<Response>;
+};
+
+async function loadApiApp(): Promise<ApiApp> {
 	const module = await import(pathToFileURL(API_APP_DIST).href);
 	if (typeof module.createApp !== 'function') {
 		throw new Error('API app module did not export createApp');

--- a/tests/specs/73_search_api_routes.test.ts
+++ b/tests/specs/73_search_api_routes.test.ts
@@ -1,0 +1,529 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { EmbeddingService, LlmService, Services } from '@mulder/core';
+import type { HybridRetrievalResult } from '@mulder/retrieval';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as db from '../lib/db.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const RETRIEVAL_DIR = resolve(ROOT, 'packages/retrieval');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const RETRIEVAL_DIST = resolve(RETRIEVAL_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const mocks = vi.hoisted(() => ({
+	hybridRetrieve: vi.fn(),
+	getQueryPool: vi.fn(),
+	createServiceRegistry: vi.fn(),
+}));
+
+vi.mock('@mulder/retrieval', async () => {
+	const actual = await vi.importActual<typeof import('@mulder/retrieval')>('@mulder/retrieval');
+	return {
+		...actual,
+		hybridRetrieve: mocks.hybridRetrieve,
+	};
+});
+
+vi.mock('@mulder/core', async () => {
+	const actual = await vi.importActual<typeof import('@mulder/core')>('@mulder/core');
+	return {
+		...actual,
+		getQueryPool: mocks.getQueryPool,
+		createServiceRegistry: mocks.createServiceRegistry,
+	};
+});
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function cleanState(): void {
+	db.runSql('DELETE FROM pipeline_run_sources; DELETE FROM pipeline_runs; DELETE FROM jobs;');
+}
+
+function buildMockServices(): Services {
+	const embedding: EmbeddingService = {
+		embed: async () => [],
+	};
+	const llm: LlmService = {
+		generateStructured: async () => ({}),
+		generateText: async () => '',
+		groundedGenerate: async () => ({
+			text: '',
+			groundingMetadata: {},
+		}),
+		countTokens: async () => 0,
+	};
+
+	return {
+		storage: {
+			upload: async () => {},
+			download: async () => Buffer.alloc(0),
+			exists: async () => false,
+			list: async () => ({ paths: [] }),
+			delete: async () => {},
+		},
+		documentAi: {
+			processDocument: async () => ({
+				document: {},
+				pageImages: [],
+			}),
+		},
+		llm,
+		embedding,
+		firestore: {
+			setDocument: async () => {},
+			getDocument: async () => null,
+		},
+	};
+}
+
+function createHybridResult(overrides?: Partial<HybridRetrievalResult>): HybridRetrievalResult {
+	return {
+		query: 'ufo sighting',
+		strategy: 'hybrid',
+		topK: 10,
+		results: [
+			{
+				chunkId: randomUUID(),
+				storyId: randomUUID(),
+				content: 'Observed lights moved silently across the sky before vanishing.',
+				score: 0.82,
+				rerankScore: 0.91,
+				rank: 1,
+				contributions: [
+					{
+						strategy: 'vector',
+						rank: 1,
+						score: 0.82,
+					},
+				],
+				metadata: {},
+			},
+		],
+		confidence: {
+			corpus_size: 12,
+			taxonomy_status: 'bootstrapping',
+			corroboration_reliability: 'low',
+			graph_density: 0.03,
+			degraded: false,
+			message: undefined,
+		},
+		explain: {
+			counts: {
+				vector: 20,
+				fulltext: 8,
+			},
+			skipped: [],
+			failures: {},
+			seedEntityIds: [],
+			contributions: [],
+		},
+		...overrides,
+	};
+}
+
+function authorizedHeaders(ip: string): HeadersInit {
+	return {
+		Authorization: 'Bearer test-api-key',
+		'Content-Type': 'application/json',
+		'X-Forwarded-For': ip,
+	};
+}
+
+async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+describe('Spec 73 — Search API Routes', () => {
+	const originalConfig = process.env.MULDER_CONFIG;
+	const originalLogLevel = process.env.MULDER_LOG_LEVEL;
+	let app: Awaited<ReturnType<typeof loadApiApp>>;
+	let mockServices: Services;
+	let mockPool: object;
+	let currentHybridResult: HybridRetrievalResult;
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		buildPackage(CORE_DIR);
+		buildPackage(RETRIEVAL_DIR);
+		buildPackage(API_DIR);
+
+		await import(pathToFileURL(CORE_DIST).href);
+		await import(pathToFileURL(RETRIEVAL_DIST).href);
+
+		mockServices = buildMockServices();
+		mockPool = {};
+		mocks.getQueryPool.mockReturnValue(mockPool);
+		mocks.createServiceRegistry.mockReturnValue(mockServices);
+
+		currentHybridResult = createHybridResult();
+		mocks.hybridRetrieve.mockImplementation(async () => currentHybridResult);
+
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(() => {
+		cleanState();
+		currentHybridResult = createHybridResult();
+		mocks.hybridRetrieve.mockClear();
+		mocks.getQueryPool.mockClear();
+		mocks.createServiceRegistry.mockClear();
+		mocks.hybridRetrieve.mockImplementation(async () => currentHybridResult);
+		mocks.getQueryPool.mockReturnValue(mockPool);
+		mocks.createServiceRegistry.mockReturnValue(mockServices);
+	});
+
+	afterAll(() => {
+		cleanState();
+		if (originalConfig === undefined) {
+			delete process.env.MULDER_CONFIG;
+		} else {
+			process.env.MULDER_CONFIG = originalConfig;
+		}
+		if (originalLogLevel === undefined) {
+			delete process.env.MULDER_LOG_LEVEL;
+		} else {
+			process.env.MULDER_LOG_LEVEL = originalLogLevel;
+		}
+	});
+
+	it('QA-01: POST /api/search returns a synchronous retrieval response for an authenticated request', async () => {
+		const response = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.10'),
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+				explain: false,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			data: {
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+				results: [
+					{
+						chunk_id: expect.any(String),
+						story_id: expect.any(String),
+						content: 'Observed lights moved silently across the sky before vanishing.',
+						score: 0.82,
+						rerank_score: 0.91,
+						rank: 1,
+						contributions: [
+							{
+								strategy: 'vector',
+								rank: 1,
+								score: 0.82,
+							},
+						],
+						metadata: {},
+					},
+				],
+				confidence: {
+					corpus_size: 12,
+					taxonomy_status: 'bootstrapping',
+					corroboration_reliability: 'low',
+					graph_density: 0.03,
+					degraded: false,
+					message: null,
+				},
+				explain: {
+					counts: {
+						vector: 20,
+						fulltext: 8,
+					},
+					skipped: [],
+					failures: {},
+					seed_entity_ids: [],
+					contributions: [],
+				},
+			},
+		});
+	});
+
+	it('QA-02: malformed search requests fail at the HTTP edge', async () => {
+		const invalidRequests = [
+			{},
+			{
+				query: 'ufo sighting',
+				strategy: 'bad-strategy',
+			},
+			{
+				query: 'ufo sighting',
+				top_k: 0,
+			},
+		];
+
+		for (let index = 0; index < invalidRequests.length; index += 1) {
+			const response = await app.request(`http://localhost/api/search?case=${index}`, {
+				method: 'POST',
+				headers: authorizedHeaders(`203.0.113.${20 + index}`),
+				body: JSON.stringify(invalidRequests[index]),
+			});
+
+			expect(response.status).toBe(400);
+			expect(mocks.hybridRetrieve).not.toHaveBeenCalled();
+			expect(await response.json()).toMatchObject({
+				error: {
+					code: 'VALIDATION_ERROR',
+					message: 'Invalid request',
+				},
+			});
+		}
+	});
+
+	it('QA-03: the search route stays synchronous and read-only', async () => {
+		const beforeJobs = Number(db.runSql('SELECT COUNT(*) FROM jobs;'));
+		const beforeRuns = Number(db.runSql('SELECT COUNT(*) FROM pipeline_runs;'));
+
+		const response = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.30'),
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(Number(db.runSql('SELECT COUNT(*) FROM jobs;'))).toBe(beforeJobs);
+		expect(Number(db.runSql('SELECT COUNT(*) FROM pipeline_runs;'))).toBe(beforeRuns);
+		expect(mocks.hybridRetrieve).toHaveBeenCalledTimes(1);
+	});
+
+	it('QA-04: no_rerank and rerank=false disable re-ranking for the request', async () => {
+		const noRerankResponse = await app.request('http://localhost/api/search?no_rerank=true', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.40'),
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+			}),
+		});
+
+		expect(noRerankResponse.status).toBe(200);
+		expect(mocks.hybridRetrieve).toHaveBeenCalledTimes(1);
+		expect(mocks.hybridRetrieve.mock.calls[0]?.[5]).toMatchObject({
+			noRerank: true,
+			strategy: 'hybrid',
+			topK: 10,
+		});
+
+		mocks.hybridRetrieve.mockClear();
+
+		const aliasResponse = await app.request('http://localhost/api/search?rerank=false', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.41'),
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+			}),
+		});
+
+		expect(aliasResponse.status).toBe(200);
+		expect(mocks.hybridRetrieve).toHaveBeenCalledTimes(1);
+		expect(mocks.hybridRetrieve.mock.calls[0]?.[5]).toMatchObject({
+			noRerank: true,
+			strategy: 'hybrid',
+			topK: 10,
+		});
+	});
+
+	it('QA-05: explain mode exposes strategy provenance', async () => {
+		currentHybridResult = createHybridResult({
+			explain: {
+				counts: {
+					vector: 20,
+					fulltext: 8,
+				},
+				skipped: [],
+				failures: {},
+				seedEntityIds: [randomUUID()],
+				contributions: [
+					{
+						chunkId: randomUUID(),
+						rerankScore: 0.91,
+						rrfScore: 0.024,
+						strategies: [
+							{
+								strategy: 'vector',
+								rank: 1,
+								score: 0.82,
+							},
+							{
+								strategy: 'fulltext',
+								rank: 2,
+								score: 0.44,
+							},
+						],
+					},
+				],
+			},
+		});
+
+		const response = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.50'),
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+				explain: true,
+			}),
+		});
+
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			data: {
+				explain: {
+					counts: {
+						vector: 20,
+						fulltext: 8,
+					},
+					seed_entity_ids: [expect.any(String)],
+					contributions: [
+						{
+							chunk_id: expect.any(String),
+							rerank_score: 0.91,
+							rrf_score: 0.024,
+							strategies: [
+								{
+									strategy: 'vector',
+									rank: 1,
+									score: 0.82,
+								},
+								{
+									strategy: 'fulltext',
+									rank: 2,
+									score: 0.44,
+								},
+							],
+						},
+					],
+				},
+			},
+		});
+	});
+
+	it('QA-06: no-match searches remain successful and observable', async () => {
+		currentHybridResult = createHybridResult({
+			results: [],
+			confidence: {
+				corpus_size: 12,
+				taxonomy_status: 'bootstrapping',
+				corroboration_reliability: 'low',
+				graph_density: 0.03,
+				degraded: true,
+				message: 'no_meaningful_matches',
+			},
+			explain: {
+				counts: {},
+				skipped: ['graph:no_seeds'],
+				failures: {},
+				seedEntityIds: [],
+				contributions: [],
+			},
+		});
+
+		const response = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			headers: authorizedHeaders('203.0.113.60'),
+			body: JSON.stringify({
+				query: 'totally unmatched query',
+				strategy: 'hybrid',
+				top_k: 10,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			data: {
+				results: [],
+				confidence: {
+					degraded: true,
+					message: 'no_meaningful_matches',
+				},
+				explain: {
+					contributions: [],
+					skipped: ['graph:no_seeds'],
+				},
+			},
+		});
+	});
+
+	it('QA-07: the search route stays behind the existing auth middleware', async () => {
+		const response = await app.request('http://localhost/api/search', {
+			method: 'POST',
+			body: JSON.stringify({
+				query: 'ufo sighting',
+				strategy: 'hybrid',
+				top_k: 10,
+			}),
+		});
+
+		expect(response.status).toBe(401);
+		expect(mocks.hybridRetrieve).not.toHaveBeenCalled();
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+	});
+
+	it('QA-08: the API package compiles with the new search route surface', () => {
+		expect(typeof app.request).toBe('function');
+		expect(typeof app.fetch).toBe('function');
+	});
+});


### PR DESCRIPTION
Implements Spec 73 / M7-H7 for authenticated synchronous search over HTTP.\n\nCloses #183\n\nSpec: docs/specs/73_search_api_routes.spec.md\nRoadmap: docs/roadmap.md\n\nVerification:\n- pnpm turbo run build --filter='...[HEAD]'\n- pnpm vitest run tests/specs/73_search_api_routes.test.ts\n- npx biome check apps/api/src/lib/search.ts apps/api/src/routes/search.ts apps/api/src/routes/search.schemas.ts apps/api/src/app.ts tests/specs/73_search_api_routes.test.ts