### PR TITLE
[Infra] Add Terraform budget alerts for M8-I3

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,7 +213,7 @@ Eval framework, cost gates, schema evolution, dead letter recovery. Safe to run 
 |--------|------|------|------|
 | ⚪ | I1 | `mulder eval` CLI + reporter | §15, §1 (eval cmd) |
 | ⚪ | I2 | Cost estimator — `--cost-estimate` flag | §16.2, §1 (ingest/pipeline/reprocess cmds) |
-| ⚪ | I3 | Terraform budget alerts | §16.1 |
+| 🟡 | I3 | Terraform budget alerts | §16.1 |
 | ⚪ | I4 | Schema evolution / reprocessing — `mulder reprocess` | §3.5, §4.3 (source_steps table) |
 | ⚪ | I5 | Dead letter queue — `mulder retry` | §10.5, §1 (retry cmd) |
 | ⚪ | I6 | Devlog system — conventions established | §17 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,7 +213,7 @@ Eval framework, cost gates, schema evolution, dead letter recovery. Safe to run 
 |--------|------|------|------|
 | ⚪ | I1 | `mulder eval` CLI + reporter | §15, §1 (eval cmd) |
 | ⚪ | I2 | Cost estimator — `--cost-estimate` flag | §16.2, §1 (ingest/pipeline/reprocess cmds) |
-| 🟡 | I3 | Terraform budget alerts | §16.1 |
+| 🟢 | I3 | Terraform budget alerts | §16.1 |
 | ⚪ | I4 | Schema evolution / reprocessing — `mulder reprocess` | §3.5, §4.3 (source_steps table) |
 | ⚪ | I5 | Dead letter queue — `mulder retry` | §10.5, §1 (retry cmd) |
 | ⚪ | I6 | Devlog system — conventions established | §17 |

