### PR TITLE
[API] Entity routes — M7-H8

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { createRateLimitMiddleware } from './middleware/rate-limit.js';
 import { createRequestContextMiddleware } from './middleware/request-context.js';
 import { createRequestIdMiddleware } from './middleware/request-id.js';
 import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
+import { registerEntityRoutes } from './routes/entities.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerJobRoutes } from './routes/jobs.js';
 import { registerPipelineRoutes } from './routes/pipeline.js';
@@ -32,6 +33,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	app.use('*', createRateLimitMiddleware(apiConfig));
 
 	registerHealthRoute(app);
+	registerEntityRoutes(app);
 	registerJobRoutes(app);
 	registerPipelineRoutes(app);
 	registerSearchRoute(app);

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -1,0 +1,315 @@
+import { performance } from 'node:perf_hooks';
+import {
+	type Entity as CoreEntity,
+	type EntityAlias as CoreEntityAlias,
+	type EntityEdge as CoreEntityEdge,
+	countEntities,
+	createChildLogger,
+	createLogger,
+	DATABASE_ERROR_CODES,
+	DatabaseError,
+	type EntityFilter,
+	findAliasesByEntityId,
+	findAllEntities,
+	findEdgesByEntityId,
+	findEntitiesByCanonicalId,
+	findEntityById,
+	findStoriesByEntityId,
+	getQueryPool,
+	type Logger,
+	loadConfig,
+	type MergeEntitiesResult,
+	MulderError,
+	mergeEntities as mergeEntitiesRepository,
+} from '@mulder/core';
+import type pg from 'pg';
+import type {
+	EntityAliasResponse,
+	EntityDetailResponse,
+	EntityEdgeResponse,
+	EntityEdgesResponse,
+	EntityListQuery,
+	EntityListResponse,
+	EntityMergeResponse,
+	EntityResponse,
+	EntityStoryResponse,
+} from '../routes/entities.schemas.js';
+
+interface EntityContext {
+	pool: pg.Pool;
+}
+
+let cachedContext: EntityContext | null = null;
+let cachedConfigPath: string | null = null;
+
+function resolveConfigPath(): string {
+	return process.env.MULDER_CONFIG ?? 'mulder.config.yaml';
+}
+
+function resolveContext(): EntityContext {
+	const configPath = resolveConfigPath();
+	if (cachedContext && cachedConfigPath === configPath) {
+		return cachedContext;
+	}
+
+	const config = loadConfig(configPath);
+	if (!config.gcp?.cloud_sql) {
+		throw new DatabaseError(
+			'GCP cloud_sql configuration is required for entity routes',
+			DATABASE_ERROR_CODES.DB_CONNECTION_FAILED,
+			{
+				context: {
+					configPath,
+				},
+			},
+		);
+	}
+
+	cachedContext = {
+		pool: getQueryPool(config.gcp.cloud_sql),
+	};
+	cachedConfigPath = configPath;
+
+	return cachedContext;
+}
+
+function mapEntity(entity: CoreEntity): EntityResponse {
+	return {
+		id: entity.id,
+		canonical_id: entity.canonicalId,
+		name: entity.name,
+		type: entity.type,
+		taxonomy_status: entity.taxonomyStatus,
+		taxonomy_id: entity.taxonomyId,
+		corroboration_score: entity.corroborationScore,
+		source_count: entity.sourceCount,
+		attributes: entity.attributes ?? {},
+		created_at: entity.createdAt.toISOString(),
+		updated_at: entity.updatedAt.toISOString(),
+	};
+}
+
+function mapAlias(alias: CoreEntityAlias): EntityAliasResponse {
+	return {
+		id: alias.id,
+		entity_id: alias.entityId,
+		alias: alias.alias,
+		source: alias.source,
+	};
+}
+
+function mapStory(story: Awaited<ReturnType<typeof findStoriesByEntityId>>[number]): EntityStoryResponse {
+	return {
+		id: story.id,
+		source_id: story.sourceId,
+		title: story.title,
+		status: story.status,
+		confidence: story.confidence,
+		mention_count: story.mentionCount,
+	};
+}
+
+function mapEdge(edge: CoreEntityEdge): EntityEdgeResponse {
+	return {
+		id: edge.id,
+		source_entity_id: edge.sourceEntityId,
+		target_entity_id: edge.targetEntityId,
+		relationship: edge.relationship,
+		edge_type: edge.edgeType,
+		confidence: edge.confidence,
+		story_id: edge.storyId,
+		attributes: edge.attributes ?? {},
+	};
+}
+
+async function requireEntityById(pool: pg.Pool, id: string): Promise<CoreEntity> {
+	const entity = await findEntityById(pool, id);
+	if (!entity) {
+		throw new DatabaseError(`Entity not found: ${id}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
+			context: { id },
+		});
+	}
+
+	return entity;
+}
+
+function createRouteLogger(rootLogger: Logger, metadata: Record<string, string | number | null | undefined>) {
+	return createChildLogger(rootLogger, {
+		module: 'api',
+		route: 'entities',
+		...metadata,
+	});
+}
+
+export async function listEntities(input: EntityListQuery, logger?: Logger): Promise<EntityListResponse> {
+	const rootLogger = logger ?? createLogger();
+	const { pool } = resolveContext();
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'list',
+		type: input.type ?? null,
+		search: input.search ?? null,
+		taxonomy_status: input.taxonomy_status ?? null,
+		limit: input.limit,
+		offset: input.offset,
+	});
+	const startedAt = performance.now();
+
+	const filter: EntityFilter = {
+		type: input.type,
+		search: input.search,
+		taxonomyStatus: input.taxonomy_status,
+		limit: input.limit,
+		offset: input.offset,
+	};
+
+	const [count, entities] = await Promise.all([countEntities(pool, filter), findAllEntities(pool, filter)]);
+	const response: EntityListResponse = {
+		data: entities.map(mapEntity),
+		meta: {
+			count,
+			limit: input.limit,
+			offset: input.offset,
+		},
+	};
+
+	requestLogger.info(
+		{
+			count,
+			result_count: response.data.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'entity list request completed',
+	);
+
+	return response;
+}
+
+export async function getEntityDetail(id: string, logger?: Logger): Promise<EntityDetailResponse> {
+	const rootLogger = logger ?? createLogger();
+	const { pool } = resolveContext();
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'detail',
+		entity_id: id,
+	});
+	const startedAt = performance.now();
+
+	const entity = await requireEntityById(pool, id);
+	const [aliases, stories, mergedEntities] = await Promise.all([
+		findAliasesByEntityId(pool, id),
+		findStoriesByEntityId(pool, id),
+		findEntitiesByCanonicalId(pool, id),
+	]);
+
+	const response: EntityDetailResponse = {
+		data: {
+			entity: mapEntity(entity),
+			aliases: aliases.map(mapAlias),
+			stories: stories.map(mapStory),
+			merged_entities: mergedEntities.map(mapEntity),
+		},
+	};
+
+	requestLogger.info(
+		{
+			alias_count: response.data.aliases.length,
+			story_count: response.data.stories.length,
+			merged_count: response.data.merged_entities.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'entity detail request completed',
+	);
+
+	return response;
+}
+
+export async function getEntityEdges(id: string, logger?: Logger): Promise<EntityEdgesResponse> {
+	const rootLogger = logger ?? createLogger();
+	const { pool } = resolveContext();
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'edges',
+		entity_id: id,
+	});
+	const startedAt = performance.now();
+
+	await requireEntityById(pool, id);
+	const edges = await findEdgesByEntityId(pool, id);
+	const response: EntityEdgesResponse = {
+		data: edges.map(mapEdge),
+	};
+
+	requestLogger.info(
+		{
+			result_count: response.data.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'entity edges request completed',
+	);
+
+	return response;
+}
+
+export async function mergeEntities(targetId: string, sourceId: string, logger?: Logger): Promise<EntityMergeResponse> {
+	const rootLogger = logger ?? createLogger();
+	const { pool } = resolveContext();
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'merge',
+		target_id: targetId,
+		source_id: sourceId,
+	});
+	const startedAt = performance.now();
+
+	if (targetId === sourceId) {
+		throw new MulderError('Cannot merge an entity into itself', 'VALIDATION_ERROR', {
+			context: {
+				target_id: targetId,
+				source_id: sourceId,
+			},
+		});
+	}
+
+	const [target, source] = await Promise.all([requireEntityById(pool, targetId), requireEntityById(pool, sourceId)]);
+
+	if (target.canonicalId !== null || source.canonicalId !== null) {
+		throw new MulderError('One or both entities are already merged', 'VALIDATION_ERROR', {
+			context: {
+				target_id: targetId,
+				source_id: sourceId,
+				target_canonical_id: target.canonicalId,
+				source_canonical_id: source.canonicalId,
+			},
+		});
+	}
+
+	const result: MergeEntitiesResult = await mergeEntitiesRepository(pool, targetId, sourceId);
+	const response: EntityMergeResponse = {
+		data: {
+			target: {
+				id: result.target.id,
+			},
+			merged: {
+				id: result.merged.id,
+				canonical_id: result.merged.canonicalId ?? targetId,
+			},
+			edges_reassigned: result.edgesReassigned,
+			stories_reassigned: result.storiesReassigned,
+			aliases_copied: result.aliasesCopied,
+		},
+	};
+
+	requestLogger.info(
+		{
+			edges_reassigned: response.data.edges_reassigned,
+			stories_reassigned: response.data.stories_reassigned,
+			aliases_copied: response.data.aliases_copied,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'entity merge request completed',
+	);
+
+	return response;
+}
+
+export function resetEntityContextForTests(): void {
+	cachedContext = null;
+	cachedConfigPath = null;
+}

--- a/apps/api/src/routes/entities.schemas.ts
+++ b/apps/api/src/routes/entities.schemas.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+export const ENTITY_TAXONOMY_STATUS_VALUES = ['auto', 'curated', 'merged'] as const;
+export const ENTITY_EDGE_TYPE_VALUES = [
+	'RELATIONSHIP',
+	'DUPLICATE_OF',
+	'POTENTIAL_CONTRADICTION',
+	'CONFIRMED_CONTRADICTION',
+	'DISMISSED_CONTRADICTION',
+] as const;
+export const STORY_STATUS_VALUES = ['segmented', 'enriched', 'embedded', 'graphed', 'analyzed'] as const;
+
+export const EntityTaxonomyStatusSchema = z.enum(ENTITY_TAXONOMY_STATUS_VALUES);
+export const EntityEdgeTypeSchema = z.enum(ENTITY_EDGE_TYPE_VALUES);
+export const StoryStatusSchema = z.enum(STORY_STATUS_VALUES);
+
+export const EntityListQuerySchema = z.object({
+	type: z.string().trim().min(1).max(128).optional(),
+	search: z.string().trim().min(1).max(256).optional(),
+	taxonomy_status: EntityTaxonomyStatusSchema.optional(),
+	limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+	offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const EntitySchema = z.object({
+	id: z.string().uuid(),
+	canonical_id: z.string().uuid().nullable(),
+	name: z.string(),
+	type: z.string(),
+	taxonomy_status: EntityTaxonomyStatusSchema,
+	taxonomy_id: z.string().uuid().nullable(),
+	corroboration_score: z.number().nullable(),
+	source_count: z.number().int().nonnegative(),
+	attributes: z.record(z.string(), z.unknown()),
+	created_at: z.string(),
+	updated_at: z.string(),
+});
+
+export const EntityAliasSchema = z.object({
+	id: z.string().uuid(),
+	entity_id: z.string().uuid(),
+	alias: z.string(),
+	source: z.string().nullable(),
+});
+
+export const EntityStorySchema = z.object({
+	id: z.string().uuid(),
+	source_id: z.string().uuid(),
+	title: z.string(),
+	status: StoryStatusSchema,
+	confidence: z.number().nullable(),
+	mention_count: z.number().int().nonnegative(),
+});
+
+export const EntityEdgeSchema = z.object({
+	id: z.string().uuid(),
+	source_entity_id: z.string().uuid(),
+	target_entity_id: z.string().uuid(),
+	relationship: z.string(),
+	edge_type: EntityEdgeTypeSchema,
+	confidence: z.number().nullable(),
+	story_id: z.string().uuid().nullable(),
+	attributes: z.record(z.string(), z.unknown()),
+});
+
+export const EntityListResponseSchema = z.object({
+	data: z.array(EntitySchema),
+	meta: z.object({
+		count: z.number().int().nonnegative(),
+		limit: z.number().int().positive(),
+		offset: z.number().int().nonnegative(),
+	}),
+});
+
+export const EntityDetailResponseSchema = z.object({
+	data: z.object({
+		entity: EntitySchema,
+		aliases: z.array(EntityAliasSchema),
+		stories: z.array(EntityStorySchema),
+		merged_entities: z.array(EntitySchema),
+	}),
+});
+
+export const EntityEdgesResponseSchema = z.object({
+	data: z.array(EntityEdgeSchema),
+});
+
+export const EntityMergeRequestSchema = z.object({
+	target_id: z.string().uuid(),
+	source_id: z.string().uuid(),
+});
+
+export const EntityMergeResponseSchema = z.object({
+	data: z.object({
+		target: z.object({
+			id: z.string().uuid(),
+		}),
+		merged: z.object({
+			id: z.string().uuid(),
+			canonical_id: z.string().uuid(),
+		}),
+		edges_reassigned: z.number().int().nonnegative(),
+		stories_reassigned: z.number().int().nonnegative(),
+		aliases_copied: z.number().int().nonnegative(),
+	}),
+});
+
+export type EntityListQuery = z.infer<typeof EntityListQuerySchema>;
+export type EntityListResponse = z.infer<typeof EntityListResponseSchema>;
+export type EntityDetailResponse = z.infer<typeof EntityDetailResponseSchema>;
+export type EntityEdgesResponse = z.infer<typeof EntityEdgesResponseSchema>;
+export type EntityMergeRequest = z.infer<typeof EntityMergeRequestSchema>;
+export type EntityMergeResponse = z.infer<typeof EntityMergeResponseSchema>;
+export type EntityResponse = z.infer<typeof EntitySchema>;
+export type EntityAliasResponse = z.infer<typeof EntityAliasSchema>;
+export type EntityStoryResponse = z.infer<typeof EntityStorySchema>;
+export type EntityEdgeResponse = z.infer<typeof EntityEdgeSchema>;

--- a/apps/api/src/routes/entities.ts
+++ b/apps/api/src/routes/entities.ts
@@ -1,0 +1,59 @@
+import { MulderError } from '@mulder/core';
+import type { Context, Hono } from 'hono';
+import { getEntityDetail, getEntityEdges, listEntities, mergeEntities } from '../lib/entities.js';
+import {
+	EntityDetailResponseSchema,
+	EntityEdgesResponseSchema,
+	EntityListQuerySchema,
+	EntityListResponseSchema,
+	EntityMergeRequestSchema,
+	EntityMergeResponseSchema,
+} from './entities.schemas.js';
+
+async function readJsonBody(c: Context): Promise<unknown> {
+	try {
+		return await c.req.json();
+	} catch {
+		throw new MulderError('Invalid request', 'VALIDATION_ERROR');
+	}
+}
+
+function readEntityListQuery(url: string): Record<string, string | undefined> {
+	const searchParams = new URL(url).searchParams;
+
+	return {
+		type: searchParams.get('type') ?? undefined,
+		search: searchParams.get('search') ?? undefined,
+		taxonomy_status: searchParams.get('taxonomy_status') ?? undefined,
+		limit: searchParams.get('limit') ?? undefined,
+		offset: searchParams.get('offset') ?? undefined,
+	};
+}
+
+export function registerEntityRoutes(app: Hono): void {
+	app.get('/api/entities', async (c) => {
+		const query = EntityListQuerySchema.parse(readEntityListQuery(c.req.url));
+		const response = await listEntities(query, c.get('requestContext')?.logger);
+		EntityListResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/entities/:id', async (c) => {
+		const response = await getEntityDetail(c.req.param('id'), c.get('requestContext')?.logger);
+		EntityDetailResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/entities/:id/edges', async (c) => {
+		const response = await getEntityEdges(c.req.param('id'), c.get('requestContext')?.logger);
+		EntityEdgesResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.post('/api/entities/merge', async (c) => {
+		const body = EntityMergeRequestSchema.parse(await readJsonBody(c));
+		const response = await mergeEntities(body.target_id, body.source_id, c.get('requestContext')?.logger);
+		EntityMergeResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -190,7 +190,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
 | 🟢 | H6 | Job status API | §10.6 |
 | 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
-| ⚪ | H8 | Entity API routes (sync) | §10.6 |
+| 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | ⚪ | H9 | Evidence API routes (sync) | §10.6 |
 | ⚪ | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
 | ⚪ | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |

--- a/docs/specs/74_entity_api_routes.spec.md
+++ b/docs/specs/74_entity_api_routes.spec.md
@@ -1,0 +1,283 @@
+---
+spec: "74"
+title: "Entity API Routes"
+roadmap_step: M7-H8
+functional_spec: ["§10.6"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/185"
+created: 2026-04-15
+---
+
+# Spec 74: Entity API Routes
+
+## 1. Objective
+
+Expose Mulder's entity-management surface over authenticated HTTP so remote clients can inspect, search, and reconcile entities without shelling into `mulder entity`. Per `§10.6`, entity lookup remains a synchronous database-backed API path rather than a queued workflow; per the M7 API architecture, the HTTP surface should cover the practical entity operations needed by clients: list/search, detail, edge inspection, and lightweight merge.
+
+This step gives the API parity with the already-shipped repository and CLI capabilities while preserving Mulder's core rule that route handlers adapt inputs and outputs only. Entity state continues to live in PostgreSQL and all domain behavior continues to flow through the existing repository layer.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H8` — Entity API routes (sync)
+- **Target:** `apps/api/src/app.ts`, `apps/api/src/routes/entities.schemas.ts`, `apps/api/src/routes/entities.ts`, `apps/api/src/lib/entities.ts`, `tests/specs/74_entity_api_routes.test.ts`
+- **In scope:** authenticated `GET /api/entities`; authenticated `GET /api/entities/:id`; authenticated `GET /api/entities/:id/edges`; authenticated `POST /api/entities/merge`; query validation for list/search filters; HTTP DTO mapping for entities, aliases, stories, and edges; not-found and validation handling; and black-box tests proving the sync contract, auth protection, filtering, detail hydration, and merge behavior
+- **Out of scope:** evidence routes (`M7-H9`), document retrieval routes (`M7-H10`), UI work (`M7-H11`), taxonomy HTTP endpoints, alias mutation endpoints, batch merge workflows, and any new repository/database behavior beyond what the shipped entity repositories already provide
+- **Constraints:** keep the routes behind the existing middleware/auth stack; stay synchronous and database-backed with no job creation; reuse `@mulder/core` repositories instead of ad hoc SQL inside handlers; keep list/detail reads in the standard rate-limit tier; and preserve the core entity semantics already established by Spec 51 instead of inventing a second merge model for HTTP
+
+## 3. Dependencies
+
+- **Requires:** Spec 24 (`M3-C3`) entity + alias repositories, Spec 25 (`M3-C4`) edge repository, Spec 51 (`M5-F3`) entity management CLI semantics, Spec 69 (`M7-H3`) Hono server scaffold, and Spec 70 (`M7-H4`) API middleware stack
+- **Blocks:** no later roadmap step is strictly blocked, but this step completes the entity HTTP surface promised by `§10.6` and the M7 API architecture so non-CLI clients can browse and reconcile entities through the real API instead of shell wrappers
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/entities.schemas.ts`** — defines the query/body schemas plus the snake_case response envelopes for list, detail, edges, and merge
+2. **`apps/api/src/lib/entities.ts`** — owns repository-backed helpers that read and merge entities, then map core rows into API DTOs
+3. **`apps/api/src/routes/entities.ts`** — registers the entity route group and delegates to the route-facing entity helpers
+4. **`apps/api/src/app.ts`** — mounts the entity route group beneath the existing middleware stack
+5. **`tests/specs/74_entity_api_routes.test.ts`** — black-box verification for the entity API surface
+
+### 4.2 Route Contract
+
+#### `GET /api/entities`
+
+Purpose: list and search canonical entity rows for authenticated API clients.
+
+Query parameters:
+
+- `type` — optional entity-type filter
+- `search` — optional case-insensitive substring filter on entity name
+- `taxonomy_status` — optional filter for `auto | curated | merged`
+- `limit` — optional integer cap with a safe default
+- `offset` — optional integer offset for parity with the current repository surface
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "canonical_id": null,
+      "name": "J. Allen Hynek",
+      "type": "person",
+      "taxonomy_status": "curated",
+      "taxonomy_id": "uuid",
+      "corroboration_score": 0.92,
+      "source_count": 4,
+      "attributes": {},
+      "created_at": "2026-04-15T12:00:00.000Z",
+      "updated_at": "2026-04-15T12:30:00.000Z"
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+Rules:
+
+- the list route returns repository-backed rows only; it does not inline aliases, stories, or full edge sets for every item
+- filters only narrow the result set and never mutate entity state
+- the HTTP surface uses snake_case even when core rows are camelCase
+
+#### `GET /api/entities/:id`
+
+Purpose: return one entity plus the related data clients need for inspection and detail views.
+
+Response shape:
+
+```json
+{
+  "data": {
+    "entity": {
+      "id": "uuid",
+      "canonical_id": null,
+      "name": "J. Allen Hynek",
+      "type": "person",
+      "taxonomy_status": "curated",
+      "taxonomy_id": "uuid",
+      "corroboration_score": 0.92,
+      "source_count": 4,
+      "attributes": {},
+      "created_at": "2026-04-15T12:00:00.000Z",
+      "updated_at": "2026-04-15T12:30:00.000Z"
+    },
+    "aliases": [
+      {
+        "id": "uuid",
+        "entity_id": "uuid",
+        "alias": "Hynek",
+        "source": "manual"
+      }
+    ],
+    "stories": [
+      {
+        "id": "uuid",
+        "source_id": "uuid",
+        "title": "Project Blue Book notes",
+        "status": "enriched",
+        "confidence": 0.9,
+        "mention_count": 2
+      }
+    ],
+    "merged_entities": []
+  }
+}
+```
+
+Rules:
+
+- unknown entity IDs return a Mulder JSON not-found response
+- the detail route must hydrate aliases, linked stories, and merged-into-this-entity lineage using the existing repository layer
+- the route does not duplicate the full edge list inline; edge inspection lives on the dedicated edges endpoint
+
+#### `GET /api/entities/:id/edges`
+
+Purpose: inspect the entity's relationships without overloading the detail response.
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "source_entity_id": "uuid",
+      "target_entity_id": "uuid",
+      "relationship": "investigated",
+      "edge_type": "RELATIONSHIP",
+      "confidence": 0.84,
+      "story_id": "uuid",
+      "attributes": {}
+    }
+  ]
+}
+```
+
+Rules:
+
+- the route returns all edges already associated with the entity via the repository layer
+- unknown entity IDs fail as not-found instead of returning a misleading empty success envelope for typos
+
+#### `POST /api/entities/merge`
+
+Purpose: expose the existing lightweight entity-merge workflow synchronously over HTTP.
+
+Request body:
+
+```json
+{
+  "target_id": "uuid",
+  "source_id": "uuid"
+}
+```
+
+Success response:
+
+```json
+{
+  "data": {
+    "target": {
+      "id": "uuid"
+    },
+    "merged": {
+      "id": "uuid",
+      "canonical_id": "uuid"
+    },
+    "edges_reassigned": 3,
+    "stories_reassigned": 2,
+    "aliases_copied": 1
+  }
+}
+```
+
+Rules:
+
+- the route reuses the existing `mergeEntities` repository behavior and validation semantics
+- same-ID merges, missing entities, or already-merged source rows surface Mulder validation/not-found errors rather than partial success payloads
+- the route is synchronous and mutation-scoped only to the merge operation; it must not enqueue jobs or create pipeline rows
+
+### 4.3 Integration Points
+
+- the route group consumes the middleware protections from Spec 70, including bearer auth and standard-tier rate limiting
+- entity reads and merges reuse the shipped core repository functions instead of route-local SQL
+- the API layer should preserve CLI/API behavior parity by mapping HTTP fields only, leaving merge semantics and entity hydration logic anchored in core repositories
+- request-scoped logging should record route metadata such as filter set, entity ID, merge IDs, and result counts without introducing a second logging system
+
+### 4.4 Implementation Phases
+
+**Phase 1: DTOs + repository-backed entity bridge**
+- add list/detail/edges/merge schemas
+- implement the API-facing entity helper that loads the query pool and maps repository rows into snake_case DTOs
+
+**Phase 2: Route wiring**
+- register `GET /api/entities`
+- register `GET /api/entities/:id`
+- register `GET /api/entities/:id/edges`
+- register `POST /api/entities/merge`
+- mount the route group in the Hono app without weakening the existing middleware protections
+
+**Phase 3: Black-box QA**
+- add API-focused tests for list filtering, detail hydration, edge inspection, merge success, validation failures, not-found behavior, and auth protection
+- verify the API package still compiles with the new route surface
+
+## 5. QA Contract
+
+1. **QA-01: `GET /api/entities` lists entities for an authenticated request**
+   - Given: entities exist in the database
+   - When: `GET /api/entities` is called with a valid bearer token
+   - Then: the response is `200` and returns a `data` array plus `meta.count`
+
+2. **QA-02: list filters narrow the entity result set without mutating data**
+   - Given: entities with different `type`, `taxonomy_status`, and names exist
+   - When: `GET /api/entities` is called with `type`, `taxonomy_status`, and `search` filters
+   - Then: the response contains only the matching entities and the underlying entity rows are unchanged
+
+3. **QA-03: `GET /api/entities/:id` returns the entity with aliases, linked stories, and merged lineage**
+   - Given: an entity with aliases, story links, and optionally merged child entities exists
+   - When: `GET /api/entities/:id` is called
+   - Then: the response is `200` and returns `entity`, `aliases`, `stories`, and `merged_entities`
+
+4. **QA-04: `GET /api/entities/:id/edges` returns relationship rows for the entity**
+   - Given: an entity participates in one or more `entity_edges`
+   - When: `GET /api/entities/:id/edges` is called
+   - Then: the response is `200` and returns the related edge rows in the API envelope
+
+5. **QA-05: unknown entity IDs fail with a Mulder JSON not-found response**
+   - Given: an entity ID that does not exist
+   - When: either detail or edges is requested
+   - Then: the API returns a JSON not-found error and does not emit a success envelope
+
+6. **QA-06: `POST /api/entities/merge` performs the shipped merge workflow synchronously**
+   - Given: two distinct canonical entities exist
+   - When: `POST /api/entities/merge` is called with `target_id` and `source_id`
+   - Then: the response is `200`, the source entity is marked merged into the target, and the returned counters reflect the reassigned stories, edges, and aliases
+
+7. **QA-07: invalid merge requests fail at the HTTP or repository edge**
+   - Given: a merge request with the same ID twice, a missing entity, or an already-merged source
+   - When: `POST /api/entities/merge` is called
+   - Then: the API returns a Mulder validation/not-found error and does not partially mutate entity state
+
+8. **QA-08: entity routes stay behind the existing auth middleware**
+   - Given: the entity routes are mounted in the API app
+   - When: any entity route is requested without a valid bearer token
+   - Then: the response is `401` and no entity data is exposed
+
+9. **QA-09: the API package compiles with the new entity route surface**
+   - Given: the route, schemas, and entity bridge are wired into `@mulder/api`
+   - When: the API package build/typecheck runs
+   - Then: the package compiles successfully and exports a bootable app with the entity routes mounted
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands are introduced or modified in this step.
+
+## 6. Cost Considerations
+
+No direct third-party spend is added by these routes because the entity surface is PostgreSQL-backed and synchronous. The implementation is still operationally cost-sensitive because list polling and merge misuse could create unnecessary database load, so the routes must keep validation at the HTTP edge, stay on the existing standard rate-limit tier, and avoid any inline LLM, GCS, or job-queue work.

--- a/tests/specs/74_entity_api_routes.test.ts
+++ b/tests/specs/74_entity_api_routes.test.ts
@@ -1,0 +1,672 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const RETRIEVAL_DIR = resolve(ROOT, 'packages/retrieval');
+const TAXONOMY_DIR = resolve(ROOT, 'packages/taxonomy');
+const EVIDENCE_DIR = resolve(ROOT, 'packages/evidence');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const RETRIEVAL_DIST = resolve(RETRIEVAL_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+interface ApiApp {
+	request: (input: string | Request, init?: RequestInit) => Promise<Response>;
+	fetch: (input: string | Request, init?: RequestInit) => Promise<Response>;
+}
+
+interface EntityFixtures {
+	listPersonId: string;
+	listLocationId: string;
+	listOtherPersonId: string;
+	detailEntityId: string;
+	detailMergedChildId: string;
+	detailStoryOneId: string;
+	detailStoryTwoId: string;
+	detailIncomingEntityId: string;
+	mergeTargetId: string;
+	mergeSourceId: string;
+	mergeStoryOneId: string;
+	mergeStoryTwoId: string;
+	mergeEdgePartnerId: string;
+	alreadyMergedEntityId: string;
+	aliasEntityId: string;
+}
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function sqlString(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function cleanState(): void {
+	truncateMulderTables();
+}
+
+function seedSource(filename: string): string {
+	const id = randomUUID();
+	const fileHash = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
+	db.runSql(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, status, metadata)',
+			`VALUES (${sqlString(id)}, ${sqlString(filename)}, ${sqlString(`raw/${filename}`)}, ${sqlString(fileHash)}, 1, 'ingested', '{}'::jsonb)`,
+			'ON CONFLICT (id) DO NOTHING;',
+		].join(' '),
+	);
+	return id;
+}
+
+function seedStory(opts: { id?: string; sourceId: string; title: string; status?: string }): string {
+	const id = opts.id ?? randomUUID();
+	const slug = id.replace(/-/g, '');
+	db.runSql(
+		[
+			'INSERT INTO stories (id, source_id, title, gcs_markdown_uri, gcs_metadata_uri, status, metadata)',
+			`VALUES (${sqlString(id)}, ${sqlString(opts.sourceId)}, ${sqlString(opts.title)}, ${sqlString(`gs://test/${slug}.md`)}, ${sqlString(`gs://test/${slug}.meta.json`)}, ${sqlString(opts.status ?? 'enriched')}, '{}'::jsonb)`,
+			'ON CONFLICT (id) DO NOTHING;',
+		].join(' '),
+	);
+	return id;
+}
+
+function seedEntity(opts: {
+	id?: string;
+	name: string;
+	type: string;
+	canonicalId?: string | null;
+	taxonomyStatus?: 'auto' | 'curated' | 'merged';
+	taxonomyId?: string | null;
+	sourceCount?: number;
+	corroborationScore?: number | null;
+}): string {
+	const id = opts.id ?? randomUUID();
+	const canonicalId =
+		opts.canonicalId === undefined || opts.canonicalId === null ? 'NULL' : sqlString(opts.canonicalId);
+	const taxonomyId = opts.taxonomyId === undefined || opts.taxonomyId === null ? 'NULL' : sqlString(opts.taxonomyId);
+	const sourceCount = opts.sourceCount ?? 0;
+	const corroborationScore =
+		opts.corroborationScore === undefined || opts.corroborationScore === null
+			? 'NULL'
+			: String(opts.corroborationScore);
+	db.runSql(
+		[
+			'INSERT INTO entities (id, name, type, canonical_id, taxonomy_status, taxonomy_id, corroboration_score, source_count, attributes)',
+			`VALUES (${sqlString(id)}, ${sqlString(opts.name)}, ${sqlString(opts.type)}, ${canonicalId}, ${sqlString(opts.taxonomyStatus ?? 'auto')}, ${taxonomyId}, ${corroborationScore}, ${sourceCount}, '{}'::jsonb)`,
+			'ON CONFLICT (id) DO NOTHING;',
+		].join(' '),
+	);
+	return id;
+}
+
+function seedAlias(opts: { entityId: string; alias: string; source?: string }): string {
+	const id = randomUUID();
+	db.runSql(
+		[
+			'INSERT INTO entity_aliases (id, entity_id, alias, source)',
+			`VALUES (${sqlString(id)}, ${sqlString(opts.entityId)}, ${sqlString(opts.alias)}, ${opts.source ? sqlString(opts.source) : `'manual'`})`,
+			'ON CONFLICT DO NOTHING;',
+		].join(' '),
+	);
+	return id;
+}
+
+function seedStoryEntity(storyId: string, entityId: string, confidence: number, mentionCount: number): void {
+	db.runSql(
+		[
+			'INSERT INTO story_entities (story_id, entity_id, confidence, mention_count)',
+			`VALUES (${sqlString(storyId)}, ${sqlString(entityId)}, ${confidence}, ${mentionCount})`,
+			'ON CONFLICT DO NOTHING;',
+		].join(' '),
+	);
+}
+
+function seedEdge(opts: {
+	sourceEntityId: string;
+	targetEntityId: string;
+	relationship: string;
+	storyId?: string | null;
+	edgeType?:
+		| 'RELATIONSHIP'
+		| 'DUPLICATE_OF'
+		| 'POTENTIAL_CONTRADICTION'
+		| 'CONFIRMED_CONTRADICTION'
+		| 'DISMISSED_CONTRADICTION';
+	confidence?: number | null;
+}): string {
+	const id = randomUUID();
+	const storyId = opts.storyId === undefined || opts.storyId === null ? 'NULL' : sqlString(opts.storyId);
+	const confidence = opts.confidence === undefined || opts.confidence === null ? 'NULL' : String(opts.confidence);
+	db.runSql(
+		[
+			'INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type)',
+			`VALUES (${sqlString(id)}, ${sqlString(opts.sourceEntityId)}, ${sqlString(opts.targetEntityId)}, ${sqlString(opts.relationship)}, '{}'::jsonb, ${confidence}, ${storyId}, ${sqlString(opts.edgeType ?? 'RELATIONSHIP')})`,
+			'ON CONFLICT DO NOTHING;',
+		].join(' '),
+	);
+	return id;
+}
+
+function seedFixtures(): EntityFixtures {
+	const sourceId = seedSource('spec74-entities.pdf');
+	const detailStoryOneId = seedStory({
+		sourceId,
+		title: 'Project Blue Book notes',
+		status: 'enriched',
+	});
+	const detailStoryTwoId = seedStory({
+		sourceId,
+		title: 'Hynek interview transcript',
+		status: 'enriched',
+	});
+	const mergeStoryOneId = seedStory({
+		sourceId,
+		title: 'Merge source evidence one',
+		status: 'graphed',
+	});
+	const mergeStoryTwoId = seedStory({
+		sourceId,
+		title: 'Merge source evidence two',
+		status: 'graphed',
+	});
+
+	const listPersonId = seedEntity({
+		name: 'Josef Allen Hynek',
+		type: 'person',
+		taxonomyStatus: 'curated',
+		sourceCount: 3,
+		corroborationScore: 0.85,
+	});
+	const listLocationId = seedEntity({
+		name: 'Area 51',
+		type: 'location',
+		taxonomyStatus: 'auto',
+		sourceCount: 5,
+	});
+	const listOtherPersonId = seedEntity({
+		name: 'Kenneth Arnold',
+		type: 'person',
+		taxonomyStatus: 'auto',
+		sourceCount: 1,
+	});
+
+	const detailEntityId = listPersonId;
+	const detailMergedChildId = seedEntity({
+		name: 'Hynek Alias Cluster',
+		type: 'person',
+		canonicalId: detailEntityId,
+		taxonomyStatus: 'merged',
+	});
+	seedAlias({ entityId: detailEntityId, alias: 'Dr. Hynek', source: 'manual' });
+	seedAlias({ entityId: detailEntityId, alias: 'J. Allen Hynek', source: 'extraction' });
+	seedStoryEntity(detailStoryOneId, detailEntityId, 0.9, 2);
+	seedStoryEntity(detailStoryTwoId, detailEntityId, 0.8, 1);
+	seedEdge({
+		sourceEntityId: detailEntityId,
+		targetEntityId: listLocationId,
+		relationship: 'INVESTIGATED_AT',
+		storyId: detailStoryOneId,
+		confidence: 0.84,
+	});
+	seedEdge({
+		sourceEntityId: listOtherPersonId,
+		targetEntityId: detailEntityId,
+		relationship: 'WITNESSED',
+		storyId: detailStoryTwoId,
+		confidence: 0.77,
+	});
+
+	const mergeTargetId = seedEntity({
+		name: 'Merge Target',
+		type: 'person',
+		taxonomyStatus: 'curated',
+	});
+	const mergeSourceId = seedEntity({
+		name: 'Merge Source',
+		type: 'person',
+		taxonomyStatus: 'curated',
+	});
+	const mergeEdgePartnerId = listLocationId;
+	seedAlias({ entityId: mergeSourceId, alias: 'Source Alias', source: 'extraction' });
+	seedStoryEntity(mergeStoryOneId, mergeSourceId, 0.95, 1);
+	seedStoryEntity(mergeStoryTwoId, mergeSourceId, 0.88, 3);
+	seedEdge({
+		sourceEntityId: mergeSourceId,
+		targetEntityId: mergeEdgePartnerId,
+		relationship: 'VISITED',
+		storyId: mergeStoryOneId,
+		confidence: 0.9,
+	});
+
+	const alreadyMergedEntityId = seedEntity({
+		name: 'Already Merged',
+		type: 'person',
+		canonicalId: listLocationId,
+		taxonomyStatus: 'merged',
+	});
+
+	const aliasEntityId = seedEntity({
+		name: 'Alias Entity',
+		type: 'organization',
+		taxonomyStatus: 'auto',
+	});
+	seedAlias({ entityId: aliasEntityId, alias: 'Alias One', source: 'extraction' });
+	seedAlias({ entityId: aliasEntityId, alias: 'Alias Two', source: 'manual' });
+
+	return {
+		listPersonId,
+		listLocationId,
+		listOtherPersonId,
+		detailEntityId,
+		detailMergedChildId,
+		detailStoryOneId,
+		detailStoryTwoId,
+		detailIncomingEntityId: listOtherPersonId,
+		mergeTargetId,
+		mergeSourceId,
+		mergeStoryOneId,
+		mergeStoryTwoId,
+		mergeEdgePartnerId,
+		alreadyMergedEntityId,
+		aliasEntityId,
+	};
+}
+
+function authorizedHeaders(ip: string): Record<string, string> {
+	return {
+		Authorization: 'Bearer test-api-key',
+		'Content-Type': 'application/json',
+		'X-Forwarded-For': ip,
+	};
+}
+
+async function loadApiApp(): Promise<ApiApp> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+async function apiGet(app: ApiApp, path: string, ip: string): Promise<Response> {
+	return app.request(`http://localhost${path}`, {
+		method: 'GET',
+		headers: authorizedHeaders(ip),
+	});
+}
+
+async function apiPost(app: ApiApp, path: string, body: unknown, ip: string): Promise<Response> {
+	return app.request(`http://localhost${path}`, {
+		method: 'POST',
+		headers: authorizedHeaders(ip),
+		body: JSON.stringify(body),
+	});
+}
+
+describe('Spec 74 — Entity API Routes', () => {
+	const originalConfig = process.env.MULDER_CONFIG;
+	const originalLogLevel = process.env.MULDER_LOG_LEVEL;
+	let app: ApiApp;
+	let pgAvailable = false;
+	let fixtures: EntityFixtures;
+
+	beforeAll(async () => {
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			return;
+		}
+
+		ensureSchema();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		buildPackage(CORE_DIR);
+		buildPackage(RETRIEVAL_DIR);
+		buildPackage(TAXONOMY_DIR);
+		buildPackage(EVIDENCE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+
+		await import(pathToFileURL(CORE_DIST).href);
+		await import(pathToFileURL(RETRIEVAL_DIST).href);
+
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(() => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		cleanState();
+		fixtures = seedFixtures();
+	});
+
+	afterAll(() => {
+		if (pgAvailable) {
+			try {
+				cleanState();
+			} catch {
+				// Ignore cleanup failures.
+			}
+		}
+
+		if (originalConfig === undefined) {
+			delete process.env.MULDER_CONFIG;
+		} else {
+			process.env.MULDER_CONFIG = originalConfig;
+		}
+
+		if (originalLogLevel === undefined) {
+			delete process.env.MULDER_LOG_LEVEL;
+		} else {
+			process.env.MULDER_LOG_LEVEL = originalLogLevel;
+		}
+	});
+
+	it('QA-01: GET /api/entities lists entities for an authenticated request', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await apiGet(app, '/api/entities', '203.0.113.10');
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toMatchObject({
+			meta: {
+				count: expect.any(Number),
+				limit: 20,
+				offset: 0,
+			},
+		});
+
+		const names = (body as { data: Array<{ name: string }> }).data.map((item) => item.name);
+		expect(names).toEqual([...names].sort((left, right) => left.localeCompare(right)));
+		expect((body as { data: unknown[]; meta: { count: number } }).data.length).toBe(
+			(body as { meta: { count: number } }).meta.count,
+		);
+	});
+
+	it('QA-02: list filters narrow the entity result set without mutating data', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const beforeCount = Number(db.runSql('SELECT COUNT(*) FROM entities;'));
+		const response = await apiGet(
+			app,
+			'/api/entities?type=person&taxonomy_status=curated&search=hynek',
+			'203.0.113.11',
+		);
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as { data: Array<{ id: string; name: string }>; meta: { count: number } };
+		expect(body.meta.count).toBe(1);
+		expect(body.data).toHaveLength(1);
+		expect(body.data[0]).toMatchObject({
+			id: fixtures.detailEntityId,
+			name: 'Josef Allen Hynek',
+		});
+		expect(Number(db.runSql('SELECT COUNT(*) FROM entities;'))).toBe(beforeCount);
+	});
+
+	it('QA-03: GET /api/entities/:id returns the entity with aliases, linked stories, and merged lineage', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await apiGet(app, `/api/entities/${fixtures.detailEntityId}`, '203.0.113.12');
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			data: {
+				entity: { id: string; name: string };
+				aliases: Array<{ alias: string }>;
+				stories: Array<{ title: string; confidence: number | null; mention_count: number }>;
+				merged_entities: Array<{ id: string; name: string }>;
+			};
+		};
+
+		expect(body.data.entity).toMatchObject({
+			id: fixtures.detailEntityId,
+			name: 'Josef Allen Hynek',
+		});
+		expect(body.data.aliases.map((alias) => alias.alias).sort()).toEqual(['Dr. Hynek', 'J. Allen Hynek']);
+		expect(body.data.stories).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					title: 'Project Blue Book notes',
+					confidence: 0.9,
+					mention_count: 2,
+				}),
+				expect.objectContaining({
+					title: 'Hynek interview transcript',
+					confidence: 0.8,
+					mention_count: 1,
+				}),
+			]),
+		);
+		expect(body.data.merged_entities).toEqual([
+			expect.objectContaining({
+				id: fixtures.detailMergedChildId,
+				name: 'Hynek Alias Cluster',
+			}),
+		]);
+	});
+
+	it('QA-04: unknown entity IDs fail with a JSON not-found response', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const missingId = randomUUID();
+		for (const path of [`/api/entities/${missingId}`, `/api/entities/${missingId}/edges`]) {
+			const response = await apiGet(app, path, '203.0.113.13');
+			expect(response.status).toBe(404);
+			expect(await response.json()).toMatchObject({
+				error: {
+					code: 'DB_NOT_FOUND',
+					message: expect.stringContaining('Entity not found'),
+				},
+			});
+		}
+	});
+
+	it('QA-05: GET /api/entities/:id/edges returns relationship rows for the entity', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await apiGet(app, `/api/entities/${fixtures.detailEntityId}/edges`, '203.0.113.14');
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			data: Array<{
+				id: string;
+				source_entity_id: string;
+				target_entity_id: string;
+				relationship: string;
+				edge_type: string;
+				confidence: number | null;
+				story_id: string | null;
+			}>;
+		};
+
+		expect(body.data).toHaveLength(2);
+		expect(body.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					source_entity_id: fixtures.detailEntityId,
+					target_entity_id: fixtures.listLocationId,
+					relationship: 'INVESTIGATED_AT',
+					edge_type: 'RELATIONSHIP',
+				}),
+				expect.objectContaining({
+					source_entity_id: fixtures.listOtherPersonId,
+					target_entity_id: fixtures.detailEntityId,
+					relationship: 'WITNESSED',
+					edge_type: 'RELATIONSHIP',
+				}),
+			]),
+		);
+	});
+
+	it('QA-06: POST /api/entities/merge performs the shipped merge workflow synchronously', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const beforeJobs = Number(db.runSql('SELECT COUNT(*) FROM jobs;'));
+		const beforeRuns = Number(db.runSql('SELECT COUNT(*) FROM pipeline_runs;'));
+		const response = await apiPost(
+			app,
+			'/api/entities/merge',
+			{
+				target_id: fixtures.mergeTargetId,
+				source_id: fixtures.mergeSourceId,
+			},
+			'203.0.113.15',
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			data: {
+				target: {
+					id: fixtures.mergeTargetId,
+				},
+				merged: {
+					id: fixtures.mergeSourceId,
+					canonical_id: fixtures.mergeTargetId,
+				},
+				edges_reassigned: 1,
+				stories_reassigned: 2,
+				aliases_copied: 2,
+			},
+		});
+
+		expect(Number(db.runSql('SELECT COUNT(*) FROM jobs;'))).toBe(beforeJobs);
+		expect(Number(db.runSql('SELECT COUNT(*) FROM pipeline_runs;'))).toBe(beforeRuns);
+		expect(
+			Number(db.runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = ${sqlString(fixtures.mergeTargetId)};`)),
+		).toBe(2);
+		expect(
+			Number(db.runSql(`SELECT COUNT(*) FROM story_entities WHERE entity_id = ${sqlString(fixtures.mergeSourceId)};`)),
+		).toBe(0);
+		expect(
+			Number(
+				db.runSql(
+					`SELECT COUNT(*) FROM entity_edges WHERE source_entity_id = ${sqlString(fixtures.mergeSourceId)} OR target_entity_id = ${sqlString(fixtures.mergeSourceId)};`,
+				),
+			),
+		).toBe(0);
+		expect(
+			Number(db.runSql(`SELECT COUNT(*) FROM entity_aliases WHERE entity_id = ${sqlString(fixtures.mergeTargetId)};`)),
+		).toBe(2);
+		expect(db.runSql(`SELECT canonical_id FROM entities WHERE id = ${sqlString(fixtures.mergeSourceId)};`)).toBe(
+			fixtures.mergeTargetId,
+		);
+		expect(db.runSql(`SELECT taxonomy_status FROM entities WHERE id = ${sqlString(fixtures.mergeSourceId)};`)).toBe(
+			'merged',
+		);
+	});
+
+	it('QA-07: same-ID merges return a validation error', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await apiPost(
+			app,
+			'/api/entities/merge',
+			{
+				target_id: fixtures.mergeTargetId,
+				source_id: fixtures.mergeTargetId,
+			},
+			'203.0.113.16',
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+			},
+		});
+	});
+
+	it('QA-08: already-merged source entities return a validation error', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await apiPost(
+			app,
+			'/api/entities/merge',
+			{
+				target_id: fixtures.mergeTargetId,
+				source_id: fixtures.alreadyMergedEntityId,
+			},
+			'203.0.113.17',
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+			},
+		});
+	});
+
+	it('QA-09: the entity routes stay behind the existing auth middleware', async () => {
+		if (!pgAvailable) {
+			return;
+		}
+
+		const response = await app.request('http://localhost/api/entities', {
+			method: 'GET',
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+			},
+		});
+	});
+});


### PR DESCRIPTION
Adds the authenticated synchronous entity HTTP surface for list, detail, edge inspection, and merge.\n\nTraceability:\n- Spec: docs/specs/74_entity_api_routes.spec.md\n- Roadmap: M7-H8\n- Issue: Closes #185\n\nVerification:\n- pnpm turbo run build --filter='...[HEAD]'\n- npx biome check .\n- pnpm vitest run tests/specs/74_entity_api_routes.test.ts