### PR TITLE
[UI/API] Add document observability aggregation route for M7-H11

### DIFF
--- a/apps/api/src/lib/documents.ts
+++ b/apps/api/src/lib/documents.ts
@@ -7,15 +7,24 @@ import {
 	DATABASE_ERROR_CODES,
 	DatabaseError,
 	findAllSources,
+	findLatestPipelineRunSourceForSource,
+	findPipelineRunById,
 	findSourceById,
+	findSourceSteps,
+	findStoriesBySourceId,
 	getQueryPool,
+	type Job,
 	type Logger,
 	loadConfig,
 	type MulderConfig,
 	MulderError,
+	type PipelineRun,
+	type PipelineRunSource,
 	type Services,
 	type Source,
 	type SourceFilter,
+	type SourceStep,
+	type Story,
 } from '@mulder/core';
 import type pg from 'pg';
 import type {
@@ -23,9 +32,11 @@ import type {
 	DocumentListItem,
 	DocumentListQuery,
 	DocumentListResponse,
+	DocumentObservabilityResponse,
 	DocumentPageItem,
 	DocumentPagesResponse,
 } from '../routes/documents.schemas.js';
+import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
 
 interface DocumentContext {
 	config: MulderConfig;
@@ -183,6 +194,557 @@ function buildPageArtifact(sourceId: string, pageNumber: number): DocumentArtifa
 	};
 }
 