--- a/docs/specs/77_terraform_budget_alerts.spec.md
+++ b/docs/specs/77_terraform_budget_alerts.spec.md
@@ -1,0 +1,116 @@
+---
+spec: "77"
+title: "Terraform Budget Alerts"
+roadmap_step: M8-I3
+functional_spec: ["§16.1"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/200"
+created: 2026-04-15
+---
+
+# Spec 77: Terraform Budget Alerts
+
+## 1. Objective
+
+Establish Mulder's first real Terraform delivery surface by adding a reusable budget-alert module that creates a Cloud Billing budget for the deployment billing account with alert thresholds at 50% and 90% of a caller-provided monthly budget. Per `§16.1`, the budget amount must be specified in USD and the resource must identify the deployment by project name so operators can track spend before costly pipeline usage grows unchecked.
+
+This step is intentionally narrow. It covers only the Terraform resources and minimal scaffolding needed to define and validate the budget-alert module in-repo. It does not attempt cost estimation (`M8-I2`), automatic shutdown or Pub/Sub remediation, or the larger multi-tenant/project-factory work tracked separately.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M8-I3` — Terraform budget alerts
+- **Target:** `terraform/modules/budget/main.tf`, `terraform/modules/budget/variables.tf`, `terraform/modules/budget/outputs.tf`, `terraform/examples/budget/main.tf`, `terraform/examples/budget/versions.tf`, `tests/specs/77_terraform_budget_alerts.test.ts`
+- **In scope:** creating the new `terraform/modules/budget/` module; defining inputs for billing account, project name, and monthly budget amount; creating exactly one `google_billing_budget` resource with a specified USD amount; configuring threshold rules for 50% and 90% alerts; exposing outputs needed to reference the created budget from higher-level Terraform compositions; adding a minimal example root configuration under `terraform/examples/budget/`; and black-box verification that the example configuration formats and validates cleanly
+- **Out of scope:** Terraform for any other GCP services, notification channels, Pub/Sub automation, project/folder creation, cost-estimation CLI work, hard runtime spending caps, cross-project budget filters, or broader infra environment layout beyond what is required to exercise this one module
+- **Constraints:** keep the module self-contained and reusable; do not couple it to `mulder.config.yaml` yet; preserve the exact `§16.1` budget semantics (USD specified amount, 50% threshold, 90% threshold); and make the example/test path work without requiring the rest of Mulder's planned Terraform tree to exist first
+
+## 3. Dependencies
+
+- **Requires:** None
+- **Blocks:** no immediate roadmap step directly, but this module becomes the first concrete Terraform building block that later M8 infrastructure work can compose instead of continuing to treat `terraform/` as a planned-only directory
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`terraform/modules/budget/main.tf`** — declares the `google_billing_budget` resource and hard-codes the two required threshold rules around caller-supplied billing inputs
+2. **`terraform/modules/budget/variables.tf`** — defines validated module inputs for `billing_account`, `project_name`, and `monthly_budget_usd`
+3. **`terraform/modules/budget/outputs.tf`** — exposes stable outputs for the created budget resource so future root modules can reference it
+4. **`terraform/examples/budget/versions.tf`** — pins Terraform/provider requirements needed to validate the standalone example root
+5. **`terraform/examples/budget/main.tf`** — instantiates the budget module with placeholder-safe inputs so `terraform init` and `terraform validate` can exercise the module shape without depending on broader Mulder infra
+6. **`tests/specs/77_terraform_budget_alerts.test.ts`** — black-box coverage for file presence, required resource shape, and Terraform formatting/validation
+
+### 4.2 Terraform Contract
+
+The module must create one budget resource with these observable properties:
+
+- `display_name` is `mulder-${var.project_name}`
+- the budget amount uses `specified_amount`
+- `currency_code` is `USD`
+- `units` comes from `var.monthly_budget_usd`
+- two threshold rules exist at `0.5` and `0.9`
+
+The module may expose outputs for the created budget's display name and provider-generated budget name/id, but it must not add unrelated resources or optional alerting channels in this step.
+
+### 4.3 Example Root
+
+The example root exists only to make the new module runnable and verifiable in isolation.
+
+It must:
+
+- declare the Terraform and Google provider requirements needed for validation
+- instantiate `../../modules/budget`
+- use placeholder-safe variable values that let `terraform validate` succeed without attempting a live apply
+
+It must not:
+
+- provision any non-budget resources
+- introduce environment-specific state backends
+- require secrets or checked-in credentials
+
+### 4.4 Implementation Phases
+
+**Phase 1: module scaffold**
+- create `main.tf`, `variables.tf`, and `outputs.tf`
+- encode the exact `§16.1` budget contract
+
+**Phase 2: standalone validation root**
+- add the minimal example root under `terraform/examples/budget/`
+- ensure the module can be formatted and validated in isolation
+
+## 5. QA Contract
+
+1. **QA-01: The budget module exists as a reusable Terraform module**
+   - Given: a fresh checkout of the repository
+   - When: the `terraform/modules/budget/` directory is inspected
+   - Then: it contains the expected Terraform module files and exposes caller inputs for billing account, project name, and monthly budget amount
+
+2. **QA-02: The module encodes the exact `§16.1` budget semantics**
+   - Given: the budget module files
+   - When: the Terraform resource definition is inspected through the module's public HCL files
+   - Then: there is exactly one `google_billing_budget` resource with a USD specified amount, `units` sourced from the monthly budget variable, and threshold rules at 50% and 90%
+
+3. **QA-03: The standalone example validates cleanly**
+   - Given: Terraform is installed and the repository checkout has no pre-existing Terraform state
+   - When: `terraform -chdir=terraform/examples/budget init -backend=false` and `terraform -chdir=terraform/examples/budget validate` are run
+   - Then: both commands exit successfully and the example exercises the module without requiring unrelated Mulder infrastructure
+
+4. **QA-04: Terraform formatting stays clean**
+   - Given: the Terraform files for this step
+   - When: `terraform fmt -check -recursive terraform` is run
+   - Then: the command exits successfully with no formatting drift
+
+5. **QA-05: The step stays narrowly scoped to budget alerts**
+   - Given: the files added for this step
+   - When: they are reviewed at the filesystem level
+   - Then: no non-budget Terraform resources, notification-channel resources, or unrelated infra modules are introduced
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+- **Services called:** none during normal repository verification; Terraform validation should not apply or create live resources
+- **Operational impact:** the resulting module manages a billing budget resource in GCP, which is a cost-safety control rather than a spend-generating workload
+- **Safety requirement:** the example/test path must remain validation-only so contributors can verify the module shape without a live billing account or checked-in credentials

--- a/terraform/examples/budget/main.tf
+++ b/terraform/examples/budget/main.tf
@@ -1,0 +1,7 @@
+module "budget" {
+  source = "../../modules/budget"
+
+  billing_account    = "000000-000000-000000"
+  project_name       = "mulder-example"
+  monthly_budget_usd = 100
+}

--- a/terraform/examples/budget/versions.tf
+++ b/terraform/examples/budget/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/budget/main.tf
+++ b/terraform/modules/budget/main.tf
@@ -1,0 +1,19 @@
+resource "google_billing_budget" "mulder" {
+  billing_account = var.billing_account
+  display_name    = "mulder-${var.project_name}"
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = var.monthly_budget_usd
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+
+  threshold_rules {
+    threshold_percent = 0.9
+  }
+}

--- a/terraform/modules/budget/outputs.tf
+++ b/terraform/modules/budget/outputs.tf
@@ -1,0 +1,9 @@
+output "budget" {
+  description = "The created billing budget resource."
+  value       = google_billing_budget.mulder
+}
+
+output "budget_display_name" {
+  description = "The budget display name used in Cloud Billing."
+  value       = google_billing_budget.mulder.display_name
+}

--- a/terraform/modules/budget/variables.tf
+++ b/terraform/modules/budget/variables.tf
@@ -1,0 +1,32 @@
+variable "billing_account" {
+  description = "The billing account ID that owns the budget."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.billing_account) != ""
+    error_message = "billing_account must not be empty."
+  }
+}
+
+variable "project_name" {
+  description = "The project name used in the budget display name."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.project_name) != ""
+    error_message = "project_name must not be empty."
+  }
+}
+
+variable "monthly_budget_usd" {
+  description = "The monthly budget amount in USD."
+  type        = number
+  nullable    = false
+
+  validation {
+    condition     = var.monthly_budget_usd > 0
+    error_message = "monthly_budget_usd must be greater than 0."
+  }
+}

--- a/tests/specs/77_terraform_budget_alerts.test.ts
+++ b/tests/specs/77_terraform_budget_alerts.test.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const MODULE_DIR = resolve(ROOT, 'terraform/modules/budget');
+const EXAMPLE_DIR = resolve(ROOT, 'terraform/examples/budget');
+const TERRAFORM_ROOT = resolve(ROOT, 'terraform');
+
+function runTerraform(args: string[], cwd: string): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('terraform', args, {
+		cwd,
+		encoding: 'utf-8',
+		timeout: 240_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			TF_IN_AUTOMATION: '1',
+			TF_INPUT: '0',
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function terraformAvailable(): boolean {
+	const result = spawnSync('terraform', ['version'], {
+		encoding: 'utf-8',
+		timeout: 10_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+	return (result.status ?? 1) === 0;
+}
+
+function createTerraformSandbox(): { root: string; exampleDir: string } {
+	const root = mkdtempSync(resolve(tmpdir(), 'mulder-budget-'));
+
+	mkdirSync(resolve(root, 'terraform/modules'), { recursive: true });
+	mkdirSync(resolve(root, 'terraform/examples'), { recursive: true });
+
+	cpSync(MODULE_DIR, resolve(root, 'terraform/modules/budget'), { recursive: true });
+	cpSync(EXAMPLE_DIR, resolve(root, 'terraform/examples/budget'), { recursive: true });
+
+	return {
+		root,
+		exampleDir: resolve(root, 'terraform/examples/budget'),
+	};
+}
+
+const TERRAFORM_INSTALLED = terraformAvailable();
+
+describe('Spec 77 — Terraform Budget Alerts', () => {
+	it('QA-01: the reusable budget module exists and exposes the required inputs', () => {
+		const expectedFiles = ['main.tf', 'variables.tf', 'outputs.tf'];
+
+		for (const file of expectedFiles) {
+			expect(existsSync(resolve(MODULE_DIR, file)), `Missing module file: ${file}`).toBe(true);
+		}
+
+		const variables = readFileSync(resolve(MODULE_DIR, 'variables.tf'), 'utf-8');
+		expect(variables).toContain('variable "billing_account"');
+		expect(variables).toContain('variable "project_name"');
+		expect(variables).toContain('variable "monthly_budget_usd"');
+	});
+
+	it('QA-02: the module encodes the exact §16.1 budget contract', () => {
+		const mainTf = readFileSync(resolve(MODULE_DIR, 'main.tf'), 'utf-8');
+
+		expect(mainTf.match(/resource\s+"google_billing_budget"\s+"mulder"/g) ?? []).toHaveLength(1);
+		expect(mainTf).toContain('billing_account = var.billing_account');
+		expect(mainTf).toContain(`display_name    = "mulder-\${var.project_name}"`);
+		expect(mainTf).toContain('currency_code = "USD"');
+		expect(mainTf).toContain('units         = var.monthly_budget_usd');
+		expect(mainTf).toContain('threshold_percent = 0.5');
+		expect(mainTf).toContain('threshold_percent = 0.9');
+		expect(mainTf).not.toContain('notification_channel');
+		expect(mainTf).not.toContain('pubsub');
+		expect(mainTf).not.toContain('google_monitoring');
+	});
+
+	it.skipIf(!TERRAFORM_INSTALLED)('QA-03: the standalone example initializes and validates cleanly', () => {
+		const sandbox = createTerraformSandbox();
+
+		try {
+			const initResult = runTerraform(['init', '-backend=false'], sandbox.exampleDir);
+			expect(initResult.exitCode, `${initResult.stdout}\n${initResult.stderr}`).toBe(0);
+
+			const validateResult = runTerraform(['validate'], sandbox.exampleDir);
+			expect(validateResult.exitCode, `${validateResult.stdout}\n${validateResult.stderr}`).toBe(0);
+		} finally {
+			rmSync(sandbox.root, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(!TERRAFORM_INSTALLED)('QA-04: Terraform formatting stays clean', () => {
+		const fmtResult = runTerraform(['fmt', '-check', '-recursive', 'terraform'], ROOT);
+		expect(fmtResult.exitCode, `${fmtResult.stdout}\n${fmtResult.stderr}`).toBe(0);
+	});
+
+	it('QA-05: the step stays narrowly scoped to budget alerts', () => {
+		const moduleMain = readFileSync(resolve(MODULE_DIR, 'main.tf'), 'utf-8');
+		const exampleMain = readFileSync(resolve(EXAMPLE_DIR, 'main.tf'), 'utf-8');
+
+		expect(moduleMain).not.toContain('resource "google_storage_bucket"');
+		expect(moduleMain).not.toContain('resource "google_pubsub_topic"');
+		expect(moduleMain).not.toContain('resource "google_monitoring_notification_channel"');
+		expect(moduleMain).not.toContain('resource "google_project"');
+		expect(exampleMain).toContain('source = "../../modules/budget"');
+		expect(existsSync(resolve(TERRAFORM_ROOT, 'modules/budget'))).toBe(true);
+		expect(existsSync(resolve(TERRAFORM_ROOT, 'examples/budget'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Add Mulder's first in-repo Terraform module for Cloud Billing budget alerts, including a standalone example root and black-box spec coverage.

## Traceability

- Closes #200
- Spec: `docs/specs/77_terraform_budget_alerts.spec.md`
- Roadmap: `M8-I3`

## Changes

- add `terraform/modules/budget/` with the exact `§16.1` billing budget contract
- add `terraform/examples/budget/` so the module can be initialized and validated in isolation
- add spec coverage for module shape, Terraform validation, formatting, and scope boundaries
- move `M8/I3` to in-progress in the roadmap

## Verification

- `npx vitest run tests/specs/77_terraform_budget_alerts.test.ts --reporter=verbose`
- `terraform fmt -check -recursive terraform`
- `npx biome check tests/specs/77_terraform_budget_alerts.test.ts docs/specs/77_terraform_budget_alerts.spec.md docs/roadmap.md`