### PR TITLE
[Documents] Large PDF browser upload flow — M7-H11

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import { registerHealthRoute } from './routes/health.js';
 import { registerJobRoutes } from './routes/jobs.js';
 import { registerPipelineRoutes } from './routes/pipeline.js';
 import { registerSearchRoute } from './routes/search.js';
+import { registerUploadRoutes } from './routes/uploads.js';
 
 export interface AppOptions {
 	logger?: Logger;
@@ -40,6 +41,7 @@ export function createApp(options: AppOptions = {}): Hono {
 	registerDocumentRoutes(app);
 	registerJobRoutes(app);
 	registerPipelineRoutes(app);
+	registerUploadRoutes(app);
 	registerSearchRoute(app);
 
 	return app;

--- a/apps/api/src/lib/uploads.ts
+++ b/apps/api/src/lib/uploads.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto';
+import {
+	createChildLogger,
+	createLogger,
+	createServiceRegistry,
+	DATABASE_ERROR_CODES,
+	DatabaseError,
+	findSourceById,
+	getWorkerPool,
+	INGEST_ERROR_CODES,
+	type Logger,
+	loadConfig,
+	type MulderConfig,
+	MulderError,
+	type Services,
+} from '@mulder/core';
+import type pg from 'pg';
+import type {
+	CompleteDocumentUploadRequest,
+	CompleteDocumentUploadResponse,
+	InitiateDocumentUploadRequest,
+	InitiateDocumentUploadResponse,
+} from '../routes/uploads.schemas.js';
+
+interface UploadContext {
+	config: MulderConfig;
+	pool: pg.Pool;
+	services: Services;
+}
+
+type Queryable = pg.Pool | pg.PoolClient;
+
+let cachedContext: UploadContext | null = null;
+let cachedConfigPath: string | null = null;
+
+const PDF_CONTENT_TYPE = 'application/pdf';
+const FINALIZE_JOB_TYPE = 'document_upload_finalize';
+
+function resolveConfigPath(): string {
+	return process.env.MULDER_CONFIG ?? 'mulder.config.yaml';
+}
+
+function createRouteLogger(rootLogger: Logger, metadata: Record<string, string | number | boolean | null | undefined>) {
+	return createChildLogger(rootLogger, {
+		module: 'api',
+		route: 'uploads',
+		...metadata,
+	});
+}
+
+function resolveContext(): UploadContext {
+	const configPath = resolveConfigPath();
+	if (cachedContext && cachedConfigPath === configPath) {
+		return cachedContext;
+	}
+
+	const config = loadConfig(configPath);
+	if (!config.gcp?.cloud_sql) {
+		throw new DatabaseError(
+			'GCP cloud_sql configuration is required for upload routes',
+			DATABASE_ERROR_CODES.DB_CONNECTION_FAILED,
+			{
+				context: { configPath },
+			},
+		);
+	}
+
+	const logger = createLogger();
+	cachedContext = {
+		config,
+		pool: getWorkerPool(config.gcp.cloud_sql),
+		services: createServiceRegistry(config, logger),
+	};
+	cachedConfigPath = configPath;
+	return cachedContext;
+}
+
+function maxUploadBytes(config: MulderConfig): number {
+	return config.ingestion.max_file_size_mb * 1024 * 1024;
+}
+
+function ensurePdfInput(input: { filename: string; contentType: string }): void {
+	if (!input.filename.toLowerCase().endsWith('.pdf')) {
+		throw new MulderError('Filename must end with .pdf', 'VALIDATION_ERROR', {
+			context: { filename: input.filename },
+		});
+	}
+
+	if (input.contentType.toLowerCase() !== PDF_CONTENT_TYPE) {
+		throw new MulderError('Only application/pdf uploads are supported', 'VALIDATION_ERROR', {
+			context: { content_type: input.contentType },
+		});
+	}
+}
+
+async function assertNoInFlightFinalizeJob(pool: Queryable, sourceId: string): Promise<void> {
+	const result = await pool.query<{ count: string }>(
+		`
+			SELECT COUNT(*) AS count
+			FROM jobs
+			WHERE type = $1
+				AND status IN ('pending', 'running')
+				AND COALESCE(payload->>'sourceId', payload->>'source_id') = $2
+		`,
+		[FINALIZE_JOB_TYPE, sourceId],
+	);
+
+	if ((Number.parseInt(result.rows[0]?.count ?? '0', 10) || 0) > 0) {
+		throw new MulderError(`Upload finalize job already in progress for ${sourceId}`, 'UPLOAD_FINALIZE_CONFLICT', {
+			context: { source_id: sourceId },
+		});
+	}
+}
+
+export async function initiateDocumentUpload(
+	input: InitiateDocumentUploadRequest,
+	logger?: Logger,
+): Promise<InitiateDocumentUploadResponse> {
+	const { config, services } = resolveContext();
+	const requestLogger = createRouteLogger(logger ?? createLogger(), {
+		action: 'initiate',
+		filename: input.filename,
+		size_bytes: input.size_bytes,
+	});
+
+	ensurePdfInput({ filename: input.filename, contentType: input.content_type });
+	const maxBytes = maxUploadBytes(config);
+	if (input.size_bytes > maxBytes) {
+		throw new MulderError(
+			'Declared upload exceeds the configured ingest limit',
+			INGEST_ERROR_CODES.INGEST_FILE_TOO_LARGE,
+			{
+				context: {
+					filename: input.filename,
+					size_bytes: input.size_bytes,
+					max_bytes: maxBytes,
+				},
+			},
+		);
+	}
+
+	const sourceId = randomUUID();
+	const storagePath = `raw/${sourceId}/original.pdf`;
+	const upload = await services.storage.createUploadSession(storagePath, {
+		contentType: input.content_type,
+		expectedSizeBytes: input.size_bytes,
+	});
+
+	requestLogger.info({ sourceId, storagePath, transport: upload.transport }, 'Document upload initiated');
+
+	return {
+		data: {
+			source_id: sourceId,
+			storage_path: storagePath,
+			upload: {
+				url: upload.url,
+				method: upload.method,
+				headers: upload.headers,
+				transport: upload.transport,
+				expires_at: upload.expiresAt,
+			},
+			limits: {
+				max_bytes: maxBytes,
+			},
+		},
+	};
+}
+
+export async function completeDocumentUpload(
+	input: CompleteDocumentUploadRequest,
+	logger?: Logger,
+): Promise<CompleteDocumentUploadResponse> {
+	const { pool, services } = resolveContext();
+	const requestLogger = createRouteLogger(logger ?? createLogger(), {
+		action: 'complete',
+		source_id: input.source_id,
+		start_pipeline: input.start_pipeline,
+	});
+
+	const metadata = await services.storage.getMetadata(input.storage_path);
+	if (!metadata) {
+		throw new MulderError(`Uploaded object not found: ${input.storage_path}`, 'UPLOAD_OBJECT_NOT_FOUND', {
+			context: { source_id: input.source_id, storage_path: input.storage_path },
+		});
+	}
+
+	const client = await pool.connect();
+	let jobId: string | undefined;
+	try {
+		await client.query('BEGIN');
+		await client.query('SELECT pg_advisory_xact_lock($1, hashtext($2))', [197, input.source_id]);
+
+		const existingSource = await findSourceById(client, input.source_id);
+		if (existingSource) {
+			throw new MulderError(`Upload already finalized for ${input.source_id}`, 'UPLOAD_ALREADY_FINALIZED_CONFLICT', {
+				context: { source_id: input.source_id },
+			});
+		}
+
+		await assertNoInFlightFinalizeJob(client, input.source_id);
+
+		const result = await client.query<{ id: string }>(
+			`
+				INSERT INTO jobs (type, payload, max_attempts)
+				VALUES ($1, $2::jsonb, 3)
+				RETURNING id
+			`,
+			[
+				FINALIZE_JOB_TYPE,
+				JSON.stringify({
+					sourceId: input.source_id,
+					filename: input.filename,
+					storagePath: input.storage_path,
+					tags: input.tags ?? [],
+					startPipeline: input.start_pipeline,
+					declaredSizeBytes: metadata.sizeBytes,
+				}),
+			],
+		);
+
+		jobId = result.rows[0]?.id;
+		if (!jobId) {
+			throw new DatabaseError('Failed to enqueue upload finalize job', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+				context: { source_id: input.source_id },
+			});
+		}
+
+		await client.query('COMMIT');
+	} catch (error) {
+		try {
+			await client.query('ROLLBACK');
+		} catch {
+			// Ignore rollback failures and surface the original error.
+		}
+		throw error;
+	} finally {
+		client.release();
+	}
+
+	requestLogger.info({ jobId, sourceId: input.source_id }, 'Document upload finalize job enqueued');
+
+	return {
+		data: {
+			job_id: jobId,
+			status: 'pending',
+			source_id: input.source_id,
+		},
+		links: {
+			status: `/api/jobs/${jobId}`,
+		},
+	};
+}
+
+export async function handleDevUploadProxy(
+	storagePath: string,
+	body: Buffer,
+	contentType: string,
+	logger?: Logger,
+): Promise<void> {
+	const { config, services } = resolveContext();
+	if (!(config.dev_mode || process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development')) {
+		throw new MulderError('Dev upload proxy is unavailable', 'UPLOAD_PROXY_FORBIDDEN');
+	}
+
+	if (!storagePath.startsWith('raw/') || !storagePath.endsWith('/original.pdf')) {
+		throw new MulderError('Invalid storage path for dev upload', 'VALIDATION_ERROR', {
+			context: { storage_path: storagePath },
+		});
+	}
+
+	await services.storage.upload(storagePath, body, contentType);
+	createRouteLogger(logger ?? createLogger(), {
+		action: 'dev-upload',
+		storage_path: storagePath,
+		bytes: body.length,
+	}).info('Document upload proxy stored bytes');
+}

--- a/apps/api/src/middleware/body-limit.ts
+++ b/apps/api/src/middleware/body-limit.ts
@@ -4,6 +4,7 @@ import type { MiddlewareHandler } from 'hono';
 export const MAX_API_BODY_BYTES = 10 * 1024 * 1024;
 
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const BODY_LIMIT_EXEMPT_ROUTES = new Set(['/api/uploads/documents/dev-upload']);
 
 function parseContentLength(headerValue: string | null): number | undefined {
 	if (headerValue === null) {
@@ -47,6 +48,12 @@ async function measureRequestBodyBytes(request: Request, maxBodyBytes: number): 
 export function createBodyLimitMiddleware(maxBodyBytes = MAX_API_BODY_BYTES): MiddlewareHandler {
 	return async (c, next) => {
 		if (!BODY_METHODS.has(c.req.method.toUpperCase())) {
+			await next();
+			return;
+		}
+
+		const pathname = new URL(c.req.url).pathname;
+		if (BODY_LIMIT_EXEMPT_ROUTES.has(pathname)) {
 			await next();
 			return;
 		}

--- a/apps/api/src/routes/uploads.schemas.ts
+++ b/apps/api/src/routes/uploads.schemas.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+export const UploadTransportSchema = z.enum(['gcs_resumable', 'dev_proxy']);
+
+export const InitiateDocumentUploadRequestSchema = z.object({
+	filename: z.string().trim().min(1).max(512),
+	size_bytes: z.number().int().positive(),
+	content_type: z.string().trim().min(1).max(128),
+	tags: z.array(z.string().trim().min(1).max(64)).max(20).optional(),
+});
+
+export const UploadTargetSchema = z.object({
+	url: z.string().min(1),
+	method: z.literal('PUT'),
+	headers: z.record(z.string(), z.string()),
+	transport: UploadTransportSchema,
+	expires_at: z.string().nullable(),
+});
+
+export const InitiateDocumentUploadResponseSchema = z.object({
+	data: z.object({
+		source_id: z.string().uuid(),
+		storage_path: z.string().min(1),
+		upload: UploadTargetSchema,
+		limits: z.object({
+			max_bytes: z.number().int().positive(),
+		}),
+	}),
+});
+
+export const CompleteDocumentUploadRequestSchema = z
+	.object({
+		source_id: z.string().uuid(),
+		filename: z.string().trim().min(1).max(512),
+		storage_path: z.string().min(1),
+		tags: z.array(z.string().trim().min(1).max(64)).max(20).optional(),
+		start_pipeline: z.boolean().optional().default(true),
+	})
+	.superRefine((value, ctx) => {
+		const expectedPath = `raw/${value.source_id}/original.pdf`;
+		if (value.storage_path !== expectedPath) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['storage_path'],
+				message: `storage_path must equal ${expectedPath}`,
+			});
+		}
+	});
+
+export const CompleteDocumentUploadResponseSchema = z.object({
+	data: z.object({
+		job_id: z.string().uuid(),
+		status: z.literal('pending'),
+		source_id: z.string().uuid(),
+	}),
+	links: z.object({
+		status: z.string().regex(/^\/api\/jobs\/[0-9a-f-]+$/i),
+	}),
+});
+
+export const DevUploadQuerySchema = z.object({
+	storage_path: z.string().min(1),
+});
+
+export type InitiateDocumentUploadRequest = z.infer<typeof InitiateDocumentUploadRequestSchema>;
+export type InitiateDocumentUploadResponse = z.infer<typeof InitiateDocumentUploadResponseSchema>;
+export type CompleteDocumentUploadRequest = z.infer<typeof CompleteDocumentUploadRequestSchema>;
+export type CompleteDocumentUploadResponse = z.infer<typeof CompleteDocumentUploadResponseSchema>;

--- a/apps/api/src/routes/uploads.ts
+++ b/apps/api/src/routes/uploads.ts
@@ -1,0 +1,48 @@
+import { type Logger, MulderError } from '@mulder/core';
+import type { Context, Hono } from 'hono';
+import { completeDocumentUpload, handleDevUploadProxy, initiateDocumentUpload } from '../lib/uploads.js';
+import {
+	CompleteDocumentUploadRequestSchema,
+	CompleteDocumentUploadResponseSchema,
+	DevUploadQuerySchema,
+	InitiateDocumentUploadRequestSchema,
+	InitiateDocumentUploadResponseSchema,
+} from './uploads.schemas.js';
+
+async function readJsonBody(c: Context): Promise<unknown> {
+	try {
+		return await c.req.json();
+	} catch {
+		throw new MulderError('Invalid request', 'VALIDATION_ERROR');
+	}
+}
+
+function readRequestLogger(c: Context): Logger | undefined {
+	return c.get('requestContext')?.logger;
+}
+
+export function registerUploadRoutes(app: Hono): void {
+	app.post('/api/uploads/documents/initiate', async (c) => {
+		const body = InitiateDocumentUploadRequestSchema.parse(await readJsonBody(c));
+		const response = await initiateDocumentUpload(body, readRequestLogger(c));
+		InitiateDocumentUploadResponseSchema.parse(response);
+		return c.json(response, 201);
+	});
+
+	app.post('/api/uploads/documents/complete', async (c) => {
+		const body = CompleteDocumentUploadRequestSchema.parse(await readJsonBody(c));
+		const response = await completeDocumentUpload(body, readRequestLogger(c));
+		CompleteDocumentUploadResponseSchema.parse(response);
+		return c.json(response, 202);
+	});
+
+	app.put('/api/uploads/documents/dev-upload', async (c) => {
+		const { storage_path } = DevUploadQuerySchema.parse({
+			storage_path: new URL(c.req.url).searchParams.get('storage_path') ?? '',
+		});
+		const contentType = c.req.header('content-type') ?? 'application/octet-stream';
+		const body = Buffer.from(await c.req.arrayBuffer());
+		await handleDevUploadProxy(storage_path, body, contentType, readRequestLogger(c));
+		return c.body(null, 204);
+	});
+}

--- a/demo/src/pages/Upload.tsx
+++ b/demo/src/pages/Upload.tsx
@@ -1,44 +1,253 @@
-import { useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Upload as UploadIcon, FileText, X, Sparkles, Check, ChevronRight, Loader2 } from 'lucide-react';
+import { Check, ChevronRight, FileText, Loader2, Upload as UploadIcon, X } from 'lucide-react';
 
-type UploadStage = 'idle' | 'dropped' | 'analyzing' | 'metadata' | 'processing';
+type UploadStage = 'idle' | 'ready' | 'uploading' | 'finalizing' | 'processing' | 'complete' | 'error';
 
-const autoFilledFields = [
-  { label: 'Quellentyp', value: 'Fachzeitschrift', filled: true },
-  { label: 'Titel', value: 'MUFON UFO Journal', filled: true },
-  { label: 'Ausgabe', value: '03/2017', filled: true },
-  { label: 'Herausgeber', value: 'MUFON Inc.', filled: true },
-  { label: 'Datum', value: '2017-03-01', filled: true },
-  { label: 'Sprache', value: 'Englisch', filled: true },
-  { label: 'Seiten', value: '96', filled: true },
-];
+interface UploadJobState {
+  jobId: string;
+  sourceId: string;
+}
+
+interface UploadTarget {
+  url: string;
+  method: 'PUT';
+  headers: Record<string, string>;
+  transport: 'gcs_resumable' | 'dev_proxy';
+}
+
+interface JobPayload {
+  result_status?: 'created' | 'duplicate';
+  resolved_source_id?: string;
+  duplicate_of_source_id?: string;
+  pipeline_job_id?: string;
+}
+
+interface JobDetailResponse {
+  data: {
+    job: {
+      status: 'pending' | 'running' | 'completed' | 'failed' | 'dead_letter';
+      error_log: string | null;
+      payload: JobPayload;
+    };
+  };
+}
+
+const apiBase = import.meta.env.VITE_MULDER_API_BASE_URL ?? '';
+const apiKey = import.meta.env.VITE_MULDER_API_KEY ?? '';
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function apiUrl(path: string): string {
+  return path.startsWith('http') ? path : `${apiBase}${path}`;
+}
+
+function buildApiHeaders(contentType = 'application/json'): HeadersInit {
+  return {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    'Content-Type': contentType,
+  };
+}
 
 export default function UploadPage() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [file, setFile] = useState<File | null>(null);
   const [stage, setStage] = useState<UploadStage>('idle');
-  const [visibleFields, setVisibleFields] = useState(0);
+  const [jobState, setJobState] = useState<UploadJobState | null>(null);
+  const [sourceLink, setSourceLink] = useState<string | null>(null);
+  const [resultLabel, setResultLabel] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const handleDrop = () => {
-    setStage('dropped');
-    setTimeout(() => {
-      setStage('analyzing');
-      setTimeout(() => {
-        setStage('metadata');
-        // Animate fields appearing one by one
-        autoFilledFields.forEach((_, i) => {
-          setTimeout(() => setVisibleFields(i + 1), 300 + i * 200);
+  const fileSummary = useMemo(() => {
+    if (!file) return null;
+    return `${formatBytes(file.size)} · ${file.type || 'application/pdf'}`;
+  }, [file]);
+
+  useEffect(() => {
+    if (!jobState) {
+      return;
+    }
+
+    let cancelled = false;
+    const interval = window.setInterval(async () => {
+      try {
+        const response = await fetch(apiUrl(`/api/jobs/${jobState.jobId}`), {
+          headers: buildApiHeaders(),
         });
-      }, 1500);
-    }, 800);
+        if (!response.ok) {
+          throw new Error(`Status polling failed (${response.status})`);
+        }
+
+        const body = (await response.json()) as JobDetailResponse;
+        if (cancelled) {
+          return;
+        }
+
+        const { job } = body.data;
+        if (job.status === 'pending' || job.status === 'running') {
+          setStage('processing');
+          return;
+        }
+
+        window.clearInterval(interval);
+
+        if (job.status === 'completed') {
+          const resolvedSourceId = job.payload.resolved_source_id ?? jobState.sourceId;
+          setSourceLink(`/sources/${resolvedSourceId}`);
+          if (job.payload.result_status === 'duplicate') {
+            setResultLabel('Dokument bereits vorhanden');
+          } else {
+            setResultLabel('Quelle angelegt und Pipeline gestartet');
+          }
+          setStage('complete');
+          return;
+        }
+
+        setErrorMessage(job.error_log ?? 'Die Verarbeitung konnte nicht abgeschlossen werden.');
+        setStage('error');
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setErrorMessage(error instanceof Error ? error.message : 'Statusprüfung fehlgeschlagen');
+        setStage('error');
+      }
+    }, 1500);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [jobState]);
+
+  const openPicker = () => {
+    fileInputRef.current?.click();
   };
 
-  const handleConfirm = () => {
-    setStage('processing');
+  const reset = () => {
+    setFile(null);
+    setJobState(null);
+    setSourceLink(null);
+    setResultLabel('');
+    setErrorMessage(null);
+    setStage('idle');
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0] ?? null;
+    setFile(nextFile);
+    setJobState(null);
+    setSourceLink(null);
+    setResultLabel('');
+    setErrorMessage(null);
+    setStage(nextFile ? 'ready' : 'idle');
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setStage('uploading');
+
+    try {
+      const initiateResponse = await fetch(apiUrl('/api/uploads/documents/initiate'), {
+        method: 'POST',
+        headers: buildApiHeaders(),
+        body: JSON.stringify({
+          filename: file.name,
+          size_bytes: file.size,
+          content_type: file.type || 'application/pdf',
+        }),
+      });
+
+      if (!initiateResponse.ok) {
+        const error = (await initiateResponse.json()) as { error?: { message?: string } };
+        throw new Error(error.error?.message ?? `Upload initiation failed (${initiateResponse.status})`);
+      }
+
+      const initiateBody = (await initiateResponse.json()) as {
+        data: {
+          source_id: string;
+          storage_path: string;
+          upload: UploadTarget;
+        };
+      };
+
+      const uploadHeaders: HeadersInit = {
+        ...initiateBody.data.upload.headers,
+        'Content-Type': file.type || 'application/pdf',
+        ...(initiateBody.data.upload.transport === 'dev_proxy' && apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      };
+
+      const uploadResponse = await fetch(apiUrl(initiateBody.data.upload.url), {
+        method: initiateBody.data.upload.method,
+        headers: uploadHeaders,
+        body: file,
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error(`Direct upload failed (${uploadResponse.status})`);
+      }
+
+      setStage('finalizing');
+
+      const completeResponse = await fetch(apiUrl('/api/uploads/documents/complete'), {
+        method: 'POST',
+        headers: buildApiHeaders(),
+        body: JSON.stringify({
+          source_id: initiateBody.data.source_id,
+          filename: file.name,
+          storage_path: initiateBody.data.storage_path,
+          start_pipeline: true,
+        }),
+      });
+
+      if (!completeResponse.ok) {
+        const error = (await completeResponse.json()) as { error?: { message?: string } };
+        throw new Error(error.error?.message ?? `Finalize failed (${completeResponse.status})`);
+      }
+
+      const completeBody = (await completeResponse.json()) as {
+        data: {
+          job_id: string;
+          source_id: string;
+        };
+      };
+
+      setJobState({
+        jobId: completeBody.data.job_id,
+        sourceId: completeBody.data.source_id,
+      });
+      setStage('processing');
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Upload fehlgeschlagen');
+      setStage('error');
+    }
   };
 
   return (
     <div className="p-6 max-w-3xl mx-auto">
-      {/* Breadcrumb */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="hidden"
+        onChange={handleFileSelect}
+      />
+
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
         <Link to="/" className="hover:text-foreground no-underline text-muted-foreground">Übersicht</Link>
         <ChevronRight size={12} />
@@ -47,179 +256,123 @@ export default function UploadPage() {
 
       <h1 className="text-xl font-semibold mb-1">Quelldokument hochladen</h1>
       <p className="text-sm text-muted-foreground mb-6">
-        Laden Sie ein PDF hoch — die KI extrahiert automatisch Metadaten, identifiziert Artikel und verknüpft Akteure.
+        Laden Sie ein PDF hoch. Mulder reserviert zuerst eine Upload-Session, überträgt die Datei direkt in den Speicher und startet danach die Verarbeitung im Hintergrund.
       </p>
 
-      {stage === 'idle' && (
+      {(stage === 'idle' || stage === 'ready') && (
         <button
-          onClick={handleDrop}
+          onClick={openPicker}
           className="w-full rounded-[var(--radius)] border-2 border-dashed border-primary/40 bg-primary/5 p-12 text-center transition-colors hover:border-primary hover:bg-primary/10 cursor-pointer"
         >
           <UploadIcon size={40} className="mx-auto mb-4 text-primary/60" />
-          <div className="text-sm font-medium text-foreground">PDF-Dateien hierher ziehen oder klicken zum Durchsuchen</div>
-          <div className="mt-1 text-xs text-muted-foreground">Einzeldateien oder Stapel-Upload · Nur PDF · Max 500 MB</div>
+          <div className="text-sm font-medium text-foreground">PDF auswählen</div>
+          <div className="mt-1 text-xs text-muted-foreground">Browser startet danach einen direkten Upload und queue-basiertes Finalisieren</div>
         </button>
       )}
 
-      {stage === 'dropped' && (
-        <div className="rounded-[var(--radius)] border bg-card p-6">
+      {file && (
+        <div className="mt-6 rounded-[var(--radius)] border bg-card p-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-[var(--radius)] border bg-muted">
-              <FileText size={20} className="text-muted-foreground" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-[var(--radius)] border bg-primary/10">
+              <FileText size={20} className="text-primary" />
             </div>
-            <div className="flex-1">
-              <div className="text-sm font-medium">MUFON_UFO_Journal_03_2017.pdf</div>
-              <div className="text-xs text-muted-foreground">18.4 MB · Wird hochgeladen...</div>
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium">{file.name}</div>
+              <div className="text-xs text-muted-foreground">{fileSummary}</div>
             </div>
-            <div className="h-1.5 w-32 overflow-hidden rounded-full bg-muted">
-              <div className="h-full w-3/4 rounded-full bg-primary animate-pulse" />
-            </div>
+            {(stage === 'idle' || stage === 'ready' || stage === 'error') && (
+              <button className="text-muted-foreground hover:text-foreground" onClick={reset}>
+                <X size={16} />
+              </button>
+            )}
+            {stage === 'complete' && (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-primary">
+                <Check size={14} /> Abgeschlossen
+              </span>
+            )}
           </div>
         </div>
       )}
 
-      {(stage === 'analyzing' || stage === 'metadata' || stage === 'processing') && (
-        <div className="space-y-6">
-          {/* File info */}
-          <div className="rounded-[var(--radius)] border bg-card p-4">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-[var(--radius)] border bg-primary/10">
-                <FileText size={20} className="text-primary" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium">MUFON_UFO_Journal_03_2017.pdf</div>
-                <div className="text-xs text-muted-foreground">18.4 MB · 96 Seiten</div>
-              </div>
-              {stage !== 'processing' && (
-                <button className="text-muted-foreground hover:text-foreground">
-                  <X size={16} />
-                </button>
-              )}
-              {stage === 'processing' && (
-                <span className="flex items-center gap-1.5 text-xs font-medium text-primary">
-                  <Check size={14} /> Hochgeladen
-                </span>
-              )}
-            </div>
+      {file && stage === 'ready' && (
+        <div className="mt-6 rounded-[var(--radius)] border bg-card p-4 flex items-center justify-between gap-4">
+          <div>
+            <div className="text-sm font-medium">Bereit für den Upload</div>
+            <div className="text-xs text-muted-foreground">Die API reserviert zuerst eine Session und die Datei geht dann direkt in den Speicher.</div>
           </div>
+          <button
+            onClick={handleUpload}
+            className="flex items-center gap-1.5 rounded-[var(--radius)] border border-primary bg-primary px-4 py-2 text-xs font-medium text-primary-foreground"
+          >
+            <UploadIcon size={14} /> Upload starten
+          </button>
+        </div>
+      )}
 
-          {/* AI Analysis indicator */}
-          {stage === 'analyzing' && (
-            <div className="rounded-[var(--radius)] border border-primary/30 bg-primary/5 p-6 text-center">
-              <Loader2 size={24} className="mx-auto mb-3 text-primary animate-spin" />
-              <div className="text-sm font-medium">KI analysiert das Dokument...</div>
-              <div className="mt-1 text-xs text-muted-foreground">Liest Titelseite und Inhaltsverzeichnis zur Metadaten-Extraktion</div>
-            </div>
-          )}
-
-          {/* Metadata form - auto-filled by AI */}
-          {(stage === 'metadata' || stage === 'processing') && (
-            <div className="rounded-[var(--radius)] border bg-card">
-              <div className="flex items-center gap-2 border-b px-4 py-3">
-                <Sparkles size={14} className="text-accent dark:text-accent" />
-                <h2 className="text-sm font-semibold">Metadaten — automatisch von KI ausgefüllt</h2>
-                <span className="ml-auto rounded bg-primary/10 px-2 py-0.5 font-mono text-[10px] font-medium text-primary">
-                  Gemini 2.5 Flash
-                </span>
-              </div>
-              <div className="p-4 space-y-3">
-                {autoFilledFields.map((field, i) => (
-                  <div
-                    key={field.label}
-                    className={`transition-all duration-300 ${
-                      i < visibleFields ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 h-0 overflow-hidden'
-                    }`}
-                  >
-                    <label className="block text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
-                      {field.label}
-                    </label>
-                    <div className="relative">
-                      <div className={`rounded-[var(--radius)] border px-3 py-2 text-sm ${
-                        stage === 'processing' ? 'bg-muted/50 text-muted-foreground' : 'bg-card'
-                      }`}>
-                        {field.value}
-                      </div>
-                      {field.filled && i < visibleFields && stage !== 'processing' && (
-                        <span className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 text-[10px] text-primary font-medium">
-                          <Sparkles size={10} /> AI
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {stage === 'metadata' && visibleFields >= autoFilledFields.length && (
-                <div className="border-t px-4 py-3 flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    Prüfen und bei Bedarf korrigieren. KI-Konfidenz: <span className="font-mono font-medium text-green-600 dark:text-green-400">94%</span>
-                  </span>
-                  <button
-                    onClick={handleConfirm}
-                    className="flex items-center gap-1.5 rounded-[var(--radius)] border border-primary bg-primary px-4 py-2 text-xs font-medium text-primary-foreground"
-                  >
-                    <Check size={14} /> Bestätigen & Verarbeitung starten
-                  </button>
+      {(stage === 'uploading' || stage === 'finalizing' || stage === 'processing') && (
+        <div className="mt-6 rounded-[var(--radius)] border bg-card">
+          <div className="border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">Verarbeitungsstatus</h2>
+            <p className="text-xs text-muted-foreground mt-0.5">Die Seite kann geöffnet bleiben, während der Job im Hintergrund weiterläuft.</p>
+          </div>
+          <div className="p-4 space-y-3">
+            {[
+              { label: 'Upload-Session reservieren', active: stage !== 'uploading' ? false : true, done: stage === 'finalizing' || stage === 'processing' },
+              { label: 'Datei direkt in den Speicher übertragen', active: stage === 'uploading', done: stage === 'finalizing' || stage === 'processing' },
+              { label: 'Upload finalisieren', active: stage === 'finalizing', done: stage === 'processing' },
+              { label: 'Pipeline-Job anlegen', active: stage === 'processing', done: false },
+            ].map((step, index) => (
+              <div key={step.label} className="flex items-center gap-3">
+                <div className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-mono font-bold ${
+                  step.done
+                    ? 'border-[#86efac] bg-[#dcfce7] text-[#15803d]'
+                    : step.active
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground'
+                }`}>
+                  {step.done ? <Check size={14} /> : index + 1}
                 </div>
-              )}
-            </div>
-          )}
+                <div className="flex-1">
+                  <div className={`text-xs font-medium ${step.active ? 'text-foreground' : 'text-muted-foreground'}`}>
+                    {step.label}
+                  </div>
+                </div>
+                {step.active && <Loader2 size={14} className="text-primary animate-spin" />}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
-          {/* Processing pipeline */}
-          {stage === 'processing' && (
-            <div className="rounded-[var(--radius)] border bg-card">
-              <div className="border-b px-4 py-3">
-                <h2 className="text-sm font-semibold">Verarbeitungs-Pipeline</h2>
-                <p className="text-xs text-muted-foreground mt-0.5">Geschätzte Dauer: 3–5 Minuten</p>
-              </div>
-              <div className="p-4 space-y-3">
-                {['OCR & Layout-Analyse', 'Berichts-Segmentierung', 'Akteur-Extraktion', 'Embedding-Generierung', 'Netzwerk-Aktualisierung'].map((step, i) => {
-                  const isActive = i === 1;
-                  const isDone = i === 0;
-                  return (
-                    <div key={step} className="flex items-center gap-3">
-                      <div className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-mono font-bold ${
-                        isDone
-                          ? 'border-[#86efac] bg-[#dcfce7] text-[#15803d] dark:bg-green-900/30 dark:text-green-400'
-                          : isActive
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-muted-foreground'
-                      }`}>
-                        {isDone ? <Check size={14} /> : i + 1}
-                      </div>
-                      <div className="flex-1">
-                        <div className={`text-xs font-medium ${isDone ? 'text-muted-foreground' : isActive ? 'text-foreground' : 'text-muted-foreground'}`}>
-                          {step}
-                        </div>
-                        {isActive && (
-                          <div className="mt-1.5">
-                            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                              <div className="h-full w-2/5 rounded-full bg-primary transition-all animate-pulse" />
-                            </div>
-                            <div className="mt-1 font-mono text-[10px] text-muted-foreground">
-                              Identifiziere Artikel und Berichtsgrenzen... 12 Berichte bisher gefunden
-                            </div>
-                          </div>
-                        )}
-                        {isDone && (
-                          <div className="text-[10px] text-muted-foreground">96 Seiten analysiert · 387 Textblöcke · 52 Bilder erkannt</div>
-                        )}
-                      </div>
-                      {isActive && <Loader2 size={14} className="text-primary animate-spin" />}
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="border-t px-4 py-3 flex items-center justify-between">
-                <span className="text-xs text-muted-foreground">
-                  Sie können diese Seite verlassen — die Verarbeitung läuft im Hintergrund weiter.
-                </span>
-                <Link to="/" className="text-xs text-primary hover:underline no-underline">
-                  Zurück zur Übersicht
-                </Link>
-              </div>
-            </div>
-          )}
+      {stage === 'complete' && (
+        <div className="mt-6 rounded-[var(--radius)] border border-primary/30 bg-primary/5 p-6">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Check size={16} className="text-primary" />
+            {resultLabel}
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {sourceLink ? 'Die Quelle ist jetzt in der Bibliothek sichtbar.' : 'Der Job wurde abgeschlossen.'}
+          </p>
+          <div className="mt-4 flex items-center gap-3">
+            {sourceLink && (
+              <Link to={sourceLink} className="text-xs text-primary hover:underline no-underline">
+                Zur Quelle
+              </Link>
+            )}
+            <Link to="/sources" className="text-xs text-muted-foreground hover:text-foreground no-underline">
+              Zur Quellen-Bibliothek
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {stage === 'error' && (
+        <div className="mt-6 rounded-[var(--radius)] border border-red-300 bg-red-50 p-4">
+          <div className="text-sm font-medium text-red-700">Upload fehlgeschlagen</div>
+          <p className="mt-1 text-xs text-red-700/80">{errorMessage ?? 'Bitte erneut versuchen.'}</p>
+          <button onClick={reset} className="mt-3 text-xs text-red-700 hover:underline">
+            Neu starten
+          </button>
         </div>
       )}
     </div>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,7 +193,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | 🟢 | H9 | Evidence API routes (sync) | §10.6 |
 | 🟢 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
-| ⚪ | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
+| 🟡 | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
 
 **Also read for all M7 steps:** [`docs/api-architecture.md`](./api-architecture.md) (framework choice, route structure, middleware stack, OpenAPI strategy, key trade-offs), §10 (full job queue section — especially §10.3 transaction discipline), §14 (design decisions — PostgreSQL queue, auto-commit dequeue, per-step job slicing)
 

--- a/docs/specs/77_large_pdf_browser_upload_flow.spec.md
+++ b/docs/specs/77_large_pdf_browser_upload_flow.spec.md
@@ -1,0 +1,252 @@
+---
+spec: "77"
+title: "Large PDF Browser Upload Flow"
+roadmap_step: M7-H11
+functional_spec: ["§10.6", "§13"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/197"
+created: 2026-04-15
+---
+
+# Spec 77: Large PDF Browser Upload Flow
+
+## 1. Objective
+
+Deliver the upload half of `M7-H11` in a way that works for realistic research PDFs without fighting Mulder's global API middleware or Cloud Run request limits. Instead of proxying PDF bytes through `POST /api/documents/upload`, the browser requests an upload session from Mulder, uploads the PDF directly to Cloud Storage, and then asks Mulder to finalize the upload into the normal source + pipeline model.
+
+This spec resolves issue `#197` by making the transport explicit and durable: the API keeps its 10 MB request-body guard for normal JSON routes, while document bytes move over a direct storage upload path that supports large files and keeps route logic focused on validation, deduplication, and job orchestration.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H11` — Document Viewer UI
+- **Target:** `packages/core/src/shared/services.ts`, `packages/core/src/shared/services.dev.ts`, `packages/core/src/shared/services.gcp.ts`, `packages/core/src/database/repositories/source.types.ts`, `packages/core/src/database/repositories/source.repository.ts`, `packages/core/src/database/repositories/job.repository.ts`, `packages/core/src/database/repositories/index.ts`, `packages/core/src/index.ts`, `apps/api/src/app.ts`, `apps/api/src/routes/uploads.schemas.ts`, `apps/api/src/routes/uploads.ts`, `apps/api/src/lib/uploads.ts`, `packages/worker/src/worker.types.ts`, `packages/worker/src/dispatch.ts`, `demo/src/pages/Upload.tsx`, `tests/specs/77_large_pdf_browser_upload_flow.test.ts`
+- **In scope:** a browser-safe upload contract for large PDFs; upload-session initiation over authenticated JSON; direct-to-storage upload transport that bypasses API body-size bottlenecks; queued server-side finalization that validates the uploaded object, computes file hash, performs deduplication, creates or resolves the source, marks ingest as completed, and optionally enqueues the pipeline run; job payload/status data that lets the UI distinguish new uploads from duplicates; and black-box tests for accepted large uploads, oversized rejected uploads, duplicate handling, and preserved middleware behavior
+- **Out of scope:** the full split-view document reader for `H11`, resumable-upload pause/resume UI polish beyond what the storage session already supports, multi-file batch upload, signed download URLs, non-PDF formats, and changing the existing global 10 MB API limit for unrelated routes
+- **Constraints:** keep the public API job-producer model from `§10.6`; do not add a generic large-body bypass on the main API stack; keep storage access behind `StorageService`; preserve dedupe semantics based on file hash; and keep the browser flow compatible with the existing async worker/pipeline architecture
+
+## 3. Dependencies
+
+- **Requires:** Spec 14 (`M2-B2`) source repository, Spec 16 (`M2-B4`) ingest validation + dedupe behavior, Spec 67 (`M7-H1`) job queue repository, Spec 68 (`M7-H2`) worker loop, Spec 69 (`M7-H3`) Hono server scaffold, Spec 70 (`M7-H4`) middleware stack, Spec 71 (`M7-H5`) async pipeline API routes, and Spec 76 (`M7-H10`) document retrieval routes
+- **Blocks:** a production-worthy `H11` upload page that can handle normal research PDFs without middleware rejection, plus any later bulk-upload UI that depends on the same transport and finalize contract
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`packages/core/src/shared/services.ts`** — extend `StorageService` with upload-session creation and object metadata helpers needed by the browser upload flow
+2. **`packages/core/src/shared/services.dev.ts`** — provide deterministic dev/test storage behavior for initiated uploads and finalized objects
+3. **`packages/core/src/shared/services.gcp.ts`** — implement direct Cloud Storage upload-session creation plus object metadata reads for production
+4. **`packages/core/src/database/repositories/source.types.ts`** — allow explicit source IDs for browser-initiated uploads
+5. **`packages/core/src/database/repositories/source.repository.ts`** — persist a source row with a caller-supplied ID when finalize succeeds
+6. **`packages/core/src/database/repositories/job.repository.ts`** — support writing finalize results back into job payloads before completion
+7. **`apps/api/src/routes/uploads.schemas.ts`** — define the initiation and completion request/response envelopes
+8. **`apps/api/src/lib/uploads.ts`** — own upload-session initiation, completion-job enqueueing, and job-payload result mapping
+9. **`apps/api/src/routes/uploads.ts`** — mount authenticated upload endpoints
+10. **`apps/api/src/app.ts`** — register the upload route group while preserving the existing middleware order
+11. **`packages/worker/src/worker.types.ts`** — add the finalize job payload contract
+12. **`packages/worker/src/dispatch.ts`** — dispatch `document_upload_finalize` jobs through the finalize workflow
+13. **`demo/src/pages/Upload.tsx`** — replace the mock upload flow with the real initiate → upload → complete → poll interaction
+14. **`tests/specs/77_large_pdf_browser_upload_flow.test.ts`** — verify the contract end to end at the HTTP/job boundary
+
+### 4.2 Route Contract
+
+#### `POST /api/uploads/documents/initiate`
+
+Purpose: start a browser upload without sending PDF bytes through Mulder.
+
+Request body:
+
+```json
+{
+  "filename": "mufon-journal-2017-03.pdf",
+  "size_bytes": 19300352,
+  "content_type": "application/pdf",
+  "tags": ["review"]
+}
+```
+
+Success behavior:
+
+- returns `201`
+- response includes:
+  - `source_id` — pre-assigned UUID for the eventual source
+  - `storage_path` — `raw/{source_id}/original.pdf`
+  - `upload` — direct upload target details (`url`, `method`, optional headers, transport kind)
+  - `limits.max_bytes` — resolved from `config.ingestion.max_file_size_mb`
+- validates filename, declared content type, and declared size before creating the session
+
+Rules:
+
+- the request body stays JSON-sized and must continue to pass through the existing body-limit middleware
+- declared sizes above the configured ingest maximum fail here with a Mulder validation/error response
+- production transport uses a direct Cloud Storage resumable upload session; Mulder must not proxy the PDF bytes through the main route handler
+
+#### Direct upload step
+
+Purpose: move the PDF bytes from browser to storage without going through Mulder's API body path.
+
+Rules:
+
+- the browser uploads the file to the returned session target and stores no secrets beyond the returned session URL/headers
+- the uploaded object lands at the returned `storage_path`
+- upload failure before completion does not create a source row or queue a pipeline job
+
+#### `POST /api/uploads/documents/complete`
+
+Purpose: tell Mulder the storage upload finished and queue server-side finalization.
+
+Request body:
+
+```json
+{
+  "source_id": "uuid",
+  "filename": "mufon-journal-2017-03.pdf",
+  "storage_path": "raw/uuid/original.pdf",
+  "tags": ["review"],
+  "start_pipeline": true
+}
+```
+
+Success behavior:
+
+- returns `202`
+- enqueues a `document_upload_finalize` job
+- response includes the finalize `job_id`, a job-status link, and the provisional `source_id`
+
+Rules:
+
+- this route verifies that the uploaded object exists before enqueueing finalize work
+- repeated completion calls for the same `source_id` must not enqueue duplicate in-flight finalize jobs, including under near-simultaneous requests
+- `start_pipeline: true` means finalize should enqueue the normal pipeline run after ingest registration succeeds
+
+### 4.3 Finalize Job Contract
+
+`document_upload_finalize` is a worker-owned job that turns an uploaded object into a Mulder source.
+
+Payload in:
+
+```json
+{
+  "sourceId": "uuid",
+  "filename": "mufon-journal-2017-03.pdf",
+  "storagePath": "raw/uuid/original.pdf",
+  "tags": ["review"],
+  "startPipeline": true
+}
+```
+
+Worker behavior:
+
+1. confirm the object still exists at `storagePath`
+2. read object bytes and run the same PDF validation gates as CLI ingest where applicable:
+   - PDF magic bytes
+   - configured max file size
+   - lightweight PDF metadata extraction / page-count gate
+   - native text detection
+   - SHA-256 hash computation
+3. dedupe against existing sources by file hash
+4. if unique:
+   - create the source using the pre-assigned `sourceId`
+   - write the same source metadata shape as CLI ingest
+   - upsert `source_steps.ingest = completed`
+   - optionally enqueue the normal `pipeline_run` starting from `extract`
+5. if duplicate:
+   - delete the newly uploaded object at the provisional `storagePath`
+   - do not create a second source row
+   - mark the finalize result with the existing source ID instead
+
+Job payload out:
+
+- before completion, update the job payload with:
+  - `result_status: "created" | "duplicate"`
+  - `resolved_source_id`
+  - `duplicate_of_source_id` when applicable
+  - `pipeline_job_id` and `pipeline_run_id` when a pipeline job was queued
+
+### 4.4 UI Flow
+
+- the upload page uses the new initiate endpoint instead of a fake timer-driven upload
+- after initiation, the page uploads the file directly to the returned target
+- after the direct upload succeeds, the page calls complete and polls `/api/jobs/{job_id}`
+- when finalize completes:
+  - new upload: show the created source and pipeline job links
+  - duplicate upload: explain that the document already exists and link to the existing source
+
+### 4.5 Middleware And Limit Behavior
+
+- keep `createBodyLimitMiddleware()` at the existing 10 MB default for normal API routes
+- the upload contract must succeed for PDFs larger than 10 MB because the PDF body never traverses the JSON API route stack
+- oversized uploads must still be rejected deterministically at initiation using the configured ingest size limit
+- the dev/test upload proxy path may bypass the body-limit middleware, but only for the dedicated authenticated upload endpoint used to emulate direct storage uploads locally
+
+### 4.6 Implementation Phases
+
+**Phase 1: storage + repository groundwork**
+- extend storage/session capabilities
+- support explicit source IDs and job-payload result updates
+
+**Phase 2: API + worker finalize flow**
+- add initiate/complete routes and upload library helpers
+- add `document_upload_finalize` worker handling and pipeline enqueueing
+
+**Phase 3: UI + verification**
+- wire the upload page to the real flow
+- add black-box tests for accepted large uploads, oversized rejection, duplicates, and unchanged middleware protection
+
+## 5. QA Contract
+
+### QA-01: large PDF uploads initiate without tripping the API body limit
+
+**Given** an authenticated client declares a PDF larger than 10 MB but within `ingestion.max_file_size_mb`,
+**When** it sends `POST /api/uploads/documents/initiate`,
+**Then** the response is `201` with a direct upload target and no `REQUEST_BODY_TOO_LARGE` error.
+
+### QA-02: oversized uploads are rejected before any storage session is used
+
+**Given** an authenticated client declares a PDF larger than the configured ingest maximum,
+**When** it sends `POST /api/uploads/documents/initiate`,
+**Then** the API rejects the request with a Mulder validation/error response and no finalize job is created.
+
+### QA-03: completing a successful upload creates a source and pipeline job
+
+**Given** a PDF has been uploaded to the returned storage path and `start_pipeline` is true,
+**When** the client sends `POST /api/uploads/documents/complete`,
+**Then** the API returns `202`, the finalize job completes successfully, a source with the pre-assigned ID exists, ingest is marked completed, and a `pipeline_run` job is queued.
+
+### QA-04: duplicate uploads resolve to the existing source without creating a second record
+
+**Given** a second uploaded PDF has the same file hash as an existing source,
+**When** finalize runs,
+**Then** the finalize job completes with `result_status = "duplicate"`, the provisional upload object is removed, and only the original source row remains.
+
+### QA-05: missing uploaded objects fail clearly at completion/finalize time
+
+**Given** the browser never uploaded the file or the storage object disappeared,
+**When** the client calls complete,
+**Then** the API or finalize job returns a clear not-found style failure instead of silently creating a broken source.
+
+### QA-06: normal API routes keep their existing 10 MB body protection
+
+**Given** a non-upload mutating route still receives an oversized request body,
+**When** that request passes through the middleware stack,
+**Then** Mulder still returns `REQUEST_BODY_TOO_LARGE`.
+
+### QA-07: upload endpoints remain authenticated
+
+**Given** the upload routes are mounted,
+**When** an unauthenticated client calls initiate or complete,
+**Then** the request fails through the established auth boundary.
+
+### QA-08: repeated completion requests do not enqueue a second finalize job
+
+**Given** an uploaded object already has a pending finalize job for the same `source_id`,
+**When** the client calls `POST /api/uploads/documents/complete` again,
+**Then** Mulder returns a conflict-style error and only one pending finalize job exists for that upload.
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+This flow avoids unnecessary Mulder API egress and memory pressure by sending PDF bytes directly to storage, but it does add Cloud Storage upload-session traffic plus one finalize worker read of the uploaded object. The implementation should avoid duplicate object copies and should delete duplicate uploads promptly so large-file mistakes do not silently accumulate storage cost.

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -128,6 +128,7 @@ export {
 	markJobCompleted,
 	markJobDeadLetter,
 	markJobFailed,
+	mergeJobPayload,
 	reapRunningJobs,
 } from './job.repository.js';
 export type {

--- a/packages/core/src/database/repositories/job.repository.ts
+++ b/packages/core/src/database/repositories/job.repository.ts
@@ -124,6 +124,34 @@ export async function enqueueJob(pool: Queryable, input: EnqueueJobInput): Promi
 	}
 }
 
+export async function mergeJobPayload(pool: Queryable, id: string, patch: JobPayload): Promise<Job> {
+	const sql = `
+    UPDATE jobs
+    SET payload = COALESCE(payload, '{}'::jsonb) || $2::jsonb
+    WHERE id = $1
+    RETURNING *
+  `;
+
+	try {
+		const result = await pool.query<JobRow>(sql, [id, JSON.stringify(patch)]);
+		if (result.rows.length === 0) {
+			throw new DatabaseError(`Job not found: ${id}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
+				context: { id },
+			});
+		}
+		repoLogger.debug({ jobId: id }, 'Job payload merged');
+		return mapJobRow(result.rows[0]);
+	} catch (error: unknown) {
+		if (error instanceof DatabaseError) {
+			throw error;
+		}
+		throw new DatabaseError('Failed to merge job payload', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { id },
+		});
+	}
+}
+
 export async function findJobById(pool: pg.Pool, id: string): Promise<Job | null> {
 	const sql = 'SELECT * FROM jobs WHERE id = $1';
 
@@ -214,9 +242,21 @@ export async function dequeueJob(pool: pg.Pool, workerId: string): Promise<Deque
 	}
 }
 
-export async function markJobCompleted(pool: pg.Pool, claim: JobClaim): Promise<Job> {
+export async function markJobCompleted(pool: pg.Pool, claim: JobClaim, payloadPatch?: JobPayload): Promise<Job> {
 	const id = claim.jobId;
-	const sql = `
+	const sql = payloadPatch
+		? `
+    UPDATE jobs
+    SET status = 'completed',
+        finished_at = now(),
+        payload = COALESCE(payload, '{}'::jsonb) || $4::jsonb
+    WHERE id = $1
+      AND status = 'running'
+      AND worker_id = $2
+      AND attempts = $3
+    RETURNING *
+  `
+		: `
     UPDATE jobs
     SET status = 'completed',
         finished_at = now()
@@ -228,7 +268,12 @@ export async function markJobCompleted(pool: pg.Pool, claim: JobClaim): Promise<
   `;
 
 	try {
-		const result = await pool.query<JobRow>(sql, [id, claim.workerId, claim.attempts]);
+		const result = await pool.query<JobRow>(
+			sql,
+			payloadPatch
+				? [id, claim.workerId, claim.attempts, JSON.stringify(payloadPatch)]
+				: [id, claim.workerId, claim.attempts],
+		);
 		if (result.rows.length === 0) {
 			throw new DatabaseError(`Active job claim not found: ${id}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
 				context: { id, claim },

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -127,26 +127,61 @@ function buildSourceFilterClause(filter?: SourceFilter): { conditions: string[];
  * On conflict (duplicate hash), returns the existing record with an updated
  * `updated_at` timestamp.
  */
-export async function createSource(pool: pg.Pool, input: CreateSourceInput): Promise<Source> {
+export async function createSource(pool: Queryable, input: CreateSourceInput): Promise<Source> {
+	const columns = input.id
+		? [
+				'id',
+				'filename',
+				'storage_path',
+				'file_hash',
+				'page_count',
+				'has_native_text',
+				'native_text_ratio',
+				'tags',
+				'metadata',
+			]
+		: [
+				'filename',
+				'storage_path',
+				'file_hash',
+				'page_count',
+				'has_native_text',
+				'native_text_ratio',
+				'tags',
+				'metadata',
+			];
+	const values = input.id
+		? [
+				input.id,
+				input.filename,
+				input.storagePath,
+				input.fileHash,
+				input.pageCount ?? null,
+				input.hasNativeText ?? false,
+				input.nativeTextRatio ?? 0,
+				input.tags ?? [],
+				JSON.stringify(input.metadata ?? {}),
+			]
+		: [
+				input.filename,
+				input.storagePath,
+				input.fileHash,
+				input.pageCount ?? null,
+				input.hasNativeText ?? false,
+				input.nativeTextRatio ?? 0,
+				input.tags ?? [],
+				JSON.stringify(input.metadata ?? {}),
+			];
+	const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
 	const sql = `
-    INSERT INTO sources (filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, tags, metadata)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    INSERT INTO sources (${columns.join(', ')})
+    VALUES (${placeholders})
     ON CONFLICT (file_hash) DO UPDATE SET updated_at = now()
     RETURNING *
   `;
-	const params = [
-		input.filename,
-		input.storagePath,
-		input.fileHash,
-		input.pageCount ?? null,
-		input.hasNativeText ?? false,
-		input.nativeTextRatio ?? 0,
-		input.tags ?? [],
-		JSON.stringify(input.metadata ?? {}),
-	];
 
 	try {
-		const result = await pool.query<SourceRow>(sql, params);
+		const result = await pool.query<SourceRow>(sql, values);
 		const row = result.rows[0];
 		repoLogger.debug({ sourceId: row.id, fileHash: input.fileHash }, 'Source created or found');
 		return mapSourceRow(row);
@@ -185,7 +220,7 @@ export async function findSourceById(pool: Queryable, id: string): Promise<Sourc
  *
  * @returns The source, or `null` if not found.
  */
-export async function findSourceByHash(pool: pg.Pool, hash: string): Promise<Source | null> {
+export async function findSourceByHash(pool: Queryable, hash: string): Promise<Source | null> {
 	const sql = 'SELECT * FROM sources WHERE file_hash = $1';
 
 	try {
@@ -423,7 +458,7 @@ export async function deleteSource(pool: pg.Pool, id: string): Promise<boolean> 
  *
  * Sets `completed_at = now()` when the status is `completed`.
  */
-export async function upsertSourceStep(pool: pg.Pool, input: UpsertSourceStepInput): Promise<SourceStep> {
+export async function upsertSourceStep(pool: Queryable, input: UpsertSourceStepInput): Promise<SourceStep> {
 	const completedAt = input.status === 'completed' ? 'now()' : 'NULL';
 
 	const sql = `

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -41,6 +41,7 @@ export interface Source {
 
 /** Input for creating a new source. */
 export interface CreateSourceInput {
+	id?: string;
 	filename: string;
 	storagePath: string;
 	fileHash: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,6 +226,7 @@ export {
 	markJobDeadLetter,
 	markJobFailed,
 	mergeEntities,
+	mergeJobPayload,
 	persistEntityGroundingResult,
 	reapRunningJobs,
 	replaceSpatioTemporalClustersSnapshot,

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -9,11 +9,12 @@
  * @see docs/functional-spec.md §4.5, §9.1
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MulderConfig } from '../config/types.js';
 import type { Logger } from './logger.js';
 import type {
+	CreateStorageUploadSessionOptions,
 	DocumentAiResult,
 	DocumentAiService,
 	EmbeddingResult,
@@ -24,7 +25,9 @@ import type {
 	LlmService,
 	Services,
 	StorageListResult,
+	StorageObjectMetadata,
 	StorageService,
+	StorageUploadSession,
 	StructuredGenerateOptions,
 	TextGenerateOptions,
 } from './services.js';
@@ -145,10 +148,38 @@ class DevStorageService implements StorageService {
 		this.logger.debug({ bucketPath }, 'DevStorageService: uploaded');
 	}
 
+	async createUploadSession(
+		bucketPath: string,
+		_options: CreateStorageUploadSessionOptions,
+	): Promise<StorageUploadSession> {
+		this.logger.debug({ bucketPath }, 'DevStorageService: created upload session');
+		return {
+			url: `/api/uploads/documents/dev-upload?storage_path=${encodeURIComponent(bucketPath)}`,
+			method: 'PUT',
+			headers: {},
+			transport: 'dev_proxy',
+			expiresAt: null,
+		};
+	}
+
 	async download(bucketPath: string): Promise<Buffer> {
 		const fullPath = this.resolvePath(bucketPath);
 		this.logger.debug({ bucketPath, fullPath }, 'DevStorageService: downloading');
 		return readFileSync(fullPath);
+	}
+
+	async getMetadata(bucketPath: string): Promise<StorageObjectMetadata | null> {
+		const fullPath = this.resolvePath(bucketPath);
+		if (!existsSync(fullPath)) {
+			this.logger.debug({ bucketPath }, 'DevStorageService: metadata missing');
+			return null;
+		}
+
+		const stats = statSync(fullPath);
+		return {
+			sizeBytes: stats.size,
+			contentType: bucketPath.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 'application/octet-stream',
+		};
 	}
 
 	async exists(bucketPath: string): Promise<boolean> {

--- a/packages/core/src/shared/services.gcp.ts
+++ b/packages/core/src/shared/services.gcp.ts
@@ -22,6 +22,7 @@ import { closeGcpClients, getDocumentAIClient, getFirestoreClient, getGenAI, get
 import type { Logger } from './logger.js';
 import { withRetry } from './retry.js';
 import type {
+	CreateStorageUploadSessionOptions,
 	DocumentAiResult,
 	DocumentAiService,
 	EmbeddingResult,
@@ -32,7 +33,9 @@ import type {
 	LlmService,
 	Services,
 	StorageListResult,
+	StorageObjectMetadata,
 	StorageService,
+	StorageUploadSession,
 	StructuredGenerateOptions,
 	TextGenerateOptions,
 } from './services.js';
@@ -93,6 +96,40 @@ class GcpStorageService implements StorageService {
 		});
 	}
 
+	async createUploadSession(
+		bucketPath: string,
+		options: CreateStorageUploadSessionOptions,
+	): Promise<StorageUploadSession> {
+		return withRetry(
+			async () => {
+				const file = this.storage.bucket(this.bucketName).file(bucketPath);
+				const [url] = await file.createResumableUpload({
+					metadata: {
+						contentType: options.contentType,
+					},
+					preconditionOpts: {
+						ifGenerationMatch: 0,
+					},
+				});
+				this.logger.debug({ bucketPath }, 'GcpStorageService: created upload session');
+				return {
+					url,
+					method: 'PUT' as const,
+					headers: {},
+					transport: 'gcs_resumable' as const,
+					expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+				};
+			},
+			{
+				onRetry: (err, attempt, delayMs) => {
+					this.logger.warn({ err, attempt, delayMs, bucketPath }, 'GcpStorageService: retrying createUploadSession');
+				},
+			},
+		).catch((cause: unknown) => {
+			throw wrapGcpError('EXT_STORAGE_FAILED', `Failed to create upload session for ${bucketPath}`, cause);
+		});
+	}
+
 	async download(bucketPath: string): Promise<Buffer> {
 		return withRetry(
 			async () => {
@@ -108,6 +145,32 @@ class GcpStorageService implements StorageService {
 			},
 		).catch((cause: unknown) => {
 			throw wrapGcpError('EXT_STORAGE_FAILED', `Failed to download from ${bucketPath}`, cause);
+		});
+	}
+
+	async getMetadata(bucketPath: string): Promise<StorageObjectMetadata | null> {
+		return withRetry(
+			async () => {
+				const file = this.storage.bucket(this.bucketName).file(bucketPath);
+				const [exists] = await file.exists();
+				if (!exists) {
+					this.logger.debug({ bucketPath }, 'GcpStorageService: metadata missing');
+					return null;
+				}
+
+				const [metadata] = await file.getMetadata();
+				return {
+					sizeBytes: Number.parseInt(String(metadata.size ?? '0'), 10) || 0,
+					contentType: metadata.contentType ?? null,
+				};
+			},
+			{
+				onRetry: (err, attempt, delayMs) => {
+					this.logger.warn({ err, attempt, delayMs, bucketPath }, 'GcpStorageService: retrying getMetadata');
+				},
+			},
+		).catch((cause: unknown) => {
+			throw wrapGcpError('EXT_STORAGE_FAILED', `Failed to read metadata for ${bucketPath}`, cause);
 		});
 	}
 

--- a/packages/core/src/shared/services.ts
+++ b/packages/core/src/shared/services.ts
@@ -26,6 +26,24 @@ export interface StorageListResult {
 	paths: string[];
 }
 
+export interface StorageUploadSession {
+	url: string;
+	method: 'PUT';
+	headers: Record<string, string>;
+	transport: 'gcs_resumable' | 'dev_proxy';
+	expiresAt: string | null;
+}
+
+export interface CreateStorageUploadSessionOptions {
+	contentType: string;
+	expectedSizeBytes: number;
+}
+
+export interface StorageObjectMetadata {
+	sizeBytes: number;
+	contentType: string | null;
+}
+
 /**
  * Abstraction over Cloud Storage.
  * Upload, download, check existence, list, and delete objects from a bucket.
@@ -34,8 +52,14 @@ export interface StorageService {
 	/** Upload content (Buffer or string) to a bucket path. */
 	upload(bucketPath: string, content: Buffer | string, contentType?: string): Promise<void>;
 
+	/** Create a browser-facing direct upload session for a bucket path. */
+	createUploadSession(bucketPath: string, options: CreateStorageUploadSessionOptions): Promise<StorageUploadSession>;
+
 	/** Download content from a bucket path as a Buffer. */
 	download(bucketPath: string): Promise<Buffer>;
+
+	/** Read lightweight object metadata without downloading the full object. */
+	getMetadata(bucketPath: string): Promise<StorageObjectMetadata | null>;
 
 	/** Check whether an object exists at the given bucket path. */
 	exists(bucketPath: string): Promise<boolean>;

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -8,8 +8,21 @@
  * @see docs/functional-spec.md §10.2, §10.4
  */
 
+import { createHash } from 'node:crypto';
 import type { MulderConfig, Services } from '@mulder/core';
-import { createChildLogger } from '@mulder/core';
+import {
+	createChildLogger,
+	createPipelineRun,
+	createSource,
+	detectNativeText,
+	enqueueJob,
+	extractPdfMetadata,
+	findSourceByHash,
+	findSourceById,
+	INGEST_ERROR_CODES,
+	IngestError,
+	upsertSourceStep,
+} from '@mulder/core';
 import {
 	executeEmbed,
 	executeEnrich,
@@ -188,6 +201,50 @@ function parsePipelineRunPayload(job: WorkerJobEnvelope): {
 	return payload;
 }
 
+function parseDocumentUploadFinalizePayload(job: WorkerJobEnvelope): {
+	sourceId: string;
+	filename: string;
+	storagePath: string;
+	tags?: string[];
+	startPipeline?: boolean;
+} {
+	if (!isRecord(job.payload)) {
+		throw invalidPayload(job, `Job ${job.id} payload must be an object`, { field: 'payload' });
+	}
+
+	const sourceId = readStringField(job, 'sourceId', 'source_id');
+	const filename = readStringField(job, 'filename');
+	const storagePath = readStringField(job, 'storagePath', 'storage_path');
+	if (!sourceId || !filename || !storagePath) {
+		throw invalidPayload(job, 'document_upload_finalize jobs require sourceId, filename, and storagePath', {
+			field: 'payload',
+		});
+	}
+
+	const payload: {
+		sourceId: string;
+		filename: string;
+		storagePath: string;
+		tags?: string[];
+		startPipeline?: boolean;
+	} = {
+		sourceId,
+		filename,
+		storagePath,
+	};
+
+	if (Array.isArray(job.payload.tags)) {
+		payload.tags = job.payload.tags.filter((tag): tag is string => typeof tag === 'string');
+	}
+
+	const startPipeline = asBoolean(job.payload.startPipeline);
+	if (startPipeline !== undefined) {
+		payload.startPipeline = startPipeline;
+	}
+
+	return payload;
+}
+
 function assertStepSucceeded(job: WorkerJobEnvelope, stepName: string, status: string): void {
 	if (status === 'success') {
 		return;
@@ -212,6 +269,197 @@ function assertPipelineRunCompleted(job: WorkerJobEnvelope, status: string): voi
 			context: { jobId: job.id, jobType: job.type, status },
 		},
 	);
+}
+
+const PDF_MAGIC_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d]);
+const BROWSER_UPLOAD_PIPELINE_TAG = 'browser-upload';
+
+function hasPdfMagicBytes(buffer: Buffer): boolean {
+	return buffer.length >= PDF_MAGIC_BYTES.length && buffer.subarray(0, PDF_MAGIC_BYTES.length).equals(PDF_MAGIC_BYTES);
+}
+
+function buildPdfMetadataJson(pdfMeta: Awaited<ReturnType<typeof extractPdfMetadata>>): Record<string, unknown> {
+	const pdfMetadataJson: Record<string, unknown> = {};
+	if (pdfMeta.pdfVersion) pdfMetadataJson.pdf_version = pdfMeta.pdfVersion;
+	if (pdfMeta.title) pdfMetadataJson.title = pdfMeta.title;
+	if (pdfMeta.author) pdfMetadataJson.author = pdfMeta.author;
+	if (pdfMeta.creator) pdfMetadataJson.creator = pdfMeta.creator;
+	if (pdfMeta.producer) pdfMetadataJson.producer = pdfMeta.producer;
+	if (pdfMeta.creationDate) pdfMetadataJson.creation_date = pdfMeta.creationDate.toISOString();
+	if (pdfMeta.modificationDate) pdfMetadataJson.modification_date = pdfMeta.modificationDate.toISOString();
+	if (pdfMeta.encrypted !== undefined) pdfMetadataJson.encrypted = pdfMeta.encrypted;
+	return pdfMetadataJson;
+}
+
+async function finalizeUploadedDocument(
+	context: {
+		config: MulderConfig;
+		services: Services;
+		pool: import('pg').Pool;
+		log: ReturnType<typeof createChildLogger>;
+	},
+	payload: ReturnType<typeof parseDocumentUploadFinalizePayload>,
+): Promise<Record<string, unknown>> {
+	const { config, services, pool, log } = context;
+
+	const existingSource = await findSourceById(pool, payload.sourceId);
+	if (existingSource) {
+		return {
+			result_status: 'created',
+			resolved_source_id: existingSource.id,
+		};
+	}
+
+	const metadata = await services.storage.getMetadata(payload.storagePath);
+	if (!metadata) {
+		throw new IngestError(
+			`Uploaded object not found: ${payload.storagePath}`,
+			INGEST_ERROR_CODES.INGEST_FILE_NOT_FOUND,
+			{
+				context: { storagePath: payload.storagePath, sourceId: payload.sourceId },
+			},
+		);
+	}
+
+	const maxSizeBytes = config.ingestion.max_file_size_mb * 1024 * 1024;
+	if (metadata.sizeBytes > maxSizeBytes) {
+		throw new IngestError(
+			`Uploaded file exceeds configured ingest limit: ${payload.filename}`,
+			INGEST_ERROR_CODES.INGEST_FILE_TOO_LARGE,
+			{
+				context: {
+					storagePath: payload.storagePath,
+					sourceId: payload.sourceId,
+					fileSizeBytes: metadata.sizeBytes,
+					maxBytes: maxSizeBytes,
+				},
+			},
+		);
+	}
+
+	const buffer = await services.storage.download(payload.storagePath);
+	if (!hasPdfMagicBytes(buffer)) {
+		throw new IngestError(`Not a valid PDF file: ${payload.filename}`, INGEST_ERROR_CODES.INGEST_NOT_PDF, {
+			context: { storagePath: payload.storagePath, sourceId: payload.sourceId },
+		});
+	}
+
+	const fileHash = createHash('sha256').update(buffer).digest('hex');
+	const duplicateSource = await findSourceByHash(pool, fileHash);
+	if (duplicateSource && duplicateSource.id !== payload.sourceId) {
+		await services.storage.delete(payload.storagePath);
+		return {
+			result_status: 'duplicate',
+			resolved_source_id: duplicateSource.id,
+			duplicate_of_source_id: duplicateSource.id,
+		};
+	}
+
+	const pdfMeta = await extractPdfMetadata(buffer);
+	if (pdfMeta.pageCount > config.ingestion.max_pages) {
+		throw new IngestError(
+			`Uploaded file exceeds configured page limit: ${payload.filename}`,
+			INGEST_ERROR_CODES.INGEST_TOO_MANY_PAGES,
+			{
+				context: {
+					storagePath: payload.storagePath,
+					sourceId: payload.sourceId,
+					pageCount: pdfMeta.pageCount,
+					maxPages: config.ingestion.max_pages,
+				},
+			},
+		);
+	}
+
+	const textResult = await detectNativeText(buffer);
+
+	const client = await pool.connect();
+	try {
+		await client.query('BEGIN');
+
+		const source = await createSource(client, {
+			id: payload.sourceId,
+			filename: payload.filename,
+			storagePath: payload.storagePath,
+			fileHash,
+			pageCount: textResult.pageCount,
+			hasNativeText: textResult.hasNativeText,
+			nativeTextRatio: textResult.nativeTextRatio,
+			tags: payload.tags,
+			metadata: buildPdfMetadataJson(pdfMeta),
+		});
+
+		if (source.id !== payload.sourceId) {
+			await client.query('ROLLBACK');
+			await services.storage.delete(payload.storagePath);
+			return {
+				result_status: 'duplicate',
+				resolved_source_id: source.id,
+				duplicate_of_source_id: source.id,
+			};
+		}
+
+		await upsertSourceStep(client, {
+			sourceId: source.id,
+			stepName: 'ingest',
+			status: 'completed',
+		});
+
+		const completionPayload: Record<string, unknown> = {
+			result_status: 'created',
+			resolved_source_id: source.id,
+		};
+
+		if (payload.startPipeline ?? true) {
+			const run = await createPipelineRun(client, {
+				tag: BROWSER_UPLOAD_PIPELINE_TAG,
+				options: {
+					source_id: source.id,
+					from: 'extract',
+					up_to: null,
+					force: false,
+				},
+			});
+			const pipelineJob = await enqueueJob(client, {
+				type: 'pipeline_run',
+				payload: {
+					sourceId: source.id,
+					runId: run.id,
+					from: 'extract',
+					force: false,
+					tag: BROWSER_UPLOAD_PIPELINE_TAG,
+				},
+				maxAttempts: 3,
+			});
+			completionPayload.pipeline_job_id = pipelineJob.id;
+			completionPayload.pipeline_run_id = run.id;
+		}
+
+		await client.query('COMMIT');
+
+		services.firestore
+			.setDocument('documents', source.id, {
+				filename: payload.filename,
+				uploadedAt: new Date().toISOString(),
+				fileHash,
+				status: 'ingested',
+			})
+			.catch(() => {
+				// Observability projection remains best-effort.
+			});
+
+		log.info({ sourceId: source.id, storagePath: payload.storagePath }, 'Browser upload finalized');
+		return completionPayload;
+	} catch (error) {
+		try {
+			await client.query('ROLLBACK');
+		} catch {
+			// Ignore rollback failures and surface the original error.
+		}
+		throw error;
+	} finally {
+		client.release();
+	}
 }
 
 export const dispatchJob: WorkerDispatchFn = async (job, context) => {
@@ -250,6 +498,10 @@ export const dispatchJob: WorkerDispatchFn = async (job, context) => {
 			const result = await executeGraph(payload, config, services, pool, log);
 			assertStepSucceeded(job, 'graph', result.status);
 			return;
+		}
+		case 'document_upload_finalize': {
+			const payload = parseDocumentUploadFinalizePayload(job);
+			return await finalizeUploadedDocument({ config, services, pool, log }, payload);
 		}
 		case 'pipeline_run': {
 			const payload = parsePipelineRunPayload(job);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -11,6 +11,7 @@ export {
 	startWorker,
 } from './runtime.js';
 export type {
+	DocumentUploadFinalizeJobPayload,
 	LegacyPipelineRunJobPayload,
 	PipelineRunJobPayload,
 	SourceStepJobPayload,
@@ -18,6 +19,7 @@ export type {
 	StoryStepJobPayload,
 	StoryStepJobType,
 	SupportedJobType,
+	UploadFinalizeJobType,
 	WorkerActiveJobSnapshot,
 	WorkerDispatchContext,
 	WorkerDispatchFn,

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -24,6 +24,7 @@ import type pg from 'pg';
 import { dispatchJob } from './dispatch.js';
 import {
 	createWorkerId,
+	type DocumentUploadFinalizeJobPayload,
 	describeWorkerError,
 	type PipelineRunJobPayload,
 	type WorkerActiveJobSnapshot,
@@ -99,6 +100,7 @@ function isWorkerJobEnvelopeType(type: string): type is WorkerJobEnvelope['type'
 		type === 'enrich' ||
 		type === 'embed' ||
 		type === 'graph' ||
+		type === 'document_upload_finalize' ||
 		type === 'pipeline_run'
 	);
 }
@@ -185,6 +187,32 @@ function toWorkerJobPayload(job: Job): WorkerJobEnvelope['payload'] {
 		const tag = readOptionalString(job.payload, 'tag');
 		if (tag) {
 			payload.tag = tag;
+		}
+
+		return payload;
+	}
+
+	if (job.type === 'document_upload_finalize') {
+		const sourceId = readOptionalString(job.payload, 'sourceId', 'source_id');
+		const filename = readOptionalString(job.payload, 'filename');
+		const storagePath = readOptionalString(job.payload, 'storagePath', 'storage_path');
+		if (!sourceId || !filename || !storagePath) {
+			throw new Error(`Job ${job.id} is missing document upload finalize fields`);
+		}
+
+		const tags = Array.isArray(job.payload.tags)
+			? job.payload.tags.filter((tag): tag is string => typeof tag === 'string')
+			: undefined;
+
+		const payload: DocumentUploadFinalizeJobPayload = {
+			sourceId,
+			filename,
+			storagePath,
+			startPipeline: readOptionalBoolean(job.payload, 'startPipeline'),
+		};
+
+		if (tags && tags.length > 0) {
+			payload.tags = tags;
 		}
 
 		return payload;
@@ -289,13 +317,19 @@ export async function processNextJob(context: WorkerRuntimeContext, workerId: st
 	let typedJob: WorkerJobEnvelope | null = null;
 	try {
 		typedJob = toWorkerJobEnvelope(job);
-		await dispatch(typedJob, getWorkerDispatchContext(context, workerId));
-		await markJobCompleted(context.pool, claim);
+		const completionPayload = await dispatch(typedJob, getWorkerDispatchContext(context, workerId));
+		await markJobCompleted(context.pool, claim, isRecord(completionPayload) ? completionPayload : undefined);
 		jobLog.info('Job completed');
 		return { state: 'completed', job: typedJob, error: null };
 	} catch (error: unknown) {
 		const errorLog = describeWorkerError(error);
-		const updated = await markJobFailed(context.pool, claim, errorLog);
+		let updated: Awaited<ReturnType<typeof markJobFailed>> | null = null;
+		try {
+			updated = await markJobFailed(context.pool, claim, errorLog);
+		} catch (markError) {
+			jobLog.error({ err: markError, originalErr: error }, 'Job failure could not be persisted');
+			throw error;
+		}
 		jobLog.warn({ status: updated.status, err: error }, 'Job failed');
 		return {
 			state: updated.status === 'dead_letter' ? 'dead_letter' : 'failed',

--- a/packages/worker/src/worker.types.ts
+++ b/packages/worker/src/worker.types.ts
@@ -21,8 +21,9 @@ import type pg from 'pg';
 
 export type SourceStepJobType = 'extract' | 'segment';
 export type StoryStepJobType = 'enrich' | 'embed' | 'graph';
+export type UploadFinalizeJobType = 'document_upload_finalize';
 export type LegacyWorkerJobType = 'pipeline_run';
-export type SupportedJobType = SourceStepJobType | StoryStepJobType;
+export type SupportedJobType = SourceStepJobType | StoryStepJobType | UploadFinalizeJobType;
 export type WorkerJobType = SupportedJobType | LegacyWorkerJobType;
 
 export interface SourceStepJobPayload {
@@ -46,6 +47,14 @@ export interface PipelineRunJobPayload {
 	fallbackOnly?: boolean;
 }
 
+export interface DocumentUploadFinalizeJobPayload {
+	sourceId: string;
+	filename: string;
+	storagePath: string;
+	tags?: string[];
+	startPipeline?: boolean;
+}
+
 export type LegacyPipelineRunJobPayload = PipelineRunJobPayload;
 
 export type WorkerJobPayloadMap = {
@@ -54,6 +63,7 @@ export type WorkerJobPayloadMap = {
 	enrich: StoryStepJobPayload;
 	embed: StoryStepJobPayload;
 	graph: StoryStepJobPayload;
+	document_upload_finalize: DocumentUploadFinalizeJobPayload;
 	pipeline_run: LegacyPipelineRunJobPayload;
 };
 
@@ -136,7 +146,10 @@ export interface WorkerDispatchContext {
 	logger: Logger;
 }
 
-export type WorkerDispatchFn = (job: WorkerJobEnvelope, context: WorkerDispatchContext) => Promise<void>;
+export type WorkerDispatchFn = (
+	job: WorkerJobEnvelope,
+	context: WorkerDispatchContext,
+) => Promise<Record<string, unknown> | undefined>;
 
 export const WORKER_ERROR_CODES = {
 	WORKER_UNKNOWN_JOB_TYPE: 'WORKER_UNKNOWN_JOB_TYPE',
@@ -178,7 +191,14 @@ export function describeWorkerError(error: unknown): string {
 }
 
 export function isSupportedJobType(type: string): type is SupportedJobType {
-	return type === 'extract' || type === 'segment' || type === 'enrich' || type === 'embed' || type === 'graph';
+	return (
+		type === 'extract' ||
+		type === 'segment' ||
+		type === 'enrich' ||
+		type === 'embed' ||
+		type === 'graph' ||
+		type === 'document_upload_finalize'
+	);
 }
 
 export function createWorkerId(slot = 0): string {

--- a/tests/specs/48_layout_to_markdown.test.ts
+++ b/tests/specs/48_layout_to_markdown.test.ts
@@ -471,7 +471,9 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 				}
 				return realUpload(path, content, contentType);
 			},
+			createUploadSession: realServices.storage.createUploadSession.bind(realServices.storage),
 			download: realServices.storage.download.bind(realServices.storage),
+			getMetadata: realServices.storage.getMetadata.bind(realServices.storage),
 			exists: realServices.storage.exists.bind(realServices.storage),
 			list: realServices.storage.list.bind(realServices.storage),
 			delete: realServices.storage.delete.bind(realServices.storage),

--- a/tests/specs/71_pipeline_api_routes.test.ts
+++ b/tests/specs/71_pipeline_api_routes.test.ts
@@ -103,6 +103,7 @@ function insertSourceRow(sourceId: string): void {
 }
 
 function insertFailedPipelineStep(sourceId: string, step: string, tag = 'retry-seed'): void {
+	insertSourceRow(sourceId);
 	const runId = randomUUID();
 	db.runSql(
 		[

--- a/tests/specs/73_search_api_routes.test.ts
+++ b/tests/specs/73_search_api_routes.test.ts
@@ -78,7 +78,15 @@ function buildMockServices(): Services {
 	return {
 		storage: {
 			upload: async () => {},
+			createUploadSession: async () => ({
+				url: '/api/uploads/documents/dev-upload?storage_path=raw/test/original.pdf',
+				method: 'PUT',
+				headers: {},
+				transport: 'dev_proxy',
+				expiresAt: null,
+			}),
 			download: async () => Buffer.alloc(0),
+			getMetadata: async () => null,
 			exists: async () => false,
 			list: async () => ({ paths: [] }),
 			delete: async () => {},

--- a/tests/specs/76_document_retrieval_routes.test.ts
+++ b/tests/specs/76_document_retrieval_routes.test.ts
@@ -87,12 +87,28 @@ function buildMockServices(state: StorageState) {
 			upload: async (path: string, content: Buffer | string) => {
 				putStorageObject(state, path, content);
 			},
+			createUploadSession: async (path: string) => ({
+				url: `/api/uploads/documents/dev-upload?storage_path=${encodeURIComponent(path)}`,
+				method: 'PUT',
+				headers: {},
+				transport: 'dev_proxy',
+				expiresAt: null,
+			}),
 			download: async (path: string) => {
 				const value = state.objects.get(path);
 				if (!value) {
 					throw new Error(`Storage object not found: ${path}`);
 				}
 				return value;
+			},
+			getMetadata: async (path: string) => {
+				const value = state.objects.get(path);
+				return value
+					? {
+							sizeBytes: value.byteLength,
+							contentType: path.endsWith('.pdf') ? 'application/pdf' : 'application/octet-stream',
+						}
+					: null;
 			},
 			exists: async (path: string) => state.objects.has(path),
 			list: async (prefix: string) => ({

--- a/tests/specs/77_large_pdf_browser_upload_flow.test.ts
+++ b/tests/specs/77_large_pdf_browser_upload_flow.test.ts
@@ -1,0 +1,514 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { WorkerRuntimeContext } from '@mulder/worker';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const WORKER_DIST = resolve(WORKER_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const FIXTURE_PDF = resolve(ROOT, 'fixtures/raw/native-text-sample.pdf');
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 180_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function cleanRawStorage(): void {
+	if (!existsSync(RAW_STORAGE_DIR)) {
+		return;
+	}
+
+	for (const entry of readdirSync(RAW_STORAGE_DIR)) {
+		rmSync(join(RAW_STORAGE_DIR, entry), { recursive: true, force: true });
+	}
+}
+
+function writeUploadedObject(sourceId: string, content: Buffer): string {
+	const dir = join(RAW_STORAGE_DIR, sourceId);
+	mkdirSync(dir, { recursive: true });
+	const storagePath = join(dir, 'original.pdf');
+	writeFileSync(storagePath, content);
+	return storagePath;
+}
+
+async function loadApiApp(): Promise<{ request: (input: string | Request, init?: RequestInit) => Promise<Response> }> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+type ApiApp = Awaited<ReturnType<typeof loadApiApp>>;
+
+async function apiPost(app: ApiApp, path: string, body: unknown): Promise<Response> {
+	return await app.request(`http://localhost${path}`, {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer test-api-key',
+			'Content-Type': 'application/json',
+			'X-Forwarded-For': '203.0.113.10',
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+async function apiPut(
+	app: ApiApp,
+	path: string,
+	body: BodyInit,
+	contentType = 'application/octet-stream',
+): Promise<Response> {
+	return await app.request(`http://localhost${path}`, {
+		method: 'PUT',
+		headers: {
+			Authorization: 'Bearer test-api-key',
+			'Content-Type': contentType,
+			'X-Forwarded-For': '203.0.113.10',
+		},
+		body,
+	});
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+	return (await response.json()) as Record<string, unknown>;
+}
+
+function readJsonCell(sql: string): Record<string, unknown> {
+	return JSON.parse(db.runSql(sql)) as Record<string, unknown>;
+}
+
+async function processOneJob(context: WorkerRuntimeContext, workerModule: typeof import('@mulder/worker')) {
+	return await workerModule.processNextJob(context, 'spec-77-worker');
+}
+
+describe('Spec 77 — Large PDF Browser Upload Flow', () => {
+	let app: ApiApp;
+	let coreModule: typeof import('@mulder/core');
+	let workerModule: typeof import('@mulder/worker');
+	let workerContext: WorkerRuntimeContext;
+	let fixturePdf: Buffer;
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+		process.env.NODE_ENV = 'test';
+
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+		buildPackage(CLI_DIR);
+
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode).toBe(0);
+
+		coreModule = await import(pathToFileURL(CORE_DIST).href);
+		workerModule = await import(pathToFileURL(WORKER_DIST).href);
+		app = await loadApiApp();
+		fixturePdf = readFileSync(FIXTURE_PDF);
+
+		const config = coreModule.loadConfig(EXAMPLE_CONFIG);
+		const logger = coreModule.createLogger({ level: 'silent' });
+		workerContext = {
+			config,
+			services: coreModule.createServiceRegistry(config, logger),
+			pool: coreModule.getWorkerPool(config.gcp.cloud_sql),
+			logger,
+		};
+	}, 600000);
+
+	beforeEach(() => {
+		cleanState();
+		cleanRawStorage();
+	});
+
+	afterAll(() => {
+		try {
+			cleanState();
+			cleanRawStorage();
+		} catch {
+			// Ignore cleanup failures.
+		}
+	});
+
+	it('QA-01: initiate accepts large declared uploads without tripping the API body limit', async () => {
+		const beforeJobs = Number(db.runSql('SELECT COUNT(*) FROM jobs;'));
+		const response = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'large-research-file.pdf',
+			size_bytes: 12 * 1024 * 1024,
+			content_type: 'application/pdf',
+		});
+
+		expect(response.status).toBe(201);
+		const body = await readJson(response);
+		expect(body).toMatchObject({
+			data: {
+				source_id: expect.any(String),
+				storage_path: expect.stringMatching(/^raw\/[0-9a-f-]+\/original\.pdf$/i),
+				upload: {
+					method: 'PUT',
+					transport: expect.stringMatching(/^(gcs_resumable|dev_proxy)$/),
+				},
+				limits: {
+					max_bytes: 100 * 1024 * 1024,
+				},
+			},
+		});
+		expect(Number(db.runSql('SELECT COUNT(*) FROM jobs;'))).toBe(beforeJobs);
+	});
+
+	it('QA-01b: dev upload proxy accepts payloads above the normal API body limit', async () => {
+		const storagePath = 'raw/dev-large-upload/original.pdf';
+		const oversizedBody = Buffer.alloc(MAX_BODY_BYTES + 1, 0x20);
+		const response = await apiPut(
+			app,
+			`/api/uploads/documents/dev-upload?storage_path=${encodeURIComponent(storagePath)}`,
+			oversizedBody,
+			'application/pdf',
+		);
+
+		expect(response.status).toBe(204);
+		expect(existsSync(resolve(STORAGE_DIR, storagePath))).toBe(true);
+		expect(readFileSync(resolve(STORAGE_DIR, storagePath)).byteLength).toBe(MAX_BODY_BYTES + 1);
+	});
+
+	it('QA-02: initiate rejects declared uploads above the configured ingest limit', async () => {
+		const beforeJobs = Number(db.runSql('SELECT COUNT(*) FROM jobs;'));
+		const response = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'too-large.pdf',
+			size_bytes: 101 * 1024 * 1024,
+			content_type: 'application/pdf',
+		});
+
+		expect(response.status).toBe(413);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'INGEST_FILE_TOO_LARGE',
+				message: 'Declared upload exceeds the configured ingest limit',
+				details: {
+					filename: 'too-large.pdf',
+					size_bytes: 101 * 1024 * 1024,
+					max_bytes: 100 * 1024 * 1024,
+				},
+			},
+		});
+		expect(Number(db.runSql('SELECT COUNT(*) FROM jobs;'))).toBe(beforeJobs);
+	});
+
+	it('QA-03: complete + finalize creates a source and queues the pipeline job', async () => {
+		const initiate = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'native-text-sample.pdf',
+			size_bytes: fixturePdf.byteLength,
+			content_type: 'application/pdf',
+			tags: ['review'],
+		});
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const storagePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+
+		writeUploadedObject(sourceId, fixturePdf);
+
+		const complete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: storagePath,
+			tags: ['review'],
+			start_pipeline: true,
+		});
+
+		expect(complete.status).toBe(202);
+		const completeBody = await readJson(complete);
+		const jobId = String((completeBody.data as Record<string, unknown>).job_id);
+
+		const processed = await processOneJob(workerContext, workerModule);
+		expect(processed.state).toBe('completed');
+
+		const sourceRow = readJsonCell(
+			`SELECT row_to_json(source_row)::text FROM (
+				SELECT id, filename, storage_path, status, tags
+				FROM sources
+				WHERE id = '${sourceId}'
+			) AS source_row;`,
+		);
+		expect(sourceRow).toEqual({
+			id: sourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: storagePath,
+			status: 'ingested',
+			tags: ['review'],
+		});
+		expect(db.runSql(`SELECT status FROM source_steps WHERE source_id = '${sourceId}' AND step_name = 'ingest';`)).toBe(
+			'completed',
+		);
+		expect(Number(db.runSql("SELECT COUNT(*) FROM jobs WHERE type = 'pipeline_run' AND status = 'pending';"))).toBe(1);
+
+		const finalizePayload = readJsonCell(`SELECT payload::text FROM jobs WHERE id = '${jobId}';`);
+		expect(finalizePayload).toMatchObject({
+			sourceId,
+			filename: 'native-text-sample.pdf',
+			storagePath,
+			result_status: 'created',
+			resolved_source_id: sourceId,
+			pipeline_job_id: expect.any(String),
+			pipeline_run_id: expect.any(String),
+		});
+	});
+
+	it('QA-04: duplicate finalize resolves to the existing source and removes the provisional object', async () => {
+		const firstInitiate = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'native-text-sample.pdf',
+			size_bytes: fixturePdf.byteLength,
+			content_type: 'application/pdf',
+		});
+		const firstBody = await readJson(firstInitiate);
+		const firstSourceId = String((firstBody.data as Record<string, unknown>).source_id);
+		const firstStoragePath = String((firstBody.data as Record<string, unknown>).storage_path);
+		writeUploadedObject(firstSourceId, fixturePdf);
+
+		const firstComplete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: firstSourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: firstStoragePath,
+			start_pipeline: false,
+		});
+		expect(firstComplete.status).toBe(202);
+		await processOneJob(workerContext, workerModule);
+
+		const secondInitiate = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'native-text-sample.pdf',
+			size_bytes: fixturePdf.byteLength,
+			content_type: 'application/pdf',
+		});
+		const secondBody = await readJson(secondInitiate);
+		const secondSourceId = String((secondBody.data as Record<string, unknown>).source_id);
+		const secondStoragePath = String((secondBody.data as Record<string, unknown>).storage_path);
+		writeUploadedObject(secondSourceId, fixturePdf);
+
+		const secondComplete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: secondSourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: secondStoragePath,
+			start_pipeline: false,
+		});
+		expect(secondComplete.status).toBe(202);
+		const secondCompleteBody = await readJson(secondComplete);
+		const secondJobId = String((secondCompleteBody.data as Record<string, unknown>).job_id);
+
+		const processed = await processOneJob(workerContext, workerModule);
+		expect(processed.state).toBe('completed');
+		expect(Number(db.runSql('SELECT COUNT(*) FROM sources;'))).toBe(1);
+		expect(existsSync(join(RAW_STORAGE_DIR, secondSourceId, 'original.pdf'))).toBe(false);
+
+		const finalizePayload = readJsonCell(`SELECT payload::text FROM jobs WHERE id = '${secondJobId}';`);
+		expect(finalizePayload).toMatchObject({
+			sourceId: secondSourceId,
+			result_status: 'duplicate',
+			resolved_source_id: firstSourceId,
+			duplicate_of_source_id: firstSourceId,
+		});
+	});
+
+	it('QA-05: complete fails clearly when the uploaded object is missing', async () => {
+		const initiate = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'missing.pdf',
+			size_bytes: fixturePdf.byteLength,
+			content_type: 'application/pdf',
+		});
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const storagePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+
+		const complete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'missing.pdf',
+			storage_path: storagePath,
+		});
+
+		expect(complete.status).toBe(404);
+		expect(await complete.json()).toEqual({
+			error: {
+				code: 'UPLOAD_OBJECT_NOT_FOUND',
+				message: `Uploaded object not found: ${storagePath}`,
+				details: {
+					source_id: sourceId,
+					storage_path: storagePath,
+				},
+			},
+		});
+	});
+
+	it('QA-06: non-upload routes still reject oversized request bodies', async () => {
+		const oversizedBody = new TextEncoder().encode('x'.repeat(MAX_BODY_BYTES + 1));
+		const request = new Request('http://localhost/api/search', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer test-api-key',
+				'Content-Type': 'text/plain',
+			},
+			body: new ReadableStream({
+				start(controller) {
+					controller.enqueue(oversizedBody);
+					controller.close();
+				},
+			}),
+			duplex: 'half',
+		});
+
+		const response = await app.request(request);
+		expect(response.status).toBe(413);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'REQUEST_BODY_TOO_LARGE',
+				message: 'Request body exceeds the API limit',
+				details: {
+					content_length: MAX_BODY_BYTES + 1,
+					max_bytes: MAX_BODY_BYTES,
+				},
+			},
+		});
+	});
+
+	it('QA-07: upload routes stay behind auth', async () => {
+		const response = await app.request('http://localhost/api/uploads/documents/initiate', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				filename: 'native-text-sample.pdf',
+				size_bytes: fixturePdf.byteLength,
+				content_type: 'application/pdf',
+			}),
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+	});
+
+	it('QA-08: repeated completion requests do not enqueue a second finalize job', async () => {
+		const initiate = await apiPost(app, '/api/uploads/documents/initiate', {
+			filename: 'native-text-sample.pdf',
+			size_bytes: fixturePdf.byteLength,
+			content_type: 'application/pdf',
+		});
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const storagePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+		writeUploadedObject(sourceId, fixturePdf);
+
+		const firstComplete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: storagePath,
+			start_pipeline: false,
+		});
+		expect(firstComplete.status).toBe(202);
+
+		const secondComplete = await apiPost(app, '/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'native-text-sample.pdf',
+			storage_path: storagePath,
+			start_pipeline: false,
+		});
+		expect(secondComplete.status).toBe(409);
+		expect(await secondComplete.json()).toEqual({
+			error: {
+				code: 'UPLOAD_FINALIZE_CONFLICT',
+				message: `Upload finalize job already in progress for ${sourceId}`,
+				details: {
+					source_id: sourceId,
+				},
+			},
+		});
+		expect(
+			Number(db.runSql("SELECT COUNT(*) FROM jobs WHERE type = 'document_upload_finalize' AND status = 'pending';")),
+		).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- add a direct-to-storage browser upload flow for large PDFs
- finalize uploads through a worker job with validation, dedupe, and optional pipeline enqueueing
- replace the demo upload page and add spec coverage for large uploads, duplicates, auth, and conflict handling

## Verification
- pnpm build
- npx biome check .
- npx vitest run tests/specs/77_large_pdf_browser_upload_flow.test.ts --reporter=verbose
- npx vitest run tests/specs/71_pipeline_api_routes.test.ts --reporter=verbose
- npx vitest run tests/specs/76_document_retrieval_routes.test.ts --reporter=verbose

Closes #197