### PR TITLE
[API] Document retrieval routes — M7-H10

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { createRateLimitMiddleware } from './middleware/rate-limit.js';
 import { createRequestContextMiddleware } from './middleware/request-context.js';
 import { createRequestIdMiddleware } from './middleware/request-id.js';
 import { createSecureHeadersMiddleware } from './middleware/secure-headers.js';
+import { registerDocumentRoutes } from './routes/documents.js';
 import { registerEntityRoutes } from './routes/entities.js';
 import { registerEvidenceRoutes } from './routes/evidence.js';
 import { registerHealthRoute } from './routes/health.js';
@@ -36,6 +37,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	registerHealthRoute(app);
 	registerEntityRoutes(app);
 	registerEvidenceRoutes(app);
+	registerDocumentRoutes(app);
 	registerJobRoutes(app);
 	registerPipelineRoutes(app);
 	registerSearchRoute(app);

--- a/apps/api/src/lib/documents.ts
+++ b/apps/api/src/lib/documents.ts
@@ -1,0 +1,415 @@
+import { performance } from 'node:perf_hooks';
+import {
+	countSources,
+	createChildLogger,
+	createLogger,
+	createServiceRegistry,
+	DATABASE_ERROR_CODES,
+	DatabaseError,
+	findAllSources,
+	findSourceById,
+	getQueryPool,
+	type Logger,
+	loadConfig,
+	type MulderConfig,
+	MulderError,
+	type Services,
+	type Source,
+	type SourceFilter,
+} from '@mulder/core';
+import type pg from 'pg';
+import type {
+	DocumentArtifact,
+	DocumentListItem,
+	DocumentListQuery,
+	DocumentListResponse,
+	DocumentPageItem,
+	DocumentPagesResponse,
+} from '../routes/documents.schemas.js';
+
+interface DocumentContext {
+	config: MulderConfig;
+	pool: pg.Pool;
+	services: Services;
+}
+
+const DOCUMENT_NOT_FOUND_CODE = 'DOCUMENT_NOT_FOUND';
+const PDF_CONTENT_TYPE = 'application/pdf';
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
+const PNG_CONTENT_TYPE = 'image/png';
+
+let cachedContext: DocumentContext | null = null;
+let cachedConfigPath: string | null = null;
+
+function resolveConfigPath(): string {
+	return process.env.MULDER_CONFIG ?? 'mulder.config.yaml';
+}
+
+function createRouteLogger(rootLogger: Logger, metadata: Record<string, string | number | boolean | null | undefined>) {
+	return createChildLogger(rootLogger, {
+		module: 'api',
+		route: 'documents',
+		...metadata,
+	});
+}
+
+function resolveContext(logger: Logger): DocumentContext {
+	const configPath = resolveConfigPath();
+	if (cachedContext && cachedConfigPath === configPath) {
+		return cachedContext;
+	}
+
+	const config = loadConfig(configPath);
+	if (!config.gcp?.cloud_sql) {
+		throw new DatabaseError(
+			'GCP cloud_sql configuration is required for document routes',
+			DATABASE_ERROR_CODES.DB_CONNECTION_FAILED,
+			{
+				context: {
+					configPath,
+				},
+			},
+		);
+	}
+
+	cachedContext = {
+		config,
+		pool: getQueryPool(config.gcp.cloud_sql),
+		services: createServiceRegistry(config, logger),
+	};
+	cachedConfigPath = configPath;
+
+	return cachedContext;
+}
+
+function toIsoString(value: Date): string {
+	return value.toISOString();
+}
+
+function buildDocumentLinks(id: string): { pdf: string; layout: string; pages: string } {
+	return {
+		pdf: `/api/documents/${id}/pdf`,
+		layout: `/api/documents/${id}/layout`,
+		pages: `/api/documents/${id}/pages`,
+	};
+}
+
+function mapSourceToDocument(source: Source, layoutAvailable: boolean, pageImageCount: number): DocumentListItem {
+	return {
+		id: source.id,
+		filename: source.filename,
+		status: source.status,
+		page_count: source.pageCount,
+		has_native_text: source.hasNativeText,
+		layout_available: layoutAvailable,
+		page_image_count: pageImageCount,
+		created_at: toIsoString(source.createdAt),
+		updated_at: toIsoString(source.updatedAt),
+		links: buildDocumentLinks(source.id),
+	};
+}
+
+function escapeRegExp(value: string): string {
+	return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildStoragePath(prefix: string, sourceId: string, suffix: string): string {
+	return `${prefix}/${sourceId}/${suffix}`;
+}
+
+function buildLayoutPath(sourceId: string): string {
+	return buildStoragePath('extracted', sourceId, 'layout.md');
+}
+
+function buildPagePrefix(sourceId: string): string {
+	return `${buildStoragePath('extracted', sourceId, 'pages')}/`;
+}
+
+function buildPagePath(sourceId: string, pageNumber: number): string {
+	return `${buildPagePrefix(sourceId)}page-${String(pageNumber).padStart(3, '0')}.png`;
+}
+
+function buildPdfArtifact(source: Source): DocumentArtifact {
+	return {
+		kind: 'pdf',
+		source_id: source.id,
+		storage_path: source.storagePath,
+		content_type: PDF_CONTENT_TYPE,
+		filename: source.filename,
+	};
+}
+
+function buildLayoutArtifact(source: Source): DocumentArtifact {
+	return {
+		kind: 'layout',
+		source_id: source.id,
+		storage_path: buildLayoutPath(source.id),
+		content_type: MARKDOWN_CONTENT_TYPE,
+		filename: 'layout.md',
+	};
+}
+
+function buildPageArtifact(sourceId: string, pageNumber: number): DocumentArtifact {
+	return {
+		kind: 'page_image',
+		source_id: sourceId,
+		storage_path: buildPagePath(sourceId, pageNumber),
+		content_type: PNG_CONTENT_TYPE,
+		filename: `page-${String(pageNumber).padStart(3, '0')}.png`,
+		page_number: pageNumber,
+	};
+}
+
+function notFoundError(message: string, context: Record<string, unknown>): MulderError {
+	return new MulderError(message, DOCUMENT_NOT_FOUND_CODE, { context });
+}
+
+async function requireSource(pool: pg.Pool, id: string): Promise<Source> {
+	const source = await findSourceById(pool, id);
+	if (!source) {
+		throw notFoundError(`Document not found: ${id}`, { id });
+	}
+
+	return source;
+}
+
+function parsePageNumberFromPath(path: string, sourceId: string): number | null {
+	const pattern = new RegExp(`(?:^|/)${escapeRegExp(buildPagePrefix(sourceId))}page-(\\d+)\\.png$`);
+	const match = pattern.exec(path);
+	if (!match) {
+		return null;
+	}
+
+	const pageNumber = Number.parseInt(match[1], 10);
+	return Number.isSafeInteger(pageNumber) && pageNumber > 0 ? pageNumber : null;
+}
+
+async function listPageArtifacts(
+	services: Services,
+	sourceId: string,
+): Promise<Array<Pick<DocumentPageItem, 'page_number' | 'image_url'>>> {
+	const { paths } = await services.storage.list(buildPagePrefix(sourceId));
+	return paths
+		.map((path) => {
+			const pageNumber = parsePageNumberFromPath(path, sourceId);
+			if (!pageNumber) {
+				return null;
+			}
+
+			return {
+				page_number: pageNumber,
+				image_url: `/api/documents/${sourceId}/pages/${pageNumber}`,
+			};
+		})
+		.filter((page): page is Pick<DocumentPageItem, 'page_number' | 'image_url'> => page !== null)
+		.sort((left, right) => left.page_number - right.page_number);
+}
+
+async function countPageArtifacts(services: Services, sourceId: string): Promise<number> {
+	const pages = await listPageArtifacts(services, sourceId);
+	return pages.length;
+}
+
+async function loadArtifactBytes(
+	services: Services,
+	artifact: DocumentArtifact,
+	sourceId: string,
+	artifactLabel: string,
+): Promise<Buffer> {
+	const exists = await services.storage.exists(artifact.storage_path);
+	if (!exists) {
+		throw notFoundError(`${artifactLabel} not found for document ${sourceId}`, {
+			source_id: sourceId,
+			artifact_kind: artifact.kind,
+			storage_path: artifact.storage_path,
+		});
+	}
+
+	return await services.storage.download(artifact.storage_path);
+}
+
+async function buildDocumentListResponse(input: DocumentListQuery, logger: Logger): Promise<DocumentListResponse> {
+	const { pool, services } = resolveContext(logger);
+	const filter: SourceFilter = {
+		status: input.status,
+		search: input.search,
+		limit: input.limit,
+		offset: input.offset,
+	};
+	const startedAt = performance.now();
+	const requestLogger = createRouteLogger(logger, {
+		action: 'list',
+		status: input.status ?? null,
+		search: input.search ?? null,
+		limit: input.limit,
+		offset: input.offset,
+	});
+
+	const [count, sources] = await Promise.all([countSources(pool, filter), findAllSources(pool, filter)]);
+	const documents = await Promise.all(
+		sources.map(async (source) => {
+			const [layoutAvailable, pageImageCount] = await Promise.all([
+				services.storage.exists(buildLayoutPath(source.id)),
+				countPageArtifacts(services, source.id),
+			]);
+
+			return mapSourceToDocument(source, layoutAvailable, pageImageCount);
+		}),
+	);
+
+	const response: DocumentListResponse = {
+		data: documents,
+		meta: {
+			count,
+			limit: input.limit,
+			offset: input.offset,
+		},
+	};
+
+	requestLogger.info(
+		{
+			count,
+			result_count: response.data.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document list request completed',
+	);
+
+	return response;
+}
+
+export async function listDocuments(input: DocumentListQuery, logger?: Logger): Promise<DocumentListResponse> {
+	const rootLogger = logger ?? createLogger();
+	return await buildDocumentListResponse(input, rootLogger);
+}
+
+export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Response> {
+	const rootLogger = logger ?? createLogger();
+	const { pool, services } = resolveContext(rootLogger);
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'stream',
+		artifact_kind: 'pdf',
+		source_id: id,
+	});
+	const startedAt = performance.now();
+	const source = await requireSource(pool, id);
+	const artifact = buildPdfArtifact(source);
+	const buffer = await loadArtifactBytes(services, artifact, id, 'PDF');
+
+	requestLogger.info(
+		{
+			filename: source.filename,
+			byte_length: buffer.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document pdf request completed',
+	);
+
+	return new Response(buffer, {
+		status: 200,
+		headers: {
+			'Content-Type': artifact.content_type,
+			'Content-Disposition': `inline; filename="${source.filename.replaceAll('"', '\\"')}"`,
+		},
+	});
+}
+
+export async function streamDocumentLayout(id: string, logger?: Logger): Promise<Response> {
+	const rootLogger = logger ?? createLogger();
+	const { pool, services } = resolveContext(rootLogger);
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'stream',
+		artifact_kind: 'layout',
+		source_id: id,
+	});
+	const startedAt = performance.now();
+	const source = await requireSource(pool, id);
+	const artifact = buildLayoutArtifact(source);
+	const buffer = await loadArtifactBytes(services, artifact, id, 'layout.md');
+
+	requestLogger.info(
+		{
+			filename: source.filename,
+			byte_length: buffer.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document layout request completed',
+	);
+
+	return new Response(buffer, {
+		status: 200,
+		headers: {
+			'Content-Type': artifact.content_type,
+		},
+	});
+}
+
+export async function listDocumentPages(id: string, logger?: Logger): Promise<DocumentPagesResponse> {
+	const rootLogger = logger ?? createLogger();
+	const { pool, services } = resolveContext(rootLogger);
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'pages',
+		artifact_kind: 'page_image',
+		source_id: id,
+	});
+	const startedAt = performance.now();
+	await requireSource(pool, id);
+	const pages = await listPageArtifacts(services, id);
+
+	const response: DocumentPagesResponse = {
+		data: {
+			source_id: id,
+			pages,
+		},
+		meta: {
+			count: pages.length,
+		},
+	};
+
+	requestLogger.info(
+		{
+			result_count: response.data.pages.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document page list request completed',
+	);
+
+	return response;
+}
+
+export async function streamDocumentPage(id: string, pageNumber: number, logger?: Logger): Promise<Response> {
+	const rootLogger = logger ?? createLogger();
+	const { pool, services } = resolveContext(rootLogger);
+	const requestLogger = createRouteLogger(rootLogger, {
+		action: 'stream',
+		artifact_kind: 'page_image',
+		source_id: id,
+		page_number: pageNumber,
+	});
+	const startedAt = performance.now();
+	const source = await requireSource(pool, id);
+	const artifact = buildPageArtifact(source.id, pageNumber);
+	const buffer = await loadArtifactBytes(services, artifact, id, `page ${pageNumber}`);
+
+	requestLogger.info(
+		{
+			filename: source.filename,
+			page_number: pageNumber,
+			byte_length: buffer.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document page request completed',
+	);
+
+	return new Response(buffer, {
+		status: 200,
+		headers: {
+			'Content-Type': artifact.content_type,
+		},
+	});
+}
+
+export function resetDocumentContextForTests(): void {
+	cachedContext = null;
+	cachedConfigPath = null;
+}

--- a/apps/api/src/lib/documents.ts
+++ b/apps/api/src/lib/documents.ts
@@ -30,7 +30,6 @@ import type {
 interface DocumentContext {
 	config: MulderConfig;
 	pool: pg.Pool;
-	services: Services;
 }
 
 const DOCUMENT_NOT_FOUND_CODE = 'DOCUMENT_NOT_FOUND';
@@ -53,7 +52,7 @@ function createRouteLogger(rootLogger: Logger, metadata: Record<string, string |
 	});
 }
 