+function getProjectionField<T>(projection: Record<string, unknown>, ...keys: string[]): T | null {
+	for (const key of keys) {
+		const value = projection[key];
+		if (value !== undefined && value !== null) {
+			return value as T;
+		}
+	}
+
+	return null;
+}
+
+function readProjectionString(projection: Record<string, unknown>, ...keys: string[]): string | null {
+	const value = getProjectionField<unknown>(projection, ...keys);
+	return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readProjectionNumber(projection: Record<string, unknown>, ...keys: string[]): number | null {
+	const value = getProjectionField<unknown>(projection, ...keys);
+	return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readProjectionBoolean(projection: Record<string, unknown>, ...keys: string[]): boolean | null {
+	const value = getProjectionField<unknown>(projection, ...keys);
+	return typeof value === 'boolean' ? value : null;
+}
+
+function readProjectionDateString(projection: Record<string, unknown>, ...keys: string[]): string | null {
+	return readProjectionString(projection, ...keys);
+}
+
+function toIsoStringOrNull(value: Date | null | undefined): string | null {
+	return value ? value.toISOString() : null;
+}
+
+interface DocumentObservabilitySourceProjection {
+	status: string | null;
+	extracted_at: string | null;
+	segmented_at: string | null;
+	page_count: number | null;
+	story_count: number | null;
+	vision_fallback_count: number | null;
+	vision_fallback_capped: boolean | null;
+}
+
+interface DocumentObservabilityStoryProjection {
+	status: string | null;
+	enriched_at: string | null;
+	embedded_at: string | null;
+	graphed_at: string | null;
+	entities_extracted: number | null;
+	chunks_created: number | null;
+}
+
+interface DocumentObservabilityProgress {
+	run_id: string;
+	run_status: PipelineRun['status'];
+	current_step: string;
+	source_status: PipelineRunSource['status'];
+	updated_at: string;
+	error_message: string | null;
+}
+
+interface DocumentObservabilityStep {
+	step: string;
+	status: 'pending' | 'completed' | 'failed' | 'partial';
+	completed_at: string | null;
+	error_message: string | null;
+}
+
+interface DocumentObservabilityTimelineEvent {
+	scope: 'job' | 'source' | 'story';
+	event: string;
+	status: string;
+	occurred_at: string;
+	step: string | null;
+	story_id: string | null;
+	details: Record<string, unknown>;
+}
+
+interface DocumentObservabilityJob {
+	job_id: string;
+	status: Job['status'];
+	attempts: number;
+	max_attempts: number;
+	error_log: string | null;
+	created_at: string;
+	started_at: string | null;
+	finished_at: string | null;
+}
+
+const SOURCE_STEP_ORDER = new Map<string, number>(PIPELINE_STEP_VALUES.map((step, index) => [step, index]));
+
+function sortSourceSteps(steps: SourceStep[]): SourceStep[] {
+	return [...steps].sort((left, right) => {
+		const leftIndex = SOURCE_STEP_ORDER.get(left.stepName) ?? Number.POSITIVE_INFINITY;
+		const rightIndex = SOURCE_STEP_ORDER.get(right.stepName) ?? Number.POSITIVE_INFINITY;
+		if (leftIndex !== rightIndex) {
+			return leftIndex - rightIndex;
+		}
+
+		return left.stepName.localeCompare(right.stepName);
+	});
+}
+
+function mapSourceStep(step: SourceStep): DocumentObservabilityStep {
+	return {
+		step: step.stepName,
+		status: step.status,
+		completed_at: toIsoStringOrNull(step.completedAt),
+		error_message: step.errorMessage,
+	};
+}
+
+function buildSourceProjection(
+	projection: Record<string, unknown> | null,
+): DocumentObservabilitySourceProjection | null {
+	if (!projection) {
+		return null;
+	}
+
+	return {
+		status: readProjectionString(projection, 'status'),
+		extracted_at: readProjectionDateString(projection, 'extractedAt', 'extracted_at'),
+		segmented_at: readProjectionDateString(projection, 'segmentedAt', 'segmented_at'),
+		page_count: readProjectionNumber(projection, 'pageCount', 'page_count'),
+		story_count: readProjectionNumber(projection, 'storyCount', 'story_count'),
+		vision_fallback_count: readProjectionNumber(projection, 'visionFallbackCount', 'vision_fallback_count'),
+		vision_fallback_capped: readProjectionBoolean(projection, 'visionFallbackCapped', 'vision_fallback_capped'),
+	};
+}
+
+function buildStoryProjection(projection: Record<string, unknown> | null): DocumentObservabilityStoryProjection | null {
+	if (!projection) {
+		return null;
+	}
+
+	return {
+		status: readProjectionString(projection, 'status'),
+		enriched_at: readProjectionDateString(projection, 'enrichedAt', 'enriched_at'),
+		embedded_at: readProjectionDateString(projection, 'embeddedAt', 'embedded_at'),
+		graphed_at: readProjectionDateString(projection, 'graphedAt', 'graphed_at'),
+		entities_extracted: readProjectionNumber(projection, 'entitiesExtracted', 'entities_extracted'),
+		chunks_created: readProjectionNumber(projection, 'chunksCreated', 'chunks_created'),
+	};
+}
+
+function sortTimelineEvents(events: DocumentObservabilityTimelineEvent[]): DocumentObservabilityTimelineEvent[] {
+	return [...events].sort((left, right) => {
+		const timestampComparison = left.occurred_at.localeCompare(right.occurred_at);
+		if (timestampComparison !== 0) {
+			return timestampComparison;
+		}
+
+		const scopeComparison = left.scope.localeCompare(right.scope);
+		if (scopeComparison !== 0) {
+			return scopeComparison;
+		}
+
+		return left.event.localeCompare(right.event);
+	});
+}
+
+function makeTimelineEvent(
+	input: Omit<DocumentObservabilityTimelineEvent, 'details'> & { details?: Record<string, unknown> },
+): DocumentObservabilityTimelineEvent {
+	return {
+		...input,
+		details: input.details ?? {},
+	};
+}
+
+function buildSourceTimelineEvents(
+	sourceId: string,
+	job: DocumentObservabilityJob | null,
+	progress: DocumentObservabilityProgress | null,
+	sourceProjection: DocumentObservabilitySourceProjection | null,
+	steps: SourceStep[],
+): DocumentObservabilityTimelineEvent[] {
+	const events: DocumentObservabilityTimelineEvent[] = [];
+	const currentStep = progress?.current_step ?? null;
+	const progressUpdatedAt = progress?.updated_at ?? null;
+
+	if (job) {
+		events.push(
+			makeTimelineEvent({
+				scope: 'job',
+				event: 'job.created',
+				status: job.status,
+				occurred_at: job.created_at,
+				step: null,
+				story_id: null,
+				details: {
+					job_id: job.job_id,
+					attempts: job.attempts,
+					max_attempts: job.max_attempts,
+				},
+			}),
+		);
+
+		if (job.started_at) {
+			events.push(
+				makeTimelineEvent({
+					scope: 'job',
+					event: 'job.started',
+					status: job.status,
+					occurred_at: job.started_at,
+					step: currentStep,
+					story_id: null,
+					details: {
+						job_id: job.job_id,
+					},
+				}),
+			);
+		}
+
+		if (job.finished_at) {
+			events.push(
+				makeTimelineEvent({
+					scope: 'job',
+					event: 'job.finished',
+					status: job.status,
+					occurred_at: job.finished_at,
+					step: currentStep,
+					story_id: null,
+					details: {
+						job_id: job.job_id,
+						error_log: job.error_log,
+					},
+				}),
+			);
+		}
+	}
+
+	if (progress && progressUpdatedAt) {
+		events.push(
+			makeTimelineEvent({
+				scope: 'job',
+				event: 'run.progress',
+				status: progress.source_status,
+				occurred_at: progressUpdatedAt,
+				step: progress.current_step,
+				story_id: null,
+				details: {
+					run_id: progress.run_id,
+					source_id: sourceId,
+					run_status: progress.run_status,
+					error_message: progress.error_message,
+				},
+			}),
+		);
+	}
+
+	for (const step of steps) {
+		if (step.status === 'completed' && step.completedAt) {
+			events.push(
+				makeTimelineEvent({
+					scope: 'source',
+					event: 'source_step.completed',
+					status: step.status,
+					occurred_at: step.completedAt.toISOString(),
+					step: step.stepName,
+					story_id: null,
+					details: {
+						source_id: sourceId,
+						origin: 'postgresql',
+					},
+				}),
+			);
+			continue;
+		}
+
+		if (step.status === 'failed') {
+			const occurredAt = step.completedAt?.toISOString() ?? progressUpdatedAt;
+			if (!occurredAt) {
+				continue;
+			}
+
+			events.push(
+				makeTimelineEvent({
+					scope: 'source',
+					event: 'source_step.failed',
+					status: step.status,
+					occurred_at: occurredAt,
+					step: step.stepName,
+					story_id: null,
+					details: {
+						source_id: sourceId,
+						origin: 'postgresql',
+						error_message: step.errorMessage,
+					},
+				}),
+			);
+		}
+	}
+
+	if (sourceProjection) {
+		if (sourceProjection.extracted_at) {
+			events.push(
+				makeTimelineEvent({
+					scope: 'source',
+					event: 'source.projection.extracted',
+					status: sourceProjection.status ?? 'unknown',
+					occurred_at: sourceProjection.extracted_at,
+					step: 'extract',
+					story_id: null,
+					details: {
+						source_id: sourceId,
+						projection: 'documents',
+						field: 'extractedAt',
+					},
+				}),
+			);
+		}
+
+		if (sourceProjection.segmented_at) {
+			events.push(
+				makeTimelineEvent({
+					scope: 'source',
+					event: 'source.projection.segmented',
+					status: sourceProjection.status ?? 'unknown',
+					occurred_at: sourceProjection.segmented_at,
+					step: 'segment',
+					story_id: null,
+					details: {
+						source_id: sourceId,
+						projection: 'documents',
+						field: 'segmentedAt',
+					},
+				}),
+			);
+		}
+	}
+
+	return events;
+}
+
+function buildStoryTimelineEvents(
+	story: Story,
+	projection: DocumentObservabilityStoryProjection | null,
+): DocumentObservabilityTimelineEvent[] {
+	if (!projection) {
+		return [];
+	}
+
+	const events: DocumentObservabilityTimelineEvent[] = [];
+
+	if (projection.enriched_at) {
+		events.push(
+			makeTimelineEvent({
+				scope: 'story',
+				event: 'story.projection.enriched',
+				status: projection.status ?? story.status,
+				occurred_at: projection.enriched_at,
+				step: 'enrich',
+				story_id: story.id,
+				details: {
+					projection: 'stories',
+					field: 'enrichedAt',
+				},
+			}),
+		);
+	}
+
+	if (projection.embedded_at) {
+		events.push(
+			makeTimelineEvent({
+				scope: 'story',
+				event: 'story.projection.embedded',
+				status: projection.status ?? story.status,
+				occurred_at: projection.embedded_at,
+				step: 'embed',
+				story_id: story.id,
+				details: {
+					projection: 'stories',
+					field: 'embeddedAt',
+				},
+			}),
+		);
+	}
+
+	if (projection.graphed_at) {
+		events.push(
+			makeTimelineEvent({
+				scope: 'story',
+				event: 'story.projection.graphed',
+				status: projection.status ?? story.status,
+				occurred_at: projection.graphed_at,
+				step: 'graph',
+				story_id: story.id,
+				details: {
+					projection: 'stories',
+					field: 'graphedAt',
+				},
+			}),
+		);
+	}
+
+	return events;
+}
+
+async function loadLatestJobForSource(pool: pg.Pool, sourceId: string): Promise<DocumentObservabilityJob | null> {
+	const result = await pool.query<{
+		id: string;
+		status: Job['status'];
+		attempts: number;
+		max_attempts: number;
+		error_log: string | null;
+		created_at: Date;
+		started_at: Date | null;
+		finished_at: Date | null;
+	}>(
+		`
+			SELECT id, status, attempts, max_attempts, error_log, created_at, started_at, finished_at
+			FROM jobs
+			WHERE COALESCE(payload->>'sourceId', payload->>'source_id') = $1
+			ORDER BY created_at DESC, id DESC
+			LIMIT 1
+		`,
+		[sourceId],
+	);
+
+	const row = result.rows[0];
+	if (!row) {
+		return null;
+	}
+
+	return {
+		job_id: row.id,
+		status: row.status,
+		attempts: row.attempts,
+		max_attempts: row.max_attempts,
+		error_log: row.error_log,
+		created_at: row.created_at.toISOString(),
+		started_at: toIsoStringOrNull(row.started_at),
+		finished_at: toIsoStringOrNull(row.finished_at),
+	};
+}
+
+async function resolveObservabilityState(
+	pool: pg.Pool,
+	sourceId: string,
+): Promise<{
+	job: DocumentObservabilityJob | null;
+	progress: DocumentObservabilityProgress | null;
+}> {
+	const [latestJob, latestRunSource] = await Promise.all([
+		loadLatestJobForSource(pool, sourceId),
+		findLatestPipelineRunSourceForSource(pool, sourceId),
+	]);
+
+	if (!latestRunSource) {
+		return {
+			job: latestJob,
+			progress: null,
+		};
+	}
+
+	const run = await findPipelineRunById(pool, latestRunSource.runId);
+	if (!run) {
+		return {
+			job: latestJob,
+			progress: null,
+		};
+	}
+
+	return {
+		job: latestJob,
+		progress: {
+			run_id: latestRunSource.runId,
+			run_status: run.status,
+			current_step: latestRunSource.currentStep,
+			source_status: latestRunSource.status,
+			updated_at: latestRunSource.updatedAt.toISOString(),
+			error_message: latestRunSource.errorMessage,
+		},
+	};
+}
+
+async function buildDocumentObservabilityResponse(id: string, logger: Logger): Promise<DocumentObservabilityResponse> {
+	const requestLogger = createRouteLogger(logger, {
+		action: 'observability',
+		source_id: id,
+	});
+	const { config, pool } = resolveContext();
+	const services = createServiceRegistry(config, requestLogger);
+	const startedAt = performance.now();
+	const source = await requireSource(pool, id);
+
+	const [sourceProjectionRecord, sourceSteps, stories, observabilityState] = await Promise.all([
+		services.firestore.getDocument('documents', id),
+		findSourceSteps(pool, id),
+		findStoriesBySourceId(pool, id),
+		resolveObservabilityState(pool, id),
+	]);
+
+	const orderedSteps = sortSourceSteps(sourceSteps);
+	const sourceProjection = buildSourceProjection(sourceProjectionRecord);
+	const storyProjections = await Promise.all(
+		stories.map(async (story) => {
+			const projectionRecord = await services.firestore.getDocument('stories', story.id);
+			return {
+				story,
+				projection: buildStoryProjection(projectionRecord),
+			};
+		}),
+	);
+
+	const job = observabilityState.job;
+	const progress = observabilityState.progress;
+
+	const timeline = sortTimelineEvents([
+		...buildSourceTimelineEvents(source.id, job, progress, sourceProjection, orderedSteps),
+		...storyProjections.flatMap(({ story, projection }) => buildStoryTimelineEvents(story, projection)),
+	]);
+
+	const response: DocumentObservabilityResponse = {
+		data: {
+			source: {
+				id: source.id,
+				filename: source.filename,
+				status: source.status,
+				page_count: source.pageCount,
+				steps: orderedSteps.map(mapSourceStep),
+				projection: sourceProjection,
+			},
+			stories: storyProjections.map(({ story, projection }) => ({
+				id: story.id,
+				title: story.title,
+				status: story.status,
+				page_start: story.pageStart,
+				page_end: story.pageEnd,
+				projection,
+			})),
+			job,
+			progress,
+			timeline,
+		},
+	};
+
+	requestLogger.info(
+		{
+			story_count: response.data.stories.length,
+			timeline_count: response.data.timeline.length,
+			duration_ms: Math.round(performance.now() - startedAt),
+		},
+		'document observability request completed',
+	);
+
+	return response;
+}
+
 function notFoundError(message: string, context: Record<string, unknown>): MulderError {
 	return new MulderError(message, DOCUMENT_NOT_FOUND_CODE, { context });
 }
@@ -305,6 +867,11 @@ async function buildDocumentListResponse(input: DocumentListQuery, logger: Logge
 export async function listDocuments(input: DocumentListQuery, logger?: Logger): Promise<DocumentListResponse> {
 	const rootLogger = logger ?? createLogger();
 	return await buildDocumentListResponse(input, rootLogger);
+}
+
+export async function getDocumentObservability(id: string, logger?: Logger): Promise<DocumentObservabilityResponse> {
+	const rootLogger = logger ?? createLogger();
+	return await buildDocumentObservabilityResponse(id, rootLogger);
 }
 
 export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Response> {

--- a/apps/api/src/routes/documents.schemas.ts
+++ b/apps/api/src/routes/documents.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { JobStatusSchema, PipelineRunSourceStatusSchema, PipelineRunStatusSchema } from './jobs.schemas.js';
 
 export const SOURCE_STATUS_VALUES = [
 	'ingested',
@@ -73,6 +74,91 @@ export const DocumentPageParamsSchema = z.object({
 	num: z.coerce.number().int().positive(),
 });
 
+export const DOCUMENT_OBSERVABILITY_STEP_STATUS_VALUES = ['pending', 'completed', 'failed', 'partial'] as const;
+export const DocumentObservabilityStepStatusSchema = z.enum(DOCUMENT_OBSERVABILITY_STEP_STATUS_VALUES);
+
+export const DocumentObservabilityStepSchema = z.object({
+	step: z.string().min(1),
+	status: DocumentObservabilityStepStatusSchema,
+	completed_at: z.string().nullable(),
+	error_message: z.string().nullable(),
+});
+
+export const DocumentObservabilitySourceProjectionSchema = z.object({
+	status: z.string().nullable(),
+	extracted_at: z.string().nullable(),
+	segmented_at: z.string().nullable(),
+	page_count: z.number().int().nullable(),
+	story_count: z.number().int().nullable(),
+	vision_fallback_count: z.number().int().nullable(),
+	vision_fallback_capped: z.boolean().nullable(),
+});
+
+export const DocumentObservabilityStoryProjectionSchema = z.object({
+	status: z.string().nullable(),
+	enriched_at: z.string().nullable(),
+	embedded_at: z.string().nullable(),
+	graphed_at: z.string().nullable(),
+	entities_extracted: z.number().int().nullable(),
+	chunks_created: z.number().int().nullable(),
+});
+
+export const DocumentObservabilityStorySchema = z.object({
+	id: z.string().uuid(),
+	title: z.string().min(1),
+	status: z.string(),
+	page_start: z.number().int().nullable(),
+	page_end: z.number().int().nullable(),
+	projection: DocumentObservabilityStoryProjectionSchema.nullable(),
+});
+
+export const DocumentObservabilityJobSchema = z.object({
+	job_id: z.string().uuid(),
+	status: JobStatusSchema,
+	attempts: z.number().int().nonnegative(),
+	max_attempts: z.number().int().positive(),
+	error_log: z.string().nullable(),
+	created_at: z.string(),
+	started_at: z.string().nullable(),
+	finished_at: z.string().nullable(),
+});
+
+export const DocumentObservabilityProgressSchema = z.object({
+	run_id: z.string().uuid(),
+	run_status: PipelineRunStatusSchema,
+	current_step: z.string().min(1),
+	source_status: PipelineRunSourceStatusSchema,
+	updated_at: z.string(),
+	error_message: z.string().nullable(),
+});
+
+export const DocumentObservabilityTimelineSchema = z.object({
+	scope: z.enum(['job', 'source', 'story']),
+	event: z.string().min(1),
+	status: z.string().min(1),
+	occurred_at: z.string(),
+	step: z.string().nullable(),
+	story_id: z.string().uuid().nullable(),
+	details: z.record(z.string(), z.unknown()),
+});
+
+export const DocumentObservabilityResponseSchema = z.object({
+	data: z.object({
+		source: z.object({
+			id: z.string().uuid(),
+			filename: z.string().min(1),
+			status: SourceStatusSchema,
+			page_count: z.number().int().nullable(),
+			steps: z.array(DocumentObservabilityStepSchema),
+			projection: DocumentObservabilitySourceProjectionSchema.nullable(),
+		}),
+		stories: z.array(DocumentObservabilityStorySchema),
+		job: DocumentObservabilityJobSchema.nullable(),
+		progress: DocumentObservabilityProgressSchema.nullable(),
+		timeline: z.array(DocumentObservabilityTimelineSchema),
+	}),
+});
+
 export const DocumentArtifactSchema = z.object({
 	kind: DocumentArtifactKindSchema,
 	source_id: z.string().uuid(),
@@ -90,3 +176,4 @@ export type DocumentPageItem = z.infer<typeof DocumentPageSchema>;
 export type DocumentArtifact = z.infer<typeof DocumentArtifactSchema>;
 export type DocumentParams = z.infer<typeof DocumentParamsSchema>;
 export type DocumentPageParams = z.infer<typeof DocumentPageParamsSchema>;
+export type DocumentObservabilityResponse = z.infer<typeof DocumentObservabilityResponseSchema>;

--- a/apps/api/src/routes/documents.ts
+++ b/apps/api/src/routes/documents.ts
@@ -1,5 +1,6 @@
 import type { Context, Hono } from 'hono';
 import {
+	getDocumentObservability,
 	listDocumentPages,
 	listDocuments,
 	streamDocumentLayout,
@@ -9,6 +10,7 @@ import {
 import {
 	DocumentListQuerySchema,
 	DocumentListResponseSchema,
+	DocumentObservabilityResponseSchema,
 	DocumentPageParamsSchema,
 	DocumentPagesResponseSchema,
 	DocumentParamsSchema,
@@ -51,6 +53,13 @@ export function registerDocumentRoutes(app: Hono): void {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
 		const response = await listDocumentPages(id, readRequestLogger(c));
 		DocumentPagesResponseSchema.parse(response);
+		return c.json(response, 200);
+	});
+
+	app.get('/api/documents/:id/observability', async (c) => {
+		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
+		const response = await getDocumentObservability(id, readRequestLogger(c));
+		DocumentObservabilityResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,7 +193,7 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | 🟢 | H9 | Evidence API routes (sync) | §10.6 |
 | 🟢 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
-| ⚪ | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
+| 🟡 | H11 | Document Viewer UI — Vite+React split-view (PDF + layout.md) | §13 (demo/), consumes H10 |
 
 **Also read for all M7 steps:** [`docs/api-architecture.md`](./api-architecture.md) (framework choice, route structure, middleware stack, OpenAPI strategy, key trade-offs), §10 (full job queue section — especially §10.3 transaction discipline), §14 (design decisions — PostgreSQL queue, auto-commit dequeue, per-step job slicing)
 

--- a/docs/specs/77_document_observability_aggregation.spec.md
+++ b/docs/specs/77_document_observability_aggregation.spec.md
@@ -1,0 +1,221 @@
+---
+spec: "77"
+title: "Document Observability Aggregation Route"
+roadmap_step: M7-H11
+functional_spec: ["§13", "§10.6"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/193"
+created: 2026-04-15
+---
+
+# Spec 77: Document Observability Aggregation Route
+
+## 1. Objective
+
+Add a real `GET /api/documents/:id/observability` contract for `M7-H11` so the document-detail console and timeline can be rendered from authoritative backend state alone. Instead of pretending the source-level Firestore projection is the whole picture, this route aggregates the source record, source-step history, related story records, story-level observability projections, and the latest job/run progress tied to the document.
+
+This spec intentionally chooses the broader direction called out in issue `#193`: keep the richer H11 console/timeline promise and broaden the observability contract to match the data Mulder already persists. The API returns structured events and summaries, not fake log strings.
+
+## 2. Boundaries
+
+- **Roadmap Step:** `M7-H11` — Document Viewer UI
+- **Target:** `apps/api/src/routes/documents.schemas.ts`, `apps/api/src/routes/documents.ts`, `apps/api/src/lib/documents.ts`, `tests/specs/77_document_observability_route.test.ts`
+- **In scope:** authenticated `GET /api/documents/:id/observability`; aggregation of source metadata from PostgreSQL; source-step history from `source_steps`; related stories from `stories`; source/story observability projections from Firestore; latest pipeline job and run progress for the source from `jobs` plus `pipeline_runs`; normalized event/timeline entries derived strictly from persisted backend records; and black-box tests for missing, partial, and fully populated observability states
+- **Out of scope:** shipping the full React viewer shell; inventing synthetic narrative log text; changing pipeline write behavior; streaming/SSE/WebSocket updates; introducing Firestore as an orchestration dependency; or backfilling historical observability rows beyond what existing persistence already records
+- **Constraints:** PostgreSQL remains the source of truth for pipeline/job/story state; Firestore is read only as an observability projection for UI details; the route must degrade cleanly when projection records are absent; and the response must expose enough structured metadata for the UI to render an honest console/timeline without hard-coded fake entries
+
+## 3. Dependencies
+
+- **Requires:** Spec 14 (`M2-B2`) source repository, Spec 22 (`M2-B10`) story repository, Spec 36 (`M4-D6`) pipeline run tracking, Spec 67 (`M7-H1`) job queue repository, Spec 69 (`M7-H3`) Hono server scaffold, Spec 70 (`M7-H4`) API middleware stack, Spec 72 (`M7-H6`) job status API patterns, and Spec 76 (`M7-H10`) document retrieval routes
+- **Blocks:** the H11 document-detail console/timeline implementation, which needs a stable observability contract before the UI can drop mock activity data
+
+## 4. Blueprint
+
+### 4.1 Files
+
+1. **`apps/api/src/routes/documents.schemas.ts`** — adds the observability response schemas and validates the new route contract
+2. **`apps/api/src/lib/documents.ts`** — aggregates source, step, story, Firestore, and job/run records into a normalized observability payload
+3. **`apps/api/src/routes/documents.ts`** — registers `GET /api/documents/:id/observability`
+4. **`tests/specs/77_document_observability_route.test.ts`** — black-box verification for missing, partial, and fully populated observability states
+
+### 4.2 Route Contract
+
+#### `GET /api/documents/:id/observability`
+
+Purpose: return the authoritative backend-backed observability state needed for the H11 document-detail console/timeline.
+
+Response shape:
+
+```json
+{
+  "data": {
+    "source": {
+      "id": "uuid",
+      "filename": "case-file.pdf",
+      "status": "segmented",
+      "page_count": 12,
+      "steps": [
+        {
+          "step": "extract",
+          "status": "completed",
+          "completed_at": "2026-04-15T12:01:00.000Z",
+          "error_message": null
+        }
+      ],
+      "projection": {
+        "status": "segmented",
+        "extracted_at": "2026-04-15T12:01:00.000Z",
+        "segmented_at": "2026-04-15T12:02:30.000Z",
+        "page_count": 12,
+        "story_count": 3,
+        "vision_fallback_count": 2,
+        "vision_fallback_capped": false
+      }
+    },
+    "stories": [
+      {
+        "id": "uuid",
+        "title": "Story title",
+        "status": "embedded",
+        "page_start": 2,
+        "page_end": 5,
+        "projection": {
+          "status": "embedded",
+          "enriched_at": "2026-04-15T12:03:00.000Z",
+          "embedded_at": "2026-04-15T12:04:00.000Z",
+          "entities_extracted": 9,
+          "chunks_created": 4
+        }
+      }
+    ],
+    "job": {
+      "job_id": "uuid",
+      "status": "running",
+      "attempts": 1,
+      "max_attempts": 3,
+      "error_log": null,
+      "created_at": "2026-04-15T12:00:00.000Z",
+      "started_at": "2026-04-15T12:00:03.000Z",
+      "finished_at": null
+    },
+    "progress": {
+      "run_id": "uuid",
+      "run_status": "running",
+      "current_step": "segment",
+      "source_status": "processing",
+      "updated_at": "2026-04-15T12:00:05.000Z",
+      "error_message": null
+    },
+    "timeline": [
+      {
+        "scope": "job",
+        "event": "job.started",
+        "status": "running",
+        "occurred_at": "2026-04-15T12:00:03.000Z",
+        "step": "segment",
+        "story_id": null,
+        "details": {
+          "run_id": "uuid"
+        }
+      },
+      {
+        "scope": "source",
+        "event": "source_step.completed",
+        "status": "completed",
+        "occurred_at": "2026-04-15T12:01:00.000Z",
+        "step": "extract",
+        "story_id": null,
+        "details": {
+          "origin": "postgresql"
+        }
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `source.steps` comes from PostgreSQL `source_steps`, ordered by known pipeline step order rather than alphabetical database order
+- `source.projection` comes from `documents/{sourceId}` when present; when absent, it is `null`
+- `stories[*].projection` comes from `stories/{storyId}` when present; when absent, it is `null`
+- `job` reflects the newest queued/worker job whose payload targets the source and is `null` when no matching job exists
+- `progress` reflects the newest persisted `pipeline_run_sources` row for the source, enriched with its parent `pipeline_runs.status`, and is `null` when no run-progress row exists
+- `timeline` is a normalized event feed sorted ascending by timestamp and derived only from persisted records; it must not include invented prose-only logs
+- timeline events may be synthesized from authoritative timestamps and states, but each event must trace back to an actual row or projection field already stored by the backend
+
+### 4.3 Timeline Normalization Rules
+
+The route should emit timeline events from these sources:
+
+1. **Job lifecycle:** `jobs.created_at`, `jobs.started_at`, `jobs.finished_at`, `jobs.status`, `jobs.error_log`
+2. **Run/source progress:** latest `pipeline_run_sources` row for the source, including `current_step`, `status`, and `updated_at`
+3. **Source-step completion/failure:** `source_steps.completed_at`, `source_steps.status`, `source_steps.error_message`
+4. **Source projection milestones:** known timestamp-bearing fields on `documents/{sourceId}` such as `extractedAt` and `segmentedAt`
+5. **Story projection milestones:** known timestamp-bearing fields on `stories/{storyId}` such as `enrichedAt`, `embeddedAt`, and `graphedAt`
+
+The route must not fabricate line-by-line worker logs. The UI can map these normalized events into human-readable labels later.
+
+### 4.4 Implementation Notes
+
+- prefer existing repository functions (`findSourceById`, `findSourceSteps`, `findStoriesBySourceId`, `findJobs`, `findPipelineRunById`, `findLatestPipelineRunSourceForSource`) over new database helpers unless a blocker appears
+- reuse the existing document-route config/service bootstrap so dev-mode tests can provide in-memory Firestore projections
+- keep the timeline payload intentionally structured and compact; do not dump raw Firestore documents or raw job payloads into the response
+
+## 5. QA Contract
+
+### QA-01: unknown documents fail with the established not-found response
+
+**Given** no source row exists for the requested ID,
+**When** an authenticated client sends `GET /api/documents/{id}/observability`,
+**Then** the API returns the established Mulder not-found response and does not synthesize an empty observability payload.
+
+### QA-02: missing projections still return authoritative SQL-backed observability
+
+**Given** a source exists with `source_steps` and/or story rows but no Firestore projection documents,
+**When** an authenticated client sends `GET /api/documents/{id}/observability`,
+**Then** the response is `200`, `source.projection` and missing `stories[*].projection` entries are `null`, and the SQL-backed step/story/job data is still present.
+
+### QA-03: partial observability states stay explicit
+
+**Given** some but not all observability records exist for a source,
+**When** an authenticated client requests the route,
+**Then** the response preserves missing sections as `null` or empty arrays instead of backfilling fake completion details.
+
+### QA-04: fully populated observability returns source, stories, job, and timeline data together
+
+**Given** a source with source-step history, story rows, Firestore projection documents, and a matching pipeline job/run,
+**When** an authenticated client sends `GET /api/documents/{id}/observability`,
+**Then** the response aggregates all of those records into one payload and exposes a timeline sorted by real timestamps.
+
+### QA-05: timeline events are structured and traceable
+
+**Given** persisted timestamps across jobs, source steps, and projection milestones,
+**When** the observability route responds,
+**Then** each timeline entry includes scope, event, status, occurred timestamp, and structured details sufficient for the UI to render without relying on fake log strings.
+
+### QA-06: document observability stays read-only and non-queueing
+
+**Given** the observability route is available,
+**When** an authenticated client exercises the route,
+**Then** no jobs, pipeline runs, sources, stories, or source-step rows are created or mutated.
+
+### QA-07: unauthenticated and malformed requests fail at the HTTP boundary
+
+**Given** the route is mounted behind the existing middleware stack,
+**When** the request is unauthenticated or uses a malformed document ID,
+**Then** the API fails with the established auth or validation response shape.
+
+### QA-08: the API package still builds with the observability route added
+
+**Given** the observability route implementation is in place,
+**When** the API build and the dedicated spec test run,
+**Then** both pass without needing the full CI-equivalent suite.
+
+## 5b. CLI Test Matrix
+
+N/A — no CLI commands in this step.
+
+## 6. Cost Considerations
+
+This route adds only read-time API cost. It reuses already-persisted PostgreSQL rows and Firestore projection documents, and it does not trigger new pipeline work, LLM calls, or artifact generation. Keep Firestore lookups bounded to the source document and the stories already linked to the source so one detail-page request does not fan out unnecessarily.

--- a/packages/core/src/database/repositories/pipeline-run.repository.ts
+++ b/packages/core/src/database/repositories/pipeline-run.repository.ts
@@ -325,7 +325,7 @@ export async function findLatestPipelineRunSourceForSource(
     FROM pipeline_run_sources prs
     JOIN pipeline_runs pr ON pr.id = prs.run_id
     WHERE prs.source_id = $1
-    ORDER BY pr.created_at DESC, prs.updated_at DESC
+    ORDER BY prs.updated_at DESC, pr.created_at DESC, prs.run_id DESC
     LIMIT 1
   `;
 

--- a/tests/specs/77_document_observability_route.test.ts
+++ b/tests/specs/77_document_observability_route.test.ts
@@ -1,0 +1,993 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import pg from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const mocks = vi.hoisted(() => ({
+	getQueryPool: vi.fn(),
+	createServiceRegistry: vi.fn(),
+}));
+
+vi.mock('@mulder/core', async () => {
+	const actual = await vi.importActual<typeof import('@mulder/core')>('@mulder/core');
+	return {
+		...actual,
+		getQueryPool: mocks.getQueryPool,
+		createServiceRegistry: mocks.createServiceRegistry,
+	};
+});
+
+interface ApiApp {
+	request: (input: string | Request, init?: RequestInit) => Promise<Response>;
+}
+
+interface SeededSource {
+	id: string;
+	storagePath: string;
+}
+
+interface FirestoreState {
+	records: Map<string, Record<string, unknown>>;
+}
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_LOG_LEVEL: 'silent',
+		},
+	});
+
+	expect(result.status ?? 1).toBe(0);
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function authorizedHeaders(ip = '203.0.113.10'): Record<string, string> {
+	return {
+		Authorization: 'Bearer test-api-key',
+		'X-Forwarded-For': ip,
+	};
+}
+
+function createFirestoreState(): FirestoreState {
+	return {
+		records: new Map(),
+	};
+}
+
+function firestoreKey(collection: string, documentId: string): string {
+	return `${collection}/${documentId}`;
+}
+
+function buildMockServices(state: FirestoreState) {
+	return {
+		storage: {
+			upload: async () => {},
+			download: async () => Buffer.from(''),
+			exists: async () => false,
+			list: async () => ({ paths: [] }),
+			delete: async () => {},
+		},
+		documentAi: {
+			processDocument: async () => ({ document: {}, pageImages: [] }),
+		},
+		llm: {
+			generateStructured: async () => {
+				throw new Error('generateStructured is not used in this test');
+			},
+			generateText: async () => '',
+			groundedGenerate: async () => {
+				throw new Error('groundedGenerate is not used in this test');
+			},
+			countTokens: async () => 0,
+		},
+		embedding: {
+			embed: async () => [],
+		},
+		firestore: {
+			setDocument: async (collection: string, documentId: string, data: Record<string, unknown>) => {
+				state.records.set(firestoreKey(collection, documentId), data);
+			},
+			getDocument: async (collection: string, documentId: string) => {
+				return state.records.get(firestoreKey(collection, documentId)) ?? null;
+			},
+		},
+	};
+}
+
+async function loadApiApp(): Promise<ApiApp> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	if (typeof module.createApp !== 'function') {
+		throw new Error('API app module did not export createApp');
+	}
+
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+			},
+			rate_limiting: {
+				enabled: true,
+			},
+			explorer: {
+				enabled: false,
+			},
+		},
+	});
+}
+
+async function seedSource(
+	pool: pg.Pool,
+	input: {
+		filename: string;
+		pageCount?: number | null;
+		status?: 'ingested' | 'extracted' | 'segmented' | 'enriched' | 'embedded' | 'graphed' | 'analyzed';
+		createdAt?: string;
+		updatedAt?: string;
+	},
+): Promise<SeededSource> {
+	const id = randomUUID();
+	const storagePath = `raw/${id}/${input.filename}`;
+	const fileHash = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
+	await pool.query(
+		[
+			'INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, metadata, created_at, updated_at)',
+			'VALUES ($1, $2, $3, $4, $5, FALSE, 0, $6, $7::jsonb, $8, $9)',
+			'ON CONFLICT (id) DO UPDATE SET',
+			'filename = EXCLUDED.filename,',
+			'storage_path = EXCLUDED.storage_path,',
+			'file_hash = EXCLUDED.file_hash,',
+			'page_count = EXCLUDED.page_count,',
+			'has_native_text = EXCLUDED.has_native_text,',
+			'native_text_ratio = EXCLUDED.native_text_ratio,',
+			'status = EXCLUDED.status,',
+			'metadata = EXCLUDED.metadata,',
+			'created_at = EXCLUDED.created_at,',
+			'updated_at = EXCLUDED.updated_at',
+		].join(' '),
+		[
+			id,
+			input.filename,
+			storagePath,
+			fileHash,
+			input.pageCount ?? null,
+			input.status ?? 'ingested',
+			JSON.stringify({}),
+			input.createdAt ?? '2026-04-15T12:00:00.000Z',
+			input.updatedAt ?? '2026-04-15T12:00:00.000Z',
+		],
+	);
+
+	return {
+		id,
+		storagePath,
+	};
+}
+
+async function seedStory(
+	pool: pg.Pool,
+	input: {
+		sourceId: string;
+		title: string;
+		pageStart?: number | null;
+		pageEnd?: number | null;
+		status?: 'segmented' | 'enriched' | 'embedded' | 'graphed' | 'analyzed';
+		createdAt?: string;
+		updatedAt?: string;
+	},
+): Promise<string> {
+	const id = randomUUID();
+	await pool.query(
+		[
+			'INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, chunk_count, extraction_confidence, status, metadata, created_at, updated_at)',
+			'VALUES ($1, $2, $3, NULL, NULL, NULL, $4, $5, $6, $7, 0, NULL, $8, $9::jsonb, $10, $11)',
+			'ON CONFLICT (id) DO UPDATE SET',
+			'title = EXCLUDED.title,',
+			'page_start = EXCLUDED.page_start,',
+			'page_end = EXCLUDED.page_end,',
+			'gcs_markdown_uri = EXCLUDED.gcs_markdown_uri,',
+			'gcs_metadata_uri = EXCLUDED.gcs_metadata_uri,',
+			'chunk_count = EXCLUDED.chunk_count,',
+			'extraction_confidence = EXCLUDED.extraction_confidence,',
+			'status = EXCLUDED.status,',
+			'metadata = EXCLUDED.metadata,',
+			'created_at = EXCLUDED.created_at,',
+			'updated_at = EXCLUDED.updated_at',
+		].join(' '),
+		[
+			id,
+			input.sourceId,
+			input.title,
+			input.pageStart ?? null,
+			input.pageEnd ?? null,
+			`segments/${input.sourceId}/${id}.md`,
+			`segments/${input.sourceId}/${id}.meta.json`,
+			input.status ?? 'segmented',
+			JSON.stringify({}),
+			input.createdAt ?? '2026-04-15T12:00:00.000Z',
+			input.updatedAt ?? '2026-04-15T12:00:00.000Z',
+		],
+	);
+
+	return id;
+}
+
+async function seedSourceStep(
+	pool: pg.Pool,
+	input: {
+		sourceId: string;
+		stepName: string;
+		status: 'pending' | 'completed' | 'failed' | 'partial';
+		completedAt?: string | null;
+		errorMessage?: string | null;
+	},
+): Promise<void> {
+	await pool.query(
+		[
+			'INSERT INTO source_steps (source_id, step_name, status, error_message, completed_at)',
+			'VALUES ($1, $2, $3, $4, $5)',
+			'ON CONFLICT (source_id, step_name) DO UPDATE SET',
+			'status = EXCLUDED.status,',
+			'error_message = EXCLUDED.error_message,',
+			'completed_at = EXCLUDED.completed_at',
+		].join(' '),
+		[input.sourceId, input.stepName, input.status, input.errorMessage ?? null, input.completedAt ?? null],
+	);
+}
+
+async function seedPipelineRun(
+	pool: pg.Pool,
+	input: {
+		id: string;
+		status: 'running' | 'completed' | 'partial' | 'failed';
+		createdAt: string;
+		finishedAt?: string | null;
+	},
+): Promise<void> {
+	await pool.query(
+		[
+			'INSERT INTO pipeline_runs (id, tag, options, status, created_at, finished_at)',
+			'VALUES ($1, NULL, $2::jsonb, $3, $4, $5)',
+			'ON CONFLICT (id) DO UPDATE SET',
+			'status = EXCLUDED.status,',
+			'created_at = EXCLUDED.created_at,',
+			'finished_at = EXCLUDED.finished_at',
+		].join(' '),
+		[input.id, JSON.stringify({}), input.status, input.createdAt, input.finishedAt ?? null],
+	);
+}
+
+async function seedPipelineRunSource(
+	pool: pg.Pool,
+	input: {
+		runId: string;
+		sourceId: string;
+		currentStep: string;
+		status: 'pending' | 'processing' | 'completed' | 'failed';
+		updatedAt: string;
+		errorMessage?: string | null;
+	},
+): Promise<void> {
+	await pool.query(
+		[
+			'INSERT INTO pipeline_run_sources (run_id, source_id, current_step, status, error_message, updated_at)',
+			'VALUES ($1, $2, $3, $4, $5, $6)',
+			'ON CONFLICT (run_id, source_id) DO UPDATE SET',
+			'current_step = EXCLUDED.current_step,',
+			'status = EXCLUDED.status,',
+			'error_message = EXCLUDED.error_message,',
+			'updated_at = EXCLUDED.updated_at',
+		].join(' '),
+		[input.runId, input.sourceId, input.currentStep, input.status, input.errorMessage ?? null, input.updatedAt],
+	);
+}
+
+async function seedJob(
+	pool: pg.Pool,
+	input: {
+		id: string;
+		type?: string;
+		status: 'pending' | 'running' | 'completed' | 'failed' | 'dead_letter';
+		attempts: number;
+		maxAttempts: number;
+		createdAt: string;
+		startedAt?: string | null;
+		finishedAt?: string | null;
+		errorLog?: string | null;
+		payload: Record<string, unknown>;
+	},
+): Promise<void> {
+	await pool.query(
+		[
+			'INSERT INTO jobs (id, type, payload, status, attempts, max_attempts, error_log, worker_id, created_at, started_at, finished_at)',
+			'VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10, $11)',
+			'ON CONFLICT (id) DO UPDATE SET',
+			'type = EXCLUDED.type,',
+			'payload = EXCLUDED.payload,',
+			'status = EXCLUDED.status,',
+			'attempts = EXCLUDED.attempts,',
+			'max_attempts = EXCLUDED.max_attempts,',
+			'error_log = EXCLUDED.error_log,',
+			'worker_id = EXCLUDED.worker_id,',
+			'created_at = EXCLUDED.created_at,',
+			'started_at = EXCLUDED.started_at,',
+			'finished_at = EXCLUDED.finished_at',
+		].join(' '),
+		[
+			input.id,
+			input.type ?? 'pipeline_run',
+			JSON.stringify(input.payload),
+			input.status,
+			input.attempts,
+			input.maxAttempts,
+			input.errorLog ?? null,
+			'worker-1',
+			input.createdAt,
+			input.startedAt ?? null,
+			input.finishedAt ?? null,
+		],
+	);
+}
+
+async function readJson(response: Response): Promise<unknown> {
+	return await response.json();
+}
+
+describe('Spec 77 — Document Observability Aggregation Route', () => {
+	const originalConfig = process.env.MULDER_CONFIG;
+	const originalLogLevel = process.env.MULDER_LOG_LEVEL;
+	let pool: pg.Pool;
+	let app: ApiApp;
+	let firestore: FirestoreState;
+
+	beforeAll(async () => {
+		db.requirePg();
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+
+		ensureSchema();
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+
+		pool = new pg.Pool({
+			host: db.TEST_PG_HOST,
+			port: db.TEST_PG_PORT,
+			user: db.TEST_PG_USER,
+			password: db.TEST_PG_PASSWORD,
+			database: db.TEST_PG_DATABASE,
+		});
+
+		firestore = createFirestoreState();
+		mocks.getQueryPool.mockReturnValue(pool);
+		mocks.createServiceRegistry.mockReturnValue(buildMockServices(firestore));
+
+		app = await loadApiApp();
+	}, 600000);
+
+	beforeEach(async () => {
+		firestore.records.clear();
+		mocks.getQueryPool.mockClear();
+		mocks.createServiceRegistry.mockClear();
+		mocks.getQueryPool.mockReturnValue(pool);
+		mocks.createServiceRegistry.mockReturnValue(buildMockServices(firestore));
+	});
+
+	afterAll(async () => {
+		await pool?.end();
+		if (originalConfig === undefined) {
+			delete process.env.MULDER_CONFIG;
+		} else {
+			process.env.MULDER_CONFIG = originalConfig;
+		}
+		if (originalLogLevel === undefined) {
+			delete process.env.MULDER_LOG_LEVEL;
+		} else {
+			process.env.MULDER_LOG_LEVEL = originalLogLevel;
+		}
+	});
+
+	it('QA-01: unknown documents return the established not-found response', async () => {
+		const id = randomUUID();
+		const response = await app.request(`http://localhost/api/documents/${id}/observability`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(404);
+		expect(await readJson(response)).toEqual({
+			error: {
+				code: 'DOCUMENT_NOT_FOUND',
+				message: `Document not found: ${id}`,
+				details: {
+					id,
+				},
+			},
+		});
+	});
+
+	it('QA-02: missing projections still return authoritative SQL-backed observability', async () => {
+		const source = await seedSource(pool, {
+			filename: 'missing-projections.pdf',
+			pageCount: 11,
+			status: 'segmented',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'extract',
+			status: 'completed',
+			completedAt: '2026-04-15T12:01:00.000Z',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'segment',
+			status: 'completed',
+			completedAt: '2026-04-15T12:02:00.000Z',
+		});
+		const storyId = await seedStory(pool, {
+			sourceId: source.id,
+			title: 'Missing projections story',
+			pageStart: 2,
+			pageEnd: 4,
+			status: 'segmented',
+		});
+		const runId = randomUUID();
+		const jobId = randomUUID();
+		await seedPipelineRun(pool, {
+			id: runId,
+			status: 'running',
+			createdAt: '2026-04-15T12:00:00.000Z',
+		});
+		await seedPipelineRunSource(pool, {
+			runId,
+			sourceId: source.id,
+			currentStep: 'segment',
+			status: 'processing',
+			updatedAt: '2026-04-15T12:02:05.000Z',
+		});
+		await seedJob(pool, {
+			id: jobId,
+			status: 'running',
+			attempts: 1,
+			maxAttempts: 3,
+			createdAt: '2026-04-15T12:00:00.000Z',
+			startedAt: '2026-04-15T12:00:02.000Z',
+			payload: {
+				sourceId: source.id,
+				runId,
+			},
+		});
+
+		const response = await app.request(`http://localhost/api/documents/${source.id}/observability`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await readJson(response)).toMatchObject({
+			data: {
+				source: {
+					id: source.id,
+					filename: 'missing-projections.pdf',
+					status: 'segmented',
+					page_count: 11,
+					steps: [
+						{
+							step: 'extract',
+							status: 'completed',
+							completed_at: '2026-04-15T12:01:00.000Z',
+							error_message: null,
+						},
+						{
+							step: 'segment',
+							status: 'completed',
+							completed_at: '2026-04-15T12:02:00.000Z',
+							error_message: null,
+						},
+					],
+					projection: null,
+				},
+				stories: [
+					{
+						id: storyId,
+						title: 'Missing projections story',
+						status: 'segmented',
+						page_start: 2,
+						page_end: 4,
+						projection: null,
+					},
+				],
+				job: {
+					job_id: jobId,
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					error_log: null,
+					created_at: '2026-04-15T12:00:00.000Z',
+					started_at: '2026-04-15T12:00:02.000Z',
+					finished_at: null,
+				},
+				progress: {
+					run_id: runId,
+					run_status: 'running',
+					current_step: 'segment',
+					source_status: 'processing',
+					updated_at: '2026-04-15T12:02:05.000Z',
+					error_message: null,
+				},
+			},
+		});
+	});
+
+	it('QA-02b: newest job metadata stays separate from newest persisted progress', async () => {
+		const source = await seedSource(pool, {
+			filename: 'job-without-progress.pdf',
+			pageCount: 8,
+			status: 'extracted',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'extract',
+			status: 'completed',
+			completedAt: '2026-04-15T12:01:00.000Z',
+		});
+		const staleRunId = randomUUID();
+		await seedPipelineRun(pool, {
+			id: staleRunId,
+			status: 'running',
+			createdAt: '2026-04-15T11:59:00.000Z',
+		});
+		await seedPipelineRunSource(pool, {
+			runId: staleRunId,
+			sourceId: source.id,
+			currentStep: 'graph',
+			status: 'failed',
+			updatedAt: '2026-04-15T12:09:00.000Z',
+			errorMessage: 'stale progress from an older run',
+		});
+		const jobId = randomUUID();
+		await seedJob(pool, {
+			id: jobId,
+			type: 'document_observability',
+			status: 'running',
+			attempts: 1,
+			maxAttempts: 3,
+			createdAt: '2026-04-15T12:00:00.000Z',
+			startedAt: '2026-04-15T12:00:02.000Z',
+			payload: {
+				sourceId: source.id,
+			},
+		});
+
+		const response = await app.request(`http://localhost/api/documents/${source.id}/observability`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await readJson(response)) as {
+			data: {
+				source: {
+					id: string;
+					steps: Array<{
+						step: string;
+						status: string;
+						completed_at: string | null;
+						error_message: string | null;
+					}>;
+				};
+				job: {
+					job_id: string;
+					status: string;
+					attempts: number;
+					max_attempts: number;
+					error_log: string | null;
+					created_at: string;
+					started_at: string | null;
+					finished_at: string | null;
+				};
+				progress: {
+					run_id: string;
+					run_status: string;
+					current_step: string;
+					source_status: string;
+					updated_at: string;
+					error_message: string | null;
+				};
+				timeline: Array<{ event: string; occurred_at: string }>;
+			};
+		};
+		expect(body).toMatchObject({
+			data: {
+				source: {
+					id: source.id,
+					steps: [
+						{
+							step: 'extract',
+							status: 'completed',
+							completed_at: '2026-04-15T12:01:00.000Z',
+							error_message: null,
+						},
+					],
+				},
+				job: {
+					job_id: jobId,
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					error_log: null,
+					created_at: '2026-04-15T12:00:00.000Z',
+					started_at: '2026-04-15T12:00:02.000Z',
+					finished_at: null,
+				},
+				progress: {
+					run_id: staleRunId,
+					run_status: 'running',
+					current_step: 'graph',
+					source_status: 'failed',
+					updated_at: '2026-04-15T12:09:00.000Z',
+					error_message: 'stale progress from an older run',
+				},
+				timeline: expect.arrayContaining([
+					expect.objectContaining({ event: 'job.created' }),
+					expect.objectContaining({ event: 'job.started' }),
+					expect.objectContaining({ event: 'source_step.completed' }),
+					expect.objectContaining({ event: 'run.progress' }),
+				]),
+			},
+		});
+		expect(body.data.job).not.toHaveProperty('run_id');
+		expect(body.data.job).not.toHaveProperty('current_step');
+		expect(body.data.job).not.toHaveProperty('source_status');
+		expect(body.data.progress).toMatchObject({
+			run_id: staleRunId,
+			run_status: 'running',
+			current_step: 'graph',
+			source_status: 'failed',
+			updated_at: '2026-04-15T12:09:00.000Z',
+			error_message: 'stale progress from an older run',
+		});
+		expect(body.data.timeline.map((event) => event.event)).toEqual([
+			'job.created',
+			'job.started',
+			'source_step.completed',
+			'run.progress',
+		]);
+	});
+
+	it('QA-03: partial observability states remain explicit', async () => {
+		const source = await seedSource(pool, {
+			filename: 'partial-observability.pdf',
+			pageCount: 9,
+			status: 'extracted',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'extract',
+			status: 'completed',
+			completedAt: '2026-04-15T12:01:00.000Z',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'segment',
+			status: 'failed',
+			errorMessage: 'segmentation timed out',
+		});
+		const storyA = await seedStory(pool, {
+			sourceId: source.id,
+			title: 'Projected story',
+			pageStart: 1,
+			pageEnd: 3,
+			status: 'enriched',
+		});
+		const storyB = await seedStory(pool, {
+			sourceId: source.id,
+			title: 'Unprojected story',
+			pageStart: 4,
+			pageEnd: 6,
+			status: 'segmented',
+		});
+		firestore.records.set(firestoreKey('documents', source.id), {
+			status: 'extracted',
+			extractedAt: '2026-04-15T12:01:30.000Z',
+			pageCount: 9,
+			storyCount: 2,
+		});
+		firestore.records.set(firestoreKey('stories', storyA), {
+			status: 'enriched',
+			enrichedAt: '2026-04-15T12:03:00.000Z',
+			entitiesExtracted: 7,
+		});
+
+		const response = await app.request(`http://localhost/api/documents/${source.id}/observability`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await readJson(response)).toMatchObject({
+			data: {
+				source: {
+					projection: {
+						status: 'extracted',
+						extracted_at: '2026-04-15T12:01:30.000Z',
+						segmented_at: null,
+						page_count: 9,
+						story_count: 2,
+						vision_fallback_count: null,
+						vision_fallback_capped: null,
+					},
+				},
+				stories: [
+					{
+						id: storyA,
+						projection: {
+							status: 'enriched',
+							enriched_at: '2026-04-15T12:03:00.000Z',
+							embedded_at: null,
+							graphed_at: null,
+							entities_extracted: 7,
+							chunks_created: null,
+						},
+					},
+					{
+						id: storyB,
+						projection: null,
+					},
+				],
+				job: null,
+				progress: null,
+			},
+		});
+	});
+
+	it('QA-04/05/06: fully populated observability aggregates the persisted records and stays read-only', async () => {
+		const source = await seedSource(pool, {
+			filename: 'full-observability.pdf',
+			pageCount: 12,
+			status: 'segmented',
+		});
+		const storyA = await seedStory(pool, {
+			sourceId: source.id,
+			title: 'First full story',
+			pageStart: 2,
+			pageEnd: 5,
+			status: 'embedded',
+		});
+		const storyB = await seedStory(pool, {
+			sourceId: source.id,
+			title: 'Second full story',
+			pageStart: 6,
+			pageEnd: 8,
+			status: 'enriched',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'extract',
+			status: 'completed',
+			completedAt: '2026-04-15T12:01:00.000Z',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'segment',
+			status: 'completed',
+			completedAt: '2026-04-15T12:02:00.000Z',
+		});
+		await seedSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'enrich',
+			status: 'failed',
+			errorMessage: 'entity extraction interrupted',
+		});
+		const runId = randomUUID();
+		const jobId = randomUUID();
+		await seedPipelineRun(pool, {
+			id: runId,
+			status: 'running',
+			createdAt: '2026-04-15T12:00:00.000Z',
+		});
+		await seedPipelineRunSource(pool, {
+			runId,
+			sourceId: source.id,
+			currentStep: 'enrich',
+			status: 'failed',
+			updatedAt: '2026-04-15T12:03:05.000Z',
+			errorMessage: 'entity extraction interrupted',
+		});
+		await seedJob(pool, {
+			id: jobId,
+			status: 'running',
+			attempts: 1,
+			maxAttempts: 3,
+			createdAt: '2026-04-15T12:00:00.000Z',
+			startedAt: '2026-04-15T12:00:03.000Z',
+			payload: {
+				sourceId: source.id,
+				runId,
+			},
+		});
+		firestore.records.set(firestoreKey('documents', source.id), {
+			status: 'segmented',
+			extractedAt: '2026-04-15T12:01:10.000Z',
+			segmentedAt: '2026-04-15T12:02:30.000Z',
+			pageCount: 12,
+			storyCount: 2,
+			visionFallbackCount: 1,
+			visionFallbackCapped: false,
+		});
+		firestore.records.set(firestoreKey('stories', storyA), {
+			status: 'embedded',
+			enrichedAt: '2026-04-15T12:03:20.000Z',
+			embeddedAt: '2026-04-15T12:04:00.000Z',
+			graphedAt: '2026-04-15T12:05:00.000Z',
+			entitiesExtracted: 9,
+			chunksCreated: 4,
+		});
+		firestore.records.set(firestoreKey('stories', storyB), {
+			status: 'enriched',
+			enrichedAt: '2026-04-15T12:03:40.000Z',
+			entitiesExtracted: 5,
+		});
+
+		const beforeCounts = await Promise.all([
+			pool.query('SELECT COUNT(*) FROM jobs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_runs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_run_sources'),
+			pool.query('SELECT COUNT(*) FROM source_steps'),
+			pool.query('SELECT COUNT(*) FROM stories'),
+		]);
+
+		const response = await app.request(`http://localhost/api/documents/${source.id}/observability`, {
+			headers: authorizedHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await readJson(response)) as {
+			data: {
+				source: { id: string; projection: Record<string, unknown> | null };
+				stories: Array<{ id: string; projection: Record<string, unknown> | null }>;
+				job: Record<string, unknown> | null;
+				progress: Record<string, unknown> | null;
+				timeline: Array<{ event: string; occurred_at: string }>;
+			};
+		};
+		expect(body).toMatchObject({
+			data: {
+				source: {
+					id: source.id,
+					projection: {
+						status: 'segmented',
+						extracted_at: '2026-04-15T12:01:10.000Z',
+						segmented_at: '2026-04-15T12:02:30.000Z',
+						page_count: 12,
+						story_count: 2,
+						vision_fallback_count: 1,
+						vision_fallback_capped: false,
+					},
+				},
+				stories: [
+					{
+						id: storyA,
+						projection: {
+							status: 'embedded',
+							enriched_at: '2026-04-15T12:03:20.000Z',
+							embedded_at: '2026-04-15T12:04:00.000Z',
+							graphed_at: '2026-04-15T12:05:00.000Z',
+							entities_extracted: 9,
+							chunks_created: 4,
+						},
+					},
+					{
+						id: storyB,
+						projection: {
+							status: 'enriched',
+							enriched_at: '2026-04-15T12:03:40.000Z',
+							embedded_at: null,
+							graphed_at: null,
+							entities_extracted: 5,
+							chunks_created: null,
+						},
+					},
+				],
+				job: {
+					job_id: jobId,
+					status: 'running',
+					attempts: 1,
+					max_attempts: 3,
+					error_log: null,
+					created_at: '2026-04-15T12:00:00.000Z',
+					started_at: '2026-04-15T12:00:03.000Z',
+					finished_at: null,
+				},
+				progress: {
+					run_id: runId,
+					run_status: 'running',
+					current_step: 'enrich',
+					source_status: 'failed',
+					updated_at: '2026-04-15T12:03:05.000Z',
+					error_message: 'entity extraction interrupted',
+				},
+			},
+		});
+
+		const afterCounts = await Promise.all([
+			pool.query('SELECT COUNT(*) FROM jobs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_runs'),
+			pool.query('SELECT COUNT(*) FROM pipeline_run_sources'),
+			pool.query('SELECT COUNT(*) FROM source_steps'),
+			pool.query('SELECT COUNT(*) FROM stories'),
+		]);
+		expect(afterCounts.map((result) => result.rows[0].count)).toEqual(
+			beforeCounts.map((result) => result.rows[0].count),
+		);
+
+		expect(body.data.timeline.map((event) => event.event)).toEqual([
+			'job.created',
+			'job.started',
+			'source_step.completed',
+			'source.projection.extracted',
+			'source_step.completed',
+			'source.projection.segmented',
+			'run.progress',
+			'source_step.failed',
+			'story.projection.enriched',
+			'story.projection.enriched',
+			'story.projection.embedded',
+			'story.projection.graphed',
+		]);
+		expect(body.data.timeline.map((event) => event.occurred_at)).toEqual([
+			'2026-04-15T12:00:00.000Z',
+			'2026-04-15T12:00:03.000Z',
+			'2026-04-15T12:01:00.000Z',
+			'2026-04-15T12:01:10.000Z',
+			'2026-04-15T12:02:00.000Z',
+			'2026-04-15T12:02:30.000Z',
+			'2026-04-15T12:03:05.000Z',
+			'2026-04-15T12:03:05.000Z',
+			'2026-04-15T12:03:20.000Z',
+			'2026-04-15T12:03:40.000Z',
+			'2026-04-15T12:04:00.000Z',
+			'2026-04-15T12:05:00.000Z',
+		]);
+	});
+
+	it('QA-07: unauthenticated and malformed requests fail at the HTTP boundary', async () => {
+		const documentId = randomUUID();
+
+		const unauthenticatedResponse = await app.request(`http://localhost/api/documents/${documentId}/observability`);
+		expect(unauthenticatedResponse.status).toBe(401);
+		expect(await readJson(unauthenticatedResponse)).toEqual({
+			error: {
+				code: 'AUTH_UNAUTHORIZED',
+				message: 'A valid API key is required',
+			},
+		});
+
+		const malformedResponse = await app.request('http://localhost/api/documents/not-a-uuid/observability', {
+			headers: authorizedHeaders(),
+		});
+		expect(malformedResponse.status).toBe(400);
+		expect(await readJson(malformedResponse)).toMatchObject({
+			error: {
+				code: 'VALIDATION_ERROR',
+				message: 'Invalid request',
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add `GET /api/documents/:id/observability` with a backend-backed contract for H11 document detail
- aggregate source, source-step, story, job, and latest run-progress state into one observability payload
- add spec 77 plus black-box route coverage for missing, partial, fully populated, and stale-progress cases

## Traceability
- Closes #193
- Spec: `docs/specs/77_document_observability_aggregation.spec.md`
- Roadmap: `M7-H11` (kept in progress because this PR delivers the observability slice, not the full viewer)

## Verification
- `pnpm --filter @mulder/api build`
- Independent QA worker: `PASS` on spec 77 verification lane
- Independent architect review: `APPROVED`
