### PR TITLE
API: harden job status path validation — M7-H6

### DIFF
--- a/apps/api/src/routes/jobs.schemas.ts
+++ b/apps/api/src/routes/jobs.schemas.ts
@@ -15,6 +15,10 @@ export const JobListQuerySchema = z.object({
 	limit: z.coerce.number().int().positive().max(100).optional().default(20),
 });
 
+export const JobDetailParamsSchema = z.object({
+	id: z.string().uuid(),
+});
+
 export const JobSummarySchema = z.object({
 	id: z.string().uuid(),
 	type: z.string(),
@@ -80,5 +84,6 @@ export const JobDetailResponseSchema = z.object({
 });
 
 export type JobListQuery = z.infer<typeof JobListQuerySchema>;
+export type JobDetailParams = z.infer<typeof JobDetailParamsSchema>;
 export type JobListResponse = z.infer<typeof JobListResponseSchema>;
 export type JobDetailResponse = z.infer<typeof JobDetailResponseSchema>;

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,6 +1,11 @@
 import type { Hono } from 'hono';
 import { getJobStatusById, listRecentJobs } from '../lib/job-status.js';
-import { JobDetailResponseSchema, JobListQuerySchema, JobListResponseSchema } from './jobs.schemas.js';
+import {
+	JobDetailParamsSchema,
+	JobDetailResponseSchema,
+	JobListQuerySchema,
+	JobListResponseSchema,
+} from './jobs.schemas.js';
 
 function readJobListQuery(url: string): Record<string, string | undefined> {
 	const searchParams = new URL(url).searchParams;
@@ -21,7 +26,8 @@ export function registerJobRoutes(app: Hono): void {
 	});
 
 	app.get('/api/jobs/:id', async (c) => {
-		const response = await getJobStatusById(c.req.param('id'));
+		const { id } = JobDetailParamsSchema.parse({ id: c.req.param('id') });
+		const response = await getJobStatusById(id);
 		JobDetailResponseSchema.parse(response);
 		return c.json(response, 200);
 	});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -188,7 +188,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
-| 🟢 | H6 | Job status API | §10.6 |
+| 🟡 | H6 | Job status API | §10.6 |
 | 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | ⚪ | H9 | Evidence API routes (sync) | §10.6 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -188,7 +188,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H3 | Hono server scaffold — app, node-server, health endpoint | §13 (apps/api/) |
 | 🟢 | H4 | Middleware — auth, rate limiting, error handling, request context | §10.6 (rate limiting tiers) |
 | 🟢 | H5 | Pipeline API routes (async) | §10.2, §10.6 |
-| 🟡 | H6 | Job status API | §10.6 |
+| 🟢 | H6 | Job status API | §10.6 |
 | 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | ⚪ | H9 | Evidence API routes (sync) | §10.6 |

--- a/docs/specs/75_job_status_api_path_validation_hardening.spec.md
+++ b/docs/specs/75_job_status_api_path_validation_hardening.spec.md
@@ -1,0 +1,93 @@
+---
+spec: "75"
+title: "Job Status API Path Validation Hardening"
+roadmap_step: M7-H6
+functional_spec: ["§10.6"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/188"
+created: 2026-04-15
+---
+
+# Spec 75: Job Status API Path Validation Hardening
+
+## 1. Objective
+
+Harden Mulder's `GET /api/jobs/:id` contract so malformed job IDs fail as client validation errors at the HTTP boundary instead of surfacing downstream PostgreSQL UUID errors as `503` responses. Per `§10.6`, the jobs API is a lightweight read surface for polling queued work; invalid path input should therefore be rejected early with a stable `400` JSON validation response while preserving the existing `404` behavior for unknown but well-formed UUIDs.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H6` — Job status API
+- **Target:** `apps/api/src/routes/jobs.schemas.ts`, `apps/api/src/routes/jobs.ts`, `tests/specs/72_job_status_api.test.ts`
+- **In scope:** a Zod-backed path-param schema for `/api/jobs/:id`; route-level UUID validation before `getJobStatusById()` is called; preserving the existing success and not-found contracts for valid UUIDs; and black-box tests proving malformed IDs return `400` instead of `503`
+- **Out of scope:** list-route query changes for `GET /api/jobs`; payload `runId` / `run_id` hardening inside `apps/api/src/lib/job-status.ts`; queue schema or repository changes; new middleware behavior; and any search/entity/evidence/document API work
+- **Constraints:** keep the route behind the existing auth and rate-limit stack; rely on the existing error-handler behavior for Zod validation failures; do not weaken the current `404` not-found contract for valid UUIDs that do not exist; and keep the fix limited to the route boundary rather than pushing malformed IDs into the repository layer
+
+## 3. Dependencies
+
+- **Requires:** Spec 70 (`M7-H4`) API middleware stack for Zod validation error handling, and Spec 72 (`M7-H6`) job status API for the existing route surface and response shapes
+- **Blocks:** no later roadmap step directly, but this follow-up restores the client-visible contract expected by API consumers polling `/api/jobs/:id`
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/jobs.schemas.ts`** — add a dedicated params schema for the job detail route, using UUID validation compatible with the current error-handler stack
+2. **`apps/api/src/routes/jobs.ts`** — parse `c.req.param('id')` through the params schema before calling `getJobStatusById()`
+3. **`tests/specs/72_job_status_api.test.ts`** — add black-box coverage for malformed job IDs returning `400`, while retaining the existing `404` assertion for missing but valid UUIDs
+
+### 4.2 Route Contract Adjustment
+
+#### `GET /api/jobs/:id`
+
+Additional rule:
+
+- malformed non-UUID path values are rejected with a `400` Mulder validation error before any repository query runs
+
+Examples:
+
+- `/api/jobs/not-a-uuid` → `400` with `error.code = "VALIDATION_ERROR"`
+- `/api/jobs/550e8400-e29b-41d4-a716-446655440000` when the row does not exist → existing `404 DB_NOT_FOUND`
+
+### 4.3 Implementation Phases
+
+**Phase 1: Route schema**
+- add a `JobDetailParamsSchema` (or equivalent) in `jobs.schemas.ts`
+- keep the shape minimal: `{ id: uuid }`
+
+**Phase 2: Route hardening**
+- parse the route param in `registerJobRoutes()`
+- pass only the validated UUID string into `getJobStatusById()`
+
+**Phase 3: Regression QA**
+- add a malformed-ID test that asserts `400`
+- keep the existing missing-valid-UUID test to prove `404` still works
+
+## 5. QA Contract
+
+1. **QA-01: malformed job IDs fail fast with a validation error**
+   - Given: the jobs routes are mounted and authenticated
+   - When: `GET /api/jobs/not-a-uuid` is called
+   - Then: the response is `400` with Mulder's JSON validation error envelope, and no `503 DB_QUERY_FAILED` response is emitted
+
+2. **QA-02: unknown but valid UUIDs still return not-found**
+   - Given: a well-formed UUID that does not exist in the `jobs` table
+   - When: `GET /api/jobs/:id` is called with that UUID
+   - Then: the response remains `404` with `DB_NOT_FOUND`
+
+3. **QA-03: known job detail behavior is unchanged for valid UUIDs**
+   - Given: an existing job row
+   - When: `GET /api/jobs/:id` is called with that job's UUID
+   - Then: the response still succeeds with `200` and returns the existing job detail envelope
+
+4. **QA-04: the API package still compiles with the hardened route**
+   - Given: the route files are wired into `@mulder/api`
+   - When: the API package build or typecheck runs
+   - Then: the package compiles successfully without changing the public route surface beyond the new validation behavior
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+None for direct third-party spend. This is a route-boundary validation hardening change on an existing PostgreSQL-backed read endpoint.

--- a/tests/specs/72_job_status_api.test.ts
+++ b/tests/specs/72_job_status_api.test.ts
@@ -63,43 +63,22 @@ function cleanState(): void {
 	);
 }
 
-function insertSourceRow(sourceId: string): void {
+function seedJobProgressState(input: {
+	runId: string;
+	sourceId: string;
+	currentStep: string;
+	sourceStatus: 'pending' | 'processing' | 'completed' | 'failed';
+	updatedAt: string;
+}): void {
 	const fileHash = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
 	db.runSql(
 		[
 			'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata)',
-			`VALUES ('${sourceId}', 'route-test.pdf', '/tmp/route-test.pdf', '${fileHash}', 1, true, 1, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb)`,
+			`VALUES ('${input.sourceId}', 'route-test.pdf', '/tmp/route-test.pdf', '${fileHash}', 1, true, 1, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb)`,
 			'ON CONFLICT (id) DO UPDATE SET updated_at = now();',
-		].join(' '),
-	);
-}
-
-function insertPipelineRun(runId: string, status: 'running' | 'completed' | 'partial' | 'failed'): void {
-	db.runSql(
-		[
-			`INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at)`,
-			`VALUES ('${runId}', 'status-test', '{}'::jsonb, '${status}', TIMESTAMPTZ '2026-04-14T12:00:02.000Z',`,
-			status === 'running' ? 'NULL' : `TIMESTAMPTZ '2026-04-14T12:00:06.000Z'`,
-			');',
-		].join(' '),
-	);
-}
-
-function insertPipelineRunSource(input: {
-	runId: string;
-	sourceId: string;
-	currentStep: string;
-	status: 'pending' | 'processing' | 'completed' | 'failed';
-	errorMessage?: string | null;
-	updatedAt: string;
-}): void {
-	db.runSql(
-		[
+			`INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at) VALUES ('${input.runId}', 'status-test', '{}'::jsonb, 'running', TIMESTAMPTZ '2026-04-14T12:00:02.000Z', NULL);`,
 			'INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status, error_message, updated_at)',
-			`VALUES ('${input.runId}', '${input.sourceId}', '${input.currentStep}', '${input.status}',`,
-			input.errorMessage === null || input.errorMessage === undefined ? 'NULL' : `'${input.errorMessage}'`,
-			`, TIMESTAMPTZ '${input.updatedAt}')`,
-			'ON CONFLICT (run_id, source_id) DO UPDATE SET current_step = EXCLUDED.current_step, status = EXCLUDED.status, error_message = EXCLUDED.error_message, updated_at = EXCLUDED.updated_at;',
+			`VALUES ('${input.runId}', '${input.sourceId}', '${input.currentStep}', '${input.sourceStatus}', NULL, TIMESTAMPTZ '${input.updatedAt}');`,
 		].join(' '),
 	);
 }
@@ -196,13 +175,11 @@ describe('Spec 72 — Job Status API', () => {
 		runId = randomUUID();
 		sourceId = randomUUID();
 		cleanState();
-		insertSourceRow(sourceId);
-		insertPipelineRun(runId, 'running');
-		insertPipelineRunSource({
+		seedJobProgressState({
 			runId,
 			sourceId,
 			currentStep: 'extract',
-			status: 'processing',
+			sourceStatus: 'processing',
 			updatedAt: '2026-04-14T12:00:05.000Z',
 		});
 		insertJob({
@@ -536,6 +513,20 @@ describe('Spec 72 — Job Status API', () => {
 			error: {
 				code: 'AUTH_UNAUTHORIZED',
 				message: 'A valid API key is required',
+			},
+		});
+	});
+
+	it('QA-05: malformed job ids return a validation error before the repository layer', async () => {
+		const response = await app.request('http://localhost/api/jobs/not-a-uuid', {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+				message: 'Invalid request',
 			},
 		});
 	});


### PR DESCRIPTION
Implements Spec 75 / M7-H6 for issue #188.\n\n- Validates GET /api/jobs/:id path params as UUIDs before repository lookup\n- Preserves 404 for missing but well-formed UUIDs\n- Adds regression coverage for malformed IDs returning 400\n\nSpec: docs/specs/75_job_status_api_path_validation_hardening.spec.md\nCloses #188