-function resolveContext(logger: Logger): DocumentContext {
+function resolveContext(): DocumentContext {
 	const configPath = resolveConfigPath();
 	if (cachedContext && cachedConfigPath === configPath) {
 		return cachedContext;
@@ -75,7 +74,6 @@ function resolveContext(logger: Logger): DocumentContext {
 	cachedContext = {
 		config,
 		pool: getQueryPool(config.gcp.cloud_sql),
-		services: createServiceRegistry(config, logger),
 	};
 	cachedConfigPath = configPath;
 
@@ -127,6 +125,31 @@ function buildPagePrefix(sourceId: string): string {
 
 function buildPagePath(sourceId: string, pageNumber: number): string {
 	return `${buildPagePrefix(sourceId)}page-${String(pageNumber).padStart(3, '0')}.png`;
+}
+
+function sanitizeContentDispositionFilename(filename: string): string {
+	let sanitized = '';
+	for (const char of filename) {
+		const code = char.charCodeAt(0);
+		if (code < 32 || code === 127 || char === '\\') {
+			sanitized += '_';
+			continue;
+		}
+
+		if (char === '"') {
+			sanitized += '\\"';
+			continue;
+		}
+
+		sanitized += char;
+	}
+
+	sanitized = sanitized.trim();
+	return sanitized.length > 0 ? sanitized : 'document.pdf';
+}
+
+function buildInlineContentDisposition(filename: string): string {
+	return `inline; filename="${sanitizeContentDispositionFilename(filename)}"`;
 }
 
 function buildPdfArtifact(source: Source): DocumentArtifact {
@@ -229,14 +252,6 @@ async function loadArtifactBytes(
 }
 
 async function buildDocumentListResponse(input: DocumentListQuery, logger: Logger): Promise<DocumentListResponse> {
-	const { pool, services } = resolveContext(logger);
-	const filter: SourceFilter = {
-		status: input.status,
-		search: input.search,
-		limit: input.limit,
-		offset: input.offset,
-	};
-	const startedAt = performance.now();
 	const requestLogger = createRouteLogger(logger, {
 		action: 'list',
 		status: input.status ?? null,
@@ -244,6 +259,15 @@ async function buildDocumentListResponse(input: DocumentListQuery, logger: Logge
 		limit: input.limit,
 		offset: input.offset,
 	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
+	const filter: SourceFilter = {
+		status: input.status,
+		search: input.search,
+		limit: input.limit,
+		offset: input.offset,
+	};
+	const startedAt = performance.now();
 
 	const [count, sources] = await Promise.all([countSources(pool, filter), findAllSources(pool, filter)]);
 	const documents = await Promise.all(
@@ -285,12 +309,13 @@ export async function listDocuments(input: DocumentListQuery, logger?: Logger): 
 
 export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
-	const { pool, services } = resolveContext(rootLogger);
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
 		artifact_kind: 'pdf',
 		source_id: id,
 	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
 	const source = await requireSource(pool, id);
 	const artifact = buildPdfArtifact(source);
@@ -309,19 +334,20 @@ export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Re
 		status: 200,
 		headers: {
 			'Content-Type': artifact.content_type,
-			'Content-Disposition': `inline; filename="${source.filename.replaceAll('"', '\\"')}"`,
+			'Content-Disposition': buildInlineContentDisposition(source.filename),
 		},
 	});
 }
 
 export async function streamDocumentLayout(id: string, logger?: Logger): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
-	const { pool, services } = resolveContext(rootLogger);
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
 		artifact_kind: 'layout',
 		source_id: id,
 	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
 	const source = await requireSource(pool, id);
 	const artifact = buildLayoutArtifact(source);
@@ -346,12 +372,13 @@ export async function streamDocumentLayout(id: string, logger?: Logger): Promise
 
 export async function listDocumentPages(id: string, logger?: Logger): Promise<DocumentPagesResponse> {
 	const rootLogger = logger ?? createLogger();
-	const { pool, services } = resolveContext(rootLogger);
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'pages',
 		artifact_kind: 'page_image',
 		source_id: id,
 	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
 	await requireSource(pool, id);
 	const pages = await listPageArtifacts(services, id);
@@ -379,13 +406,14 @@ export async function listDocumentPages(id: string, logger?: Logger): Promise<Do
 
 export async function streamDocumentPage(id: string, pageNumber: number, logger?: Logger): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
-	const { pool, services } = resolveContext(rootLogger);
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
 		artifact_kind: 'page_image',
 		source_id: id,
 		page_number: pageNumber,
 	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
 	const source = await requireSource(pool, id);
 	const artifact = buildPageArtifact(source.id, pageNumber);

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -51,6 +51,10 @@ function resolveRateLimitTier(method: string, path: string, query: URLSearchPara
 		return 'relaxed';
 	}
 
+	if (normalizedMethod === 'GET' && (path === '/api/documents' || path.startsWith('/api/documents/'))) {
+		return 'standard';
+	}
+
 	if (normalizedMethod === 'POST' && path === '/api/search') {
 		const noRerank = query.get('no_rerank') === 'true' || query.get('rerank') === 'false';
 		return noRerank ? 'standard' : 'strict';

--- a/apps/api/src/routes/documents.schemas.ts
+++ b/apps/api/src/routes/documents.schemas.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+export const SOURCE_STATUS_VALUES = [
+	'ingested',
+	'extracted',
+	'segmented',
+	'enriched',
+	'embedded',
+	'graphed',
+	'analyzed',
+] as const;
+export const DOCUMENT_ARTIFACT_KIND_VALUES = ['pdf', 'layout', 'page_image'] as const;
+
+export const SourceStatusSchema = z.enum(SOURCE_STATUS_VALUES);
+export const DocumentArtifactKindSchema = z.enum(DOCUMENT_ARTIFACT_KIND_VALUES);
+
+export const DocumentListQuerySchema = z.object({
+	status: SourceStatusSchema.optional(),
+	search: z.string().trim().min(1).max(256).optional(),
+	limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+	offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const DocumentLinksSchema = z.object({
+	pdf: z.string().min(1),
+	layout: z.string().min(1),
+	pages: z.string().min(1),
+});
+
+export const DocumentListItemSchema = z.object({
+	id: z.string().uuid(),
+	filename: z.string().min(1),
+	status: SourceStatusSchema,
+	page_count: z.number().int().nullable(),
+	has_native_text: z.boolean(),
+	layout_available: z.boolean(),
+	page_image_count: z.number().int().nonnegative(),
+	created_at: z.string(),
+	updated_at: z.string(),
+	links: DocumentLinksSchema,
+});
+
+export const DocumentListResponseSchema = z.object({
+	data: z.array(DocumentListItemSchema),
+	meta: z.object({
+		count: z.number().int().nonnegative(),
+		limit: z.number().int().positive(),
+		offset: z.number().int().nonnegative(),
+	}),
+});
+
+export const DocumentPageSchema = z.object({
+	page_number: z.number().int().positive(),
+	image_url: z.string().min(1),
+});
+
+export const DocumentPagesResponseSchema = z.object({
+	data: z.object({
+		source_id: z.string().uuid(),
+		pages: z.array(DocumentPageSchema),
+	}),
+	meta: z.object({
+		count: z.number().int().nonnegative(),
+	}),
+});
+
+export const DocumentParamsSchema = z.object({
+	id: z.string().uuid(),
+});
+
+export const DocumentPageParamsSchema = z.object({
+	id: z.string().uuid(),
+	num: z.coerce.number().int().positive(),
+});
+
+export const DocumentArtifactSchema = z.object({
+	kind: DocumentArtifactKindSchema,
+	source_id: z.string().uuid(),
+	storage_path: z.string().min(1),
+	content_type: z.string().min(1),
+	filename: z.string().min(1).optional(),
+	page_number: z.number().int().positive().optional(),
+});
+
+export type DocumentListQuery = z.infer<typeof DocumentListQuerySchema>;
+export type DocumentListResponse = z.infer<typeof DocumentListResponseSchema>;
+export type DocumentListItem = z.infer<typeof DocumentListItemSchema>;
+export type DocumentPagesResponse = z.infer<typeof DocumentPagesResponseSchema>;
+export type DocumentPageItem = z.infer<typeof DocumentPageSchema>;
+export type DocumentArtifact = z.infer<typeof DocumentArtifactSchema>;
+export type DocumentParams = z.infer<typeof DocumentParamsSchema>;
+export type DocumentPageParams = z.infer<typeof DocumentPageParamsSchema>;

--- a/apps/api/src/routes/documents.ts
+++ b/apps/api/src/routes/documents.ts
@@ -1,0 +1,64 @@
+import type { Context, Hono } from 'hono';
+import {
+	listDocumentPages,
+	listDocuments,
+	streamDocumentLayout,
+	streamDocumentPage,
+	streamDocumentPdf,
+} from '../lib/documents.js';
+import {
+	DocumentListQuerySchema,
+	DocumentListResponseSchema,
+	DocumentPageParamsSchema,
+	DocumentPagesResponseSchema,
+	DocumentParamsSchema,
+} from './documents.schemas.js';
+
+function readDocumentListQuery(url: string): Record<string, string | undefined> {
+	const searchParams = new URL(url).searchParams;
+
+	return {
+		status: searchParams.get('status') ?? undefined,
+		search: searchParams.get('search') ?? undefined,
+		limit: searchParams.get('limit') ?? undefined,
+		offset: searchParams.get('offset') ?? undefined,
+	};
+}
+
+function readRequestLogger(c: Context) {
+	return c.get('requestContext')?.logger;
+}
+
+export function registerDocumentRoutes(app: Hono): void {
+	app.get('/api/documents', async (c) => {
+		const query = DocumentListQuerySchema.parse(readDocumentListQuery(c.req.url));
+		const response = await listDocuments(query, readRequestLogger(c));
+		DocumentListResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/documents/:id/pdf', async (c) => {
+		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
+		return await streamDocumentPdf(id, readRequestLogger(c));
+	});
+
+	app.get('/api/documents/:id/layout', async (c) => {
+		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
+		return await streamDocumentLayout(id, readRequestLogger(c));
+	});
+
+	app.get('/api/documents/:id/pages', async (c) => {
+		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
+		const response = await listDocumentPages(id, readRequestLogger(c));
+		DocumentPagesResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/documents/:id/pages/:num', async (c) => {
+		const { id, num } = DocumentPageParamsSchema.parse({
+			id: c.req.param('id'),
+			num: c.req.param('num'),
+		});
+		return await streamDocumentPage(id, num, readRequestLogger(c));
+	});
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -192,7 +192,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | 🟢 | H9 | Evidence API routes (sync) | §10.6 |
-| ⚪ | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
+| 🟡 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
 | ⚪ | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
 
 **Also read for all M7 steps:** [`docs/api-architecture.md`](./api-architecture.md) (framework choice, route structure, middleware stack, OpenAPI strategy, key trade-offs), §10 (full job queue section — especially §10.3 transaction discipline), §14 (design decisions — PostgreSQL queue, auto-commit dequeue, per-step job slicing)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -192,7 +192,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H7 | Search API routes (sync) | §10.6, §5 |
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | 🟢 | H9 | Evidence API routes (sync) | §10.6 |
-| 🟡 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
+| 🟢 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
 | ⚪ | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
 
 **Also read for all M7 steps:** [`docs/api-architecture.md`](./api-architecture.md) (framework choice, route structure, middleware stack, OpenAPI strategy, key trade-offs), §10 (full job queue section — especially §10.3 transaction discipline), §14 (design decisions — PostgreSQL queue, auto-commit dequeue, per-step job slicing)

--- a/docs/specs/76_document_retrieval_routes.spec.md
+++ b/docs/specs/76_document_retrieval_routes.spec.md
@@ -1,0 +1,260 @@
+---
+spec: "76"
+title: "Document Retrieval Routes"
+roadmap_step: M7-H10
+functional_spec: ["§10.6"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/191"
+created: 2026-04-15
+---
+
+# Spec 76: Document Retrieval Routes
+
+## 1. Objective
+
+Expose Mulder's document-viewer retrieval surface over authenticated HTTP so clients can browse documents, stream the original PDF, fetch the derived `layout.md`, and inspect extracted page-image availability without shelling into CLI storage helpers. Per `§10.6`, these routes remain synchronous and artifact-backed: they read already-persisted source metadata and storage objects directly, and they never enqueue jobs or rerun pipeline steps.
+
+This step is the API half of the deferred document-viewer work. It gives `M7-H11` a real backend surface that respects Mulder's service abstraction and production shape instead of relying on local-only filesystem shortcuts.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H10` — Document retrieval routes
+- **Target:** `apps/api/src/app.ts`, `apps/api/src/routes/documents.schemas.ts`, `apps/api/src/routes/documents.ts`, `apps/api/src/lib/documents.ts`, `packages/core/src/database/repositories/source.types.ts`, `packages/core/src/database/repositories/source.repository.ts`, `packages/core/src/database/repositories/index.ts`, `tests/specs/76_document_retrieval_routes.test.ts`
+- **In scope:** authenticated `GET /api/documents`; authenticated `GET /api/documents/:id/pdf`; authenticated `GET /api/documents/:id/layout`; authenticated `GET /api/documents/:id/pages`; authenticated `GET /api/documents/:id/pages/:num`; source-list filtering needed for a viewer-facing document index; storage-backed streaming of raw PDF, derived layout markdown, and extracted page images through the existing `StorageService`; and black-box tests proving sync behavior, auth protection, artifact content types, empty or missing artifact handling, and viewer-oriented response contracts
+- **Out of scope:** the React document viewer UI (`M7-H11`), direct filesystem reads in the API layer, re-running `extract`, serving raw `layout.json`, source/stories CRUD routes outside the document-viewer surface, write or mutation endpoints, signed URL generation, caching/CDN work, and any new queue or pipeline orchestration behavior
+- **Constraints:** keep all routes behind the existing middleware/auth stack; keep the surface synchronous and read-only; use `@mulder/core` repositories plus `StorageService` rather than ad hoc SDK wiring; preserve the service-abstraction rule called out in the roadmap note for `H11`; and treat missing artifacts as observable API errors instead of silently synthesizing substitute content
+
+## 3. Dependencies
+
+- **Requires:** Spec 14 (`M2-B2`) source repository, Spec 19 (`M2-B7`) extract artifact layout/page-image persistence, Spec 48 (layout Markdown persistence beside `layout.json`), Spec 49 (`mulder show` confirms `layout.md` as a first-class artifact), Spec 69 (`M7-H3`) Hono server scaffold, and Spec 70 (`M7-H4`) API middleware stack
+- **Blocks:** Spec 11 (`M7-H11`) Document Viewer UI, which needs a stable API for listing documents and retrieving PDF, layout markdown, and page imagery without bypassing the real service layer
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/documents.schemas.ts`** — defines the query schemas, JSON list/page-list response shapes, and artifact metadata contracts for document retrieval
+2. **`apps/api/src/lib/documents.ts`** — owns repository-backed source lookup, viewer-oriented DTO mapping, and storage-backed artifact loaders
+3. **`apps/api/src/routes/documents.ts`** — registers the document route group and handles JSON vs streaming response details
+4. **`apps/api/src/app.ts`** — mounts the document route group beneath the existing middleware stack
+5. **`packages/core/src/database/repositories/source.types.ts`** — extends source-list filtering if needed for viewer-facing document search
+6. **`packages/core/src/database/repositories/source.repository.ts`** — adds any source-list query support needed for filename search and count parity
+7. **`packages/core/src/database/repositories/index.ts`** — exports any new source query helpers
+8. **`tests/specs/76_document_retrieval_routes.test.ts`** — black-box verification for the document retrieval API surface
+
+### 4.2 Route Contract
+
+#### `GET /api/documents`
+
+Purpose: list document rows for authenticated viewer clients.
+
+Query parameters:
+
+- `status` — optional source-status filter
+- `search` — optional case-insensitive filename substring filter
+- `limit` — optional integer cap with a safe default
+- `offset` — optional integer offset
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "filename": "case-file.pdf",
+      "status": "extracted",
+      "page_count": 12,
+      "has_native_text": true,
+      "layout_available": true,
+      "page_image_count": 12,
+      "created_at": "2026-04-15T12:00:00.000Z",
+      "updated_at": "2026-04-15T12:05:00.000Z",
+      "links": {
+        "pdf": "/api/documents/uuid/pdf",
+        "layout": "/api/documents/uuid/layout",
+        "pages": "/api/documents/uuid/pages"
+      }
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+Rules:
+
+- the list route is source-backed and viewer-oriented; it does not inline story bodies or full extraction payloads
+- `layout_available` reflects whether `extracted/{sourceId}/layout.md` exists in storage
+- `page_image_count` reflects the number of stored page-image objects under `extracted/{sourceId}/pages/`
+
+#### `GET /api/documents/:id/pdf`
+
+Purpose: stream the original stored PDF for a source.
+
+Success behavior:
+
+- returns `200`
+- `Content-Type: application/pdf`
+- `Content-Disposition: inline; filename="<source filename>"`
+- body bytes match the stored raw artifact referenced by `sources.storage_path`
+
+Rules:
+
+- unknown source IDs fail with a Mulder JSON not-found response
+- known sources whose raw storage object is missing also fail clearly instead of returning an empty success
+- the route streams storage-backed bytes only; it does not regenerate or transform the PDF
+
+#### `GET /api/documents/:id/layout`
+
+Purpose: return the derived layout markdown artifact produced by Extract.
+
+Success behavior:
+
+- returns `200`
+- `Content-Type: text/markdown; charset=utf-8`
+- body bytes match `extracted/{sourceId}/layout.md`
+
+Rules:
+
+- this route serves the stored `layout.md` artifact, not `layout.json`
+- sources that exist but have not been extracted yet fail with a clear not-found response for the missing artifact
+- the API must not synthesize markdown from `layout.json` on demand
+
+#### `GET /api/documents/:id/pages`
+
+Purpose: list the extracted page-image artifacts available for a source.
+
+Response shape:
+
+```json
+{
+  "data": {
+    "source_id": "uuid",
+    "pages": [
+      {
+        "page_number": 1,
+        "image_url": "/api/documents/uuid/pages/1"
+      }
+    ]
+  },
+  "meta": {
+    "count": 1
+  }
+}
+```
+
+Rules:
+
+- the route reads storage listings under `extracted/{sourceId}/pages/`
+- page numbers are derived from the stored `page-NNN.png` naming pattern
+- if a source exists but no page images are present, the route returns `200` with an empty `pages` array
+
+#### `GET /api/documents/:id/pages/:num`
+
+Purpose: stream one extracted page image for the viewer.
+
+Success behavior:
+
+- returns `200`
+- `Content-Type: image/png`
+- body bytes match the stored `extracted/{sourceId}/pages/page-{NNN}.png` object for the requested page number
+
+Rules:
+
+- page numbers must validate at the HTTP edge as positive integers
+- unknown source IDs or missing page objects fail with a Mulder JSON not-found response
+- the route serves persisted images only and never renders pages dynamically in the API process
+
+### 4.3 Integration Points
+
+- document list queries reuse the source repository and stay aligned with Mulder's source/status model
+- artifact reads go through the existing `StorageService`, keeping dev and GCP behavior swappable and avoiding a viewer-only filesystem backdoor
+- request-scoped logging should record route metadata such as source ID, filename filter, artifact kind, and page number without introducing a second logging system
+- the route group consumes the existing auth and rate-limit middleware, with document list/layout/pages in the standard tier and artifact streams preserving the same authenticated boundary
+
+### 4.4 Implementation Phases
+
+**Phase 1: source-list and artifact helper layer**
+- add document list and page-list schemas
+- implement repository-backed list helpers plus storage-backed artifact and page-list readers
+
+**Phase 2: route wiring and streaming behavior**
+- register `/api/documents/*`
+- handle JSON list responses and streaming headers/content types for PDF, markdown, and PNG artifacts
+
+**Phase 3: black-box verification**
+- cover auth protection, list filtering, sync non-queue behavior, missing-artifact handling, and byte-level artifact retrieval in a dedicated spec test
+
+## 5. QA Contract
+
+### QA-01: authenticated document listing returns viewer-ready metadata
+
+**Given** persisted source rows with stored raw/extracted artifacts,
+**When** an authenticated client sends `GET /api/documents`,
+**Then** the response is `200` JSON with document rows, viewer links, and artifact availability metadata.
+
+### QA-02: list filters narrow the document set without mutating it
+
+**Given** documents with different statuses and filenames,
+**When** an authenticated client sends `GET /api/documents` with `status` and `search` filters,
+**Then** the response includes only matching rows and no source state changes.
+
+### QA-03: PDF retrieval streams the stored raw artifact
+
+**Given** a source with a stored raw PDF,
+**When** an authenticated client sends `GET /api/documents/{id}/pdf`,
+**Then** the response is `200`, `Content-Type` is `application/pdf`, and the response bytes match the stored PDF exactly.
+
+### QA-04: layout retrieval returns the stored `layout.md` artifact
+
+**Given** an extracted source with `extracted/{id}/layout.md` in storage,
+**When** an authenticated client sends `GET /api/documents/{id}/layout`,
+**Then** the response is `200`, `Content-Type` is `text/markdown; charset=utf-8`, and the body matches the stored markdown exactly.
+
+### QA-05: missing artifacts fail clearly
+
+**Given** either an unknown source ID or a known source missing the requested PDF, layout, or page artifact,
+**When** an authenticated client requests that artifact route,
+**Then** the API returns a Mulder not-found response instead of an empty success payload.
+
+### QA-06: page listing reflects stored extracted page images
+
+**Given** an extracted source with page images under `extracted/{id}/pages/`,
+**When** an authenticated client sends `GET /api/documents/{id}/pages`,
+**Then** the response is `200` JSON with page numbers and per-page retrieval URLs derived from the stored object set.
+
+### QA-07: page-image retrieval streams exact PNG bytes
+
+**Given** a stored page image for a source,
+**When** an authenticated client sends `GET /api/documents/{id}/pages/{num}`,
+**Then** the response is `200`, `Content-Type` is `image/png`, and the response bytes match the stored page image exactly.
+
+### QA-08: document retrieval stays synchronous and non-queueing
+
+**Given** the document retrieval routes are available,
+**When** an authenticated client exercises list and artifact endpoints,
+**Then** no jobs or pipeline runs are created as a side effect.
+
+### QA-09: document retrieval stays behind auth and validates malformed inputs
+
+**Given** the route group is mounted,
+**When** a request is unauthenticated or uses malformed query/page parameters,
+**Then** the API fails at the middleware or HTTP validation edge with the established Mulder response shape.
+
+### QA-10: API package compiles with the new document route surface
+
+**Given** the document route implementation is in place,
+**When** the API build and the dedicated H10 spec test run,
+**Then** both pass without requiring the full CI-equivalent suite.
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+This step adds no new LLM, Document AI, or queue cost. It reuses already-persisted storage artifacts and source metadata. Runtime cost is limited to authenticated Cloud Storage reads and normal API compute for listing and streaming documents; the implementation should avoid eager multi-artifact downloads on list endpoints so viewer browsing does not turn one page load into unnecessary storage churn.

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -88,6 +88,35 @@ function mapSourceStepRow(row: SourceStepRow): SourceStep {
 	};
 }
 
+function escapeLikePattern(value: string): string {
+	return value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
+}
+
+function buildSourceFilterClause(filter?: SourceFilter): { conditions: string[]; params: unknown[] } {
+	const conditions: string[] = [];
+	const params: unknown[] = [];
+	let paramIndex = 1;
+
+	if (filter?.status) {
+		conditions.push(`status = $${paramIndex}`);
+		params.push(filter.status);
+		paramIndex++;
+	}
+
+	if (filter?.search) {
+		conditions.push(`filename ILIKE $${paramIndex} ESCAPE '\\'`);
+		params.push(`%${escapeLikePattern(filter.search)}%`);
+		paramIndex++;
+	}
+
+	if (filter?.tags && filter.tags.length > 0) {
+		conditions.push(`tags @> $${paramIndex}`);
+		params.push(filter.tags);
+	}
+
+	return { conditions, params };
+}
+
 // ────────────────────────────────────────────────────────────
 // Source CRUD
 // ────────────────────────────────────────────────────────────
@@ -180,26 +209,12 @@ export async function findSourceByHash(pool: pg.Pool, hash: string): Promise<Sou
  * Results are ordered by `created_at DESC`.
  */
 export async function findAllSources(pool: pg.Pool, filter?: SourceFilter): Promise<Source[]> {
-	const conditions: string[] = [];
-	const params: unknown[] = [];
-	let paramIndex = 1;
-
-	if (filter?.status) {
-		conditions.push(`status = $${paramIndex}`);
-		params.push(filter.status);
-		paramIndex++;
-	}
-
-	if (filter?.tags && filter.tags.length > 0) {
-		conditions.push(`tags @> $${paramIndex}`);
-		params.push(filter.tags);
-		paramIndex++;
-	}
-
+	const { conditions, params } = buildSourceFilterClause(filter);
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
 	const limit = filter?.limit ?? 100;
 	const offset = filter?.offset ?? 0;
+	const paramIndex = params.length + 1;
 
 	const sql = `SELECT * FROM sources ${whereClause} ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
 	params.push(limit, offset);
@@ -265,22 +280,7 @@ export async function countScoredSources(pool: pg.Pool): Promise<number> {
  * Counts sources matching the given filter. For pagination and status overview.
  */
 export async function countSources(pool: pg.Pool, filter?: SourceFilter): Promise<number> {
-	const conditions: string[] = [];
-	const params: unknown[] = [];
-	let paramIndex = 1;
-
-	if (filter?.status) {
-		conditions.push(`status = $${paramIndex}`);
-		params.push(filter.status);
-		paramIndex++;
-	}
-
-	if (filter?.tags && filter.tags.length > 0) {
-		conditions.push(`tags @> $${paramIndex}`);
-		params.push(filter.tags);
-		paramIndex++;
-	}
-
+	const { conditions, params } = buildSourceFilterClause(filter);
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 	const sql = `SELECT COUNT(*) FROM sources ${whereClause}`;
 

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -67,6 +67,8 @@ export interface UpdateSourceInput {
 /** Filters for querying sources. */
 export interface SourceFilter {
 	status?: SourceStatus;
+	/** Case-insensitive filename substring filter. */
+	search?: string;
 	tags?: string[];
 	limit?: number;
 	offset?: number;

--- a/tests/specs/71_pipeline_api_routes.test.ts
+++ b/tests/specs/71_pipeline_api_routes.test.ts
@@ -18,7 +18,7 @@ const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
 const WORKER_DIST = resolve(WORKER_DIR, 'dist/index.js');
 const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
 const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
-const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 const NATIVE_TEXT_PDF = resolve(ROOT, 'fixtures/raw/native-text-sample.pdf');
 
 function buildPackage(packageDir: string): void {

--- a/tests/specs/72_job_status_api.test.ts
+++ b/tests/specs/72_job_status_api.test.ts
@@ -15,7 +15,7 @@ const CLI_DIR = resolve(ROOT, 'apps/cli');
 const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
 const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
 const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
-const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 function buildPackage(packageDir: string): void {
 	const result = spawnSync('pnpm', ['build'], {

--- a/tests/specs/76_document_retrieval_routes.test.ts
+++ b/tests/specs/76_document_retrieval_routes.test.ts
@@ -1,0 +1,471 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import pg from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, truncateMulderTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const TAXONOMY_DIR = resolve(ROOT, 'packages/taxonomy');
+const RETRIEVAL_DIR = resolve(ROOT, 'packages/retrieval');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const EVIDENCE_DIR = resolve(ROOT, 'packages/evidence');
+const API_DIR = resolve(ROOT, 'apps/api');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const mocks = vi.hoisted(() => ({
+	getQueryPool: vi.fn(),
+	createServiceRegistry: vi.fn(),
+}));
+
+vi.mock('@mulder/core', async () => {
+	const actual = await vi.importActual<typeof import('@mulder/core')>('@mulder/core');
+	return {
+		...actual,
+		getQueryPool: mocks.getQueryPool,
+		createServiceRegistry: mocks.createServiceRegistry,
+	};
+});
+
+interface ApiApp {
+	request: (input: string | Request, init?: RequestInit) => Promise<Response>;
+	fetch: (input: string | Request, init?: RequestInit) => Promise<Response>;
+}
+
+interface StorageState {
+	objects: Map<string, Buffer>;
+}
+
+interface SeededSource {
+	id: string;
+	storagePath: string;
+}
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function authorizedHeaders(ip = '203.0.113.10'): Record<string, string> {
+	return {
+		Authorization: 'Bearer test-api-key',
+		'X-Forwarded-For': ip,
+	};
+}
+
+function createStorageState(): StorageState {
+	return {
+		objects: new Map<string, Buffer>(),
+	};
+}
+
+function putStorageObject(state: StorageState, path: string, content: Buffer | string): void {
+	state.objects.set(path, Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8'));
+}
+
+function buildMockServices(state: StorageState) {
+	return {
+		storage: {
+			upload: async (path: string, content: Buffer | string) => {
+				putStorageObject(state, path, content);
+			},
+			download: async (path: string) => {
+				const value = state.objects.get(path);
+				if (!value) {
+					throw new Error(`Storage object not found: ${path}`);
+				}
+				return value;
+			},
+			exists: async (path: string) => state.objects.has(path),
+			list: async (prefix: string) => ({
+				paths: [...state.objects.keys()].filter((path) => path.startsWith(prefix)).sort(),
+			}),
+			delete: async (path: string) => {
+				state.objects.delete(path);
+			},
+		},
+		documentAi: {
+			processDocument: async () => ({
+				document: {},
+				pageImages: [],
+			}),
+		},
+		llm: {
+			generateStructured: async () => {
+				throw new Error('generateStructured is not used in this test');
+			},
+			generateText: async () => '',
+			groundedGenerate: async () => {
+				throw new Error('groundedGenerate is not used in this test');
+			},
+			countTokens: async () => 0,
+		},
+		embedding: {
+			embed: async () => [],
+		},
+		firestore: {
+			setDocument: async () => {},
+			getDocument: async () => null,
+		},
+	};
+}
+
+async function loadApiApp(): Promise<ApiApp> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+function seedSource(
+	pool: pg.Pool,
+	input: {
+		filename: string;
+		fileHash?: string;
+		pageCount?: number | null;
+		hasNativeText?: boolean;
+		nativeTextRatio?: number;
+		status?: 'ingested' | 'extracted' | 'segmented' | 'enriched' | 'embedded' | 'graphed' | 'analyzed';
+		storagePath?: string;
+	},
+): Promise<SeededSource> {
+	const id = randomUUID();
+	const fileHash = input.fileHash ?? randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '');
+	const storagePath = input.storagePath ?? `raw/${id}/${input.filename}`;
+	return pool
+		.query(
+			[
+				'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, metadata)',
+				'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)',
+			].join(' '),
+			[
+				id,
+				input.filename,
+				storagePath,
+				fileHash,
+				input.pageCount ?? null,
+				input.hasNativeText ?? false,
+				input.nativeTextRatio ?? 0,
+				input.status ?? 'ingested',
+				JSON.stringify({}),
+			],
+		)
+		.then(() => ({
+			id,
+			storagePath,
+		}));
+}
+
+async function readJson(response: Response): Promise<unknown> {
+	return await response.json();
+}
+
+async function responseBytes(response: Response): Promise<Buffer> {
+	return Buffer.from(await response.arrayBuffer());
+}
+
+describe('Spec 76 — Document Retrieval Routes', () => {
+	const originalConfig = process.env.MULDER_CONFIG;
+	const originalLogLevel = process.env.MULDER_LOG_LEVEL;
+	let pool: pg.Pool;
+	let app: ApiApp;
+	let storageState: StorageState;
+	let sourceA: SeededSource;
+	let sourceB: SeededSource;
+	let sourceC: SeededSource;
+	const rawPdf = Buffer.from('%PDF-1.4\ncase file pdf\n%%EOF', 'utf-8');
+	const layoutMarkdown = Buffer.from('# Case File\n\nDerived layout markdown.\n', 'utf-8');
+	const pageOne = Buffer.from('page-one-bytes', 'utf-8');
+	const pageTwo = Buffer.from('page-two-bytes', 'utf-8');
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		ensureSchema();
+		buildPackage(CORE_DIR);
+		buildPackage(TAXONOMY_DIR);
+		buildPackage(RETRIEVAL_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(EVIDENCE_DIR);
+		buildPackage(API_DIR);
+
+		pool = new pg.Pool({
+			host: db.TEST_PG_HOST,
+			port: db.TEST_PG_PORT,
+			user: db.TEST_PG_USER,
+			password: db.TEST_PG_PASSWORD,
+			database: db.TEST_PG_DATABASE,
+		});
+
+		storageState = createStorageState();
+		mocks.getQueryPool.mockReturnValue(pool);
+		mocks.createServiceRegistry.mockReturnValue(buildMockServices(storageState));
+
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(async () => {
+		truncateMulderTables();
+		storageState.objects.clear();
+		mocks.getQueryPool.mockClear();
+		mocks.createServiceRegistry.mockClear();
+		mocks.getQueryPool.mockReturnValue(pool);
+		mocks.createServiceRegistry.mockReturnValue(buildMockServices(storageState));
+
+		sourceA = await seedSource(pool, {
+			filename: 'case-file.pdf',
+			pageCount: 12,
+			hasNativeText: true,
+			nativeTextRatio: 0.94,
+			status: 'extracted',
+		});
+		sourceB = await seedSource(pool, {
+			filename: 'missing-layout.pdf',
+			pageCount: 3,
+			hasNativeText: false,
+			nativeTextRatio: 0.1,
+			status: 'extracted',
+		});
+		sourceC = await seedSource(pool, {
+			filename: 'missing-pdf.pdf',
+			pageCount: 1,
+			hasNativeText: false,
+			nativeTextRatio: 0,
+			status: 'extracted',
+		});
+
+		putStorageObject(storageState, sourceA.storagePath, rawPdf);
+		putStorageObject(storageState, `extracted/${sourceA.id}/layout.md`, layoutMarkdown);
+		putStorageObject(storageState, `extracted/${sourceA.id}/pages/page-001.png`, pageOne);
+		putStorageObject(storageState, `extracted/${sourceA.id}/pages/page-002.png`, pageTwo);
+		putStorageObject(storageState, sourceB.storagePath, Buffer.from('raw-only', 'utf-8'));
+	}, 600000);
+
+	afterAll(async () => {
+		truncateMulderTables();
+		await pool?.end();
+		if (originalConfig === undefined) {
+			delete process.env.MULDER_CONFIG;
+		} else {
+			process.env.MULDER_CONFIG = originalConfig;
+		}
+		if (originalLogLevel === undefined) {
+			delete process.env.MULDER_LOG_LEVEL;
+		} else {
+			process.env.MULDER_LOG_LEVEL = originalLogLevel;
+		}
+	});
+
+	it('QA-01: GET /api/documents returns viewer-ready metadata with search and status filtering', async () => {
+		const response = await app.request('http://localhost/api/documents?status=extracted&search=case', {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toContain('application/json');
+
+		expect(await readJson(response)).toEqual({
+			data: [
+				{
+					id: sourceA.id,
+					filename: 'case-file.pdf',
+					status: 'extracted',
+					page_count: 12,
+					has_native_text: true,
+					layout_available: true,
+					page_image_count: 2,
+					created_at: expect.any(String),
+					updated_at: expect.any(String),
+					links: {
+						pdf: `/api/documents/${sourceA.id}/pdf`,
+						layout: `/api/documents/${sourceA.id}/layout`,
+						pages: `/api/documents/${sourceA.id}/pages`,
+					},
+				},
+			],
+			meta: {
+				count: 1,
+				limit: 20,
+				offset: 0,
+			},
+		});
+
+		const counts = await Promise.all([
+			pool.query('SELECT COUNT(*) FROM jobs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_runs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_run_sources'),
+		]);
+		expect(counts.map((result) => Number.parseInt(result.rows[0].count, 10))).toEqual([0, 0, 0]);
+	});
+
+	it('QA-02: PDF, layout, and page-image routes stream exact artifact bytes and content types', async () => {
+		const pdfResponse = await app.request(`http://localhost/api/documents/${sourceA.id}/pdf`, {
+			headers: authorizedHeaders(),
+		});
+		expect(pdfResponse.status).toBe(200);
+		expect(pdfResponse.headers.get('content-type')).toBe('application/pdf');
+		expect(pdfResponse.headers.get('content-disposition')).toBe(`inline; filename="case-file.pdf"`);
+		expect(await responseBytes(pdfResponse)).toEqual(rawPdf);
+
+		const layoutResponse = await app.request(`http://localhost/api/documents/${sourceA.id}/layout`, {
+			headers: authorizedHeaders(),
+		});
+		expect(layoutResponse.status).toBe(200);
+		expect(layoutResponse.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+		expect(await responseBytes(layoutResponse)).toEqual(layoutMarkdown);
+
+		const pageResponse = await app.request(`http://localhost/api/documents/${sourceA.id}/pages/2`, {
+			headers: authorizedHeaders(),
+		});
+		expect(pageResponse.status).toBe(200);
+		expect(pageResponse.headers.get('content-type')).toBe('image/png');
+		expect(await responseBytes(pageResponse)).toEqual(pageTwo);
+	});
+
+	it('QA-03: page listing reflects stored images and empty extracted folders', async () => {
+		const pageListResponse = await app.request(`http://localhost/api/documents/${sourceA.id}/pages`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(pageListResponse.status).toBe(200);
+		expect(await readJson(pageListResponse)).toEqual({
+			data: {
+				source_id: sourceA.id,
+				pages: [
+					{
+						page_number: 1,
+						image_url: `/api/documents/${sourceA.id}/pages/1`,
+					},
+					{
+						page_number: 2,
+						image_url: `/api/documents/${sourceA.id}/pages/2`,
+					},
+				],
+			},
+			meta: {
+				count: 2,
+			},
+		});
+
+		const emptyPageListResponse = await app.request(`http://localhost/api/documents/${sourceB.id}/pages`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(emptyPageListResponse.status).toBe(200);
+		expect(await readJson(emptyPageListResponse)).toEqual({
+			data: {
+				source_id: sourceB.id,
+				pages: [],
+			},
+			meta: {
+				count: 0,
+			},
+		});
+	});
+
+	it('QA-04: missing artifacts, auth protection, and malformed page input fail at the edge', async () => {
+		const missingPdfResponse = await app.request(`http://localhost/api/documents/${sourceC.id}/pdf`, {
+			headers: authorizedHeaders(),
+		});
+		expect(missingPdfResponse.status).toBe(404);
+		expect(await readJson(missingPdfResponse)).toEqual({
+			error: {
+				code: 'DOCUMENT_NOT_FOUND',
+				message: `PDF not found for document ${sourceC.id}`,
+				details: {
+					source_id: sourceC.id,
+					artifact_kind: 'pdf',
+					storage_path: sourceC.storagePath,
+				},
+			},
+		});
+
+		const missingLayoutResponse = await app.request(`http://localhost/api/documents/${sourceB.id}/layout`, {
+			headers: authorizedHeaders(),
+		});
+		expect(missingLayoutResponse.status).toBe(404);
+		expect(await readJson(missingLayoutResponse)).toEqual({
+			error: {
+				code: 'DOCUMENT_NOT_FOUND',
+				message: `layout.md not found for document ${sourceB.id}`,
+				details: {
+					source_id: sourceB.id,
+					artifact_kind: 'layout',
+					storage_path: `extracted/${sourceB.id}/layout.md`,
+				},
+			},
+		});
+
+		const missingPageResponse = await app.request(`http://localhost/api/documents/${sourceB.id}/pages/1`, {
+			headers: authorizedHeaders(),
+		});
+		expect(missingPageResponse.status).toBe(404);
+		expect(await readJson(missingPageResponse)).toEqual({
+			error: {
+				code: 'DOCUMENT_NOT_FOUND',
+				message: `page 1 not found for document ${sourceB.id}`,
+				details: {
+					source_id: sourceB.id,
+					artifact_kind: 'page_image',
+					storage_path: `extracted/${sourceB.id}/pages/page-001.png`,
+				},
+			},
+		});
+
+		const unauthenticatedResponse = await app.request('http://localhost/api/documents');
+		expect(unauthenticatedResponse.status).toBe(401);
+		expect(await readJson(unauthenticatedResponse)).toEqual({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+
+		const malformedPageResponse = await app.request(`http://localhost/api/documents/${randomUUID()}/pages/0`, {
+			headers: authorizedHeaders(),
+		});
+		expect(malformedPageResponse.status).toBe(400);
+		expect(await readJson(malformedPageResponse)).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+				message: 'Invalid request',
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add the H10 document retrieval API surface for the upcoming document viewer, including source-backed document listing plus storage-backed PDF, layout markdown, and page image retrieval routes.

## Traceability

- Roadmap: `M7-H10`
- Spec: `docs/specs/76_document_retrieval_routes.spec.md`
- Issue: Closes #191

## Changes

- add `/api/documents` list, PDF, layout, pages, and page-image endpoints
- extend source filtering for viewer-facing filename search and wire document routes into the API app + rate limiting
- add black-box H10 coverage and repair the API e2e suites to use the tracked example config path

## Verification

- `pnpm --filter @mulder/api build`
- `npx vitest run tests/specs/76_document_retrieval_routes.test.ts --reporter=verbose`
- `pnpm test:api:e2e`