### PR TITLE
Guard local demo fixture seeding

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,8 +1,13 @@
-# Mulder Demo
+# Mulder Local Demo
 
-This app is the local, API-backed Mulder demo. It is intentionally not a mock showcase: login, documents, upload,
-Case Files, search, Board, Audit, jobs, and corpus metrics all go through the real API against a deterministic local
-Postgres/storage fixture.
+This app is the local, API-backed Mulder browser demo and E2E harness. Login, documents, upload, Case Files, search,
+Board, Audit, jobs, and corpus metrics all go through the real API against a deterministic local Postgres/storage
+fixture.
+
+The fixture setup is intentionally local-only. `demo:prepare` refuses to seed unless it is pointed at the local
+docker-compose `mulder-postgres` service on port 5432 and `MULDER_ALLOW_LOCAL_E2E_SEEDING=local-docker-only` is set.
+Do not use this setup path for the production demo database; production should contain only documents ingested through
+the normal upload/pipeline flow.
 
 ## Credentials
 
@@ -19,7 +24,7 @@ cd demo
 npm run demo:stack
 ```
 
-`demo:stack` performs the full local setup:
+`demo:stack` performs the full local E2E setup:
 
 - Builds `@mulder/core`, retrieval, pipeline, worker, evidence, API, and CLI packages.
 - Runs migrations and seeds the deterministic fixture corpus.
@@ -29,7 +34,7 @@ npm run demo:stack
 
 Useful single-process commands:
 
-- `npm run demo:prepare` reseeds Postgres and writes `.local/storage` demo artifacts.
+- `npm run demo:prepare` reseeds the guarded local Docker Postgres fixture and writes `.local/storage` artifacts.
 - `npm run demo:api` starts only the API with the demo E2E config.
 - `npm run demo:worker` starts only the worker.
 - `npm run demo:web` starts only Vite.

--- a/demo/package.json
+++ b/demo/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "demo:api": "cd .. && MULDER_CONFIG=demo/tests/config/mulder.e2e.config.yaml NODE_ENV=development MULDER_LOG_LEVEL=silent MULDER_API_PORT=8080 node apps/api/dist/index.js",
-    "demo:prepare": "node ./tests/setup/prepare-e2e.mjs",
+    "demo:prepare": "MULDER_ALLOW_LOCAL_E2E_SEEDING=local-docker-only node ./tests/setup/prepare-e2e.mjs",
     "demo:stack": "node ./scripts/run-demo-stack.mjs",
     "demo:web": "VITE_PREVIEW_AUTH_BYPASS=false VITE_API_PROXY_TARGET=http://127.0.0.1:8080 vite --host 127.0.0.1",
     "demo:worker": "cd .. && MULDER_CONFIG=demo/tests/config/mulder.e2e.config.yaml NODE_ENV=development MULDER_LOG_LEVEL=silent node apps/cli/dist/index.js worker start --poll-interval 250 --concurrency 1",

--- a/demo/scripts/run-demo-stack.mjs
+++ b/demo/scripts/run-demo-stack.mjs
@@ -10,7 +10,11 @@ function runPrepare() {
   const result = spawnSync('npm', ['run', 'demo:prepare'], {
     cwd: DEMO_DIR,
     stdio: 'inherit',
-    env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+    env: {
+      ...process.env,
+      MULDER_ALLOW_LOCAL_E2E_SEEDING: 'local-docker-only',
+      MULDER_LOG_LEVEL: 'silent',
+    },
   });
 
   if ((result.status ?? 1) !== 0) {

--- a/demo/src/app/Layout.tsx
+++ b/demo/src/app/Layout.tsx
@@ -119,7 +119,7 @@ export function Layout() {
                   data-testid={`nav-${item.label.toLowerCase().replaceAll(/\s+/g, '-')}`}
                   className={({ isActive }) =>
                     cn(
-                      'inline-flex shrink-0 items-center gap-2 rounded-full px-4 py-2 text-sm transition-colors',
+                      'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-2 text-xs transition-colors sm:gap-2 sm:px-4 sm:text-sm',
                       isActive ? 'bg-surface text-ink shadow-xs' : 'text-ink-muted hover:bg-surface hover:text-ink',
                     )
                   }

--- a/demo/src/components/Upload/UploadDialog.tsx
+++ b/demo/src/components/Upload/UploadDialog.tsx
@@ -22,7 +22,7 @@ export function UploadDialog() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const upload = useDocumentUpload();
   const [open, setOpen] = useState(false);
-  const [tags, setTags] = useState('demo');
+  const [tags, setTags] = useState('');
   const [progress, setProgress] = useState<UploadProgress | null>(null);
 
   useEffect(() => {
@@ -69,13 +69,13 @@ export function UploadDialog() {
             <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-amber">Browser upload</p>
             <DialogTitle className="mt-2 font-serif text-3xl text-ink">Add a document to the archive.</DialogTitle>
             <p className="mt-2 text-sm text-ink-muted">
-              The demo uses the real upload contract: initiate, direct upload, finalize job, then worker polling.
+              This flow uses the upload contract: initiate, direct upload, finalize job, then worker polling.
             </p>
           </div>
 
           <label className="block space-y-2 text-sm text-ink-muted">
             Tags
-            <Input value={tags} onChange={(event) => setTags(event.target.value)} placeholder="demo, field-note" />
+            <Input value={tags} onChange={(event) => setTags(event.target.value)} placeholder="field-note, source" />
           </label>
 
           <div className="rounded-xl border border-dashed border-thread-strong bg-surface p-6 text-center">

--- a/demo/src/pages/Ask.tsx
+++ b/demo/src/pages/Ask.tsx
@@ -84,7 +84,7 @@ export function AskPage() {
 
       {search.isError ? (
         <div className="rounded-xl border border-carmine-soft bg-carmine-faint p-4 text-sm text-carmine">
-          Search failed. Confirm the API is running and the corpus is seeded.
+          Search failed. Confirm the API is running and the corpus has indexed documents.
         </div>
       ) : null}
 

--- a/demo/src/pages/Board.tsx
+++ b/demo/src/pages/Board.tsx
@@ -20,12 +20,13 @@ const edgeTypes = [
   'CONFIRMED_CONTRADICTION',
   'DISMISSED_CONTRADICTION',
 ];
+const graphNodeTypes = { entity: EntityNode };
 
 export function BoardPage() {
   const entityDrawer = useEntityDrawer();
   const [entityType, setEntityType] = useState('all');
   const [edgeType, setEdgeType] = useState('all');
-  const [listView, setListView] = useState(false);
+  const [listView, setListView] = useState(() => typeof window !== 'undefined' && window.matchMedia('(max-width: 767px)').matches);
   const entities = useEntities({ limit: 100 });
   const rankedEntities = useMemo(() => rankEntities(entities.data?.data ?? []), [entities.data?.data]);
   const visibleEntities = rankedEntities.filter((entity) => entityType === 'all' || entity.type === entityType).slice(0, 100);
@@ -96,13 +97,15 @@ export function BoardPage() {
           ))}
         </div>
       ) : (
-        <div className="h-[46rem] overflow-hidden rounded-2xl border border-thread bg-surface">
+        <div className="h-[46rem] w-full overflow-hidden rounded-2xl border border-thread bg-surface">
           <ReactFlow
+            className="size-full"
             edges={graph.edges}
             fitView
-            nodeTypes={{ entity: EntityNode }}
+            nodeTypes={graphNodeTypes}
             nodes={graph.nodes}
             onNodeClick={(_, node) => entityDrawer.openEntity(String(node.id))}
+            style={{ height: '100%', width: '100%' }}
           >
             <Background />
             <Controls />
@@ -112,8 +115,8 @@ export function BoardPage() {
       )}
 
       <div className="rounded-xl border border-amber-soft bg-amber-faint p-4 text-sm text-ink-muted">
-        Temporal scrubber: the current seeded attributes do not provide enough normalized event dates for a reliable
-        timeline control, so the demo renders graph and list exploration without pretending a timeline exists.
+        Temporal scrubber: the current corpus does not provide enough normalized event dates for a reliable timeline
+        control, so the board renders graph and list exploration without pretending a timeline exists.
       </div>
     </section>
   );

--- a/demo/src/pages/Desk.tsx
+++ b/demo/src/pages/Desk.tsx
@@ -94,7 +94,7 @@ export function DeskPage() {
           <div className="divide-y divide-thread">
             {recentDocuments.map((document) => (
               <Link
-                className="flex items-center justify-between gap-4 py-4 no-underline"
+                className="flex min-w-0 items-center justify-between gap-4 py-4 no-underline"
                 key={document.id}
                 to={routes.caseFile(document.id)}
               >
@@ -102,7 +102,9 @@ export function DeskPage() {
                   <p className="truncate font-serif text-2xl text-ink">{document.filename}</p>
                   <Timestamp value={document.created_at} />
                 </div>
-                <PipelineBadge status={document.status} />
+                <div className="shrink-0">
+                  <PipelineBadge status={document.status} />
+                </div>
               </Link>
             ))}
           </div>
@@ -179,7 +181,7 @@ function MiniMetric({ label, value }: { label: string; value: string }) {
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-2xl border border-thread bg-raised p-5 shadow-xs">
+    <section className="min-w-0 rounded-2xl border border-thread bg-raised p-5 shadow-xs">
       <h2 className="font-serif text-3xl text-ink">{title}</h2>
       <div className="mt-4">{children}</div>
     </section>

--- a/demo/tests/setup/prepare-e2e.mjs
+++ b/demo/tests/setup/prepare-e2e.mjs
@@ -21,6 +21,9 @@ const OWNER_EMAIL = 'owner.e2e@mulder.local';
 const OWNER_PASSWORD = 'correct horse battery staple';
 const INVITE_EMAIL = 'invite.e2e@mulder.local';
 const INVITE_TOKEN = 'mulder-e2e-invite-token';
+const SEED_ALLOW_ENV = 'MULDER_ALLOW_LOCAL_E2E_SEEDING';
+const SEED_ALLOW_VALUE = 'local-docker-only';
+const POSTGRES_CONTAINER = process.env.MULDER_E2E_POSTGRES_CONTAINER ?? 'mulder-postgres';
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PAGE_PALETTE = [
 	[190, 111, 24],
@@ -268,6 +271,71 @@ function run(command, args, options = {}) {
 	}
 }
 
+function requireLocalE2ESeedIntent() {
+	if (process.env[SEED_ALLOW_ENV] !== SEED_ALLOW_VALUE) {
+		throw new Error(
+			[
+				'Refusing to seed the Mulder browser E2E fixture.',
+				`Set ${SEED_ALLOW_ENV}=${SEED_ALLOW_VALUE} only for the local Docker-backed E2E database.`,
+				'This script deletes and inserts fixture rows and must never run against production.',
+			].join(' '),
+		);
+	}
+}
+
+function assertLocalE2EConfig(config) {
+	const cloudSql = config.gcp?.cloud_sql;
+	const failures = [];
+
+	if (config.dev_mode !== true) failures.push('dev_mode must be true');
+	if (config.project?.name !== 'mulder-demo-e2e') failures.push('project.name must be mulder-demo-e2e');
+	if (config.gcp?.project_id !== 'mulder-demo-e2e') failures.push('gcp.project_id must be mulder-demo-e2e');
+	if (!cloudSql) failures.push('gcp.cloud_sql is required');
+	if (cloudSql && !['localhost', '127.0.0.1'].includes(cloudSql.host)) failures.push('cloud_sql.host must be localhost or 127.0.0.1');
+	if (cloudSql && cloudSql.port !== 5432) failures.push('cloud_sql.port must be 5432');
+	if (cloudSql && cloudSql.user !== 'mulder') failures.push('cloud_sql.user must be mulder');
+	if (cloudSql && cloudSql.password !== 'mulder') failures.push('cloud_sql.password must be mulder');
+	if (cloudSql && cloudSql.database !== 'mulder') failures.push('cloud_sql.database must be mulder');
+
+	if (failures.length > 0) {
+		throw new Error(`Refusing to seed browser E2E fixture: ${failures.join('; ')}.`);
+	}
+}
+
+function assertDockerPostgresOwnsConfiguredPort(config) {
+	const inspect = spawnSync('docker', ['inspect', POSTGRES_CONTAINER], {
+		cwd: ROOT,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+
+	if ((inspect.status ?? 1) !== 0) {
+		throw new Error(
+			[
+				`Refusing to seed browser E2E fixture: Docker container ${POSTGRES_CONTAINER} is not inspectable.`,
+				'Start the local docker-compose Postgres service before running this script.',
+			].join(' '),
+		);
+	}
+
+	const [container] = JSON.parse(inspect.stdout);
+	const portBindings = container?.NetworkSettings?.Ports?.['5432/tcp'] ?? [];
+	const ownsPort = Boolean(
+		container?.State?.Running &&
+			portBindings.some((binding) => String(binding.HostPort) === String(config.gcp.cloud_sql.port)),
+	);
+
+	if (!ownsPort) {
+		throw new Error(
+			[
+				`Refusing to seed browser E2E fixture: ${POSTGRES_CONTAINER} is not the running local Postgres service`,
+				`bound to host port ${config.gcp.cloud_sql.port}.`,
+				'This prevents accidental fixture writes through a Cloud SQL proxy or production database tunnel.',
+			].join(' '),
+		);
+	}
+}
+
 function buildPackages() {
 	for (const packageName of packagesToBuild) {
 		run('pnpm', ['--filter', packageName, 'build']);
@@ -433,7 +501,6 @@ function writeStorageArtifacts() {
 
 async function deleteFixtureRows(client) {
 	const stories = storyIds();
-	const entities = Object.values(ENTITY_IDS);
 	const fileHashes = DEMO_SOURCES.map((source) => source.fileHash).concat(
 		'mulder-demo-e2e-native-text-sample',
 		...REAL_UPLOAD_FIXTURES.map(fileHashForPath),
@@ -443,6 +510,16 @@ async function deleteFixtureRows(client) {
 		[sourceIds(), fileHashes],
 	);
 	const sources = Array.from(new Set([...sourceIds(), ...previousSources.rows.map((row) => row.id)]));
+	const previousDevEntities = await client.query(
+		`
+			SELECT id FROM entities
+			WHERE id = ANY($1::uuid[])
+				OR name IN ('Dev Test Person', 'Dev Test Location', 'Dev Test Entity')
+				OR name LIKE 'Dev Test %'
+		`,
+		[Object.values(ENTITY_IDS)],
+	);
+	const entities = Array.from(new Set([...Object.values(ENTITY_IDS), ...previousDevEntities.rows.map((row) => row.id)]));
 	const uploadFilenames = [
 		'native-text-sample.pdf',
 		'mulder-demo-upload.pdf',
@@ -864,6 +941,11 @@ async function seedJobs(client) {
 async function seedDatabase() {
 	const core = await import(pathToFileURL(CORE_DIST).href);
 	const config = core.loadConfig(CONFIG_PATH);
+
+	requireLocalE2ESeedIntent();
+	assertLocalE2EConfig(config);
+	assertDockerPostgresOwnsConfiguredPort(config);
+
 	const pool = core.getWorkerPool(config.gcp.cloud_sql);
 	await core.runMigrations(pool, MIGRATIONS_DIR);
 
@@ -886,6 +968,7 @@ async function seedDatabase() {
 	}
 }
 
+requireLocalE2ESeedIntent();
 buildPackages();
 writeStorageArtifacts();
 await seedDatabase();


### PR DESCRIPTION
## Summary
- guard the local browser E2E fixture seeding path so it only runs with explicit local intent against the docker-compose Postgres container
- clean up leftover dev-mode entities during fixture reset so local demo state stays deterministic
- polish demo UI copy and responsive layout issues found during manual browser QA

## Verification
- direct `node ./tests/setup/prepare-e2e.mjs` without allow env refuses before writes
- `cd demo && npm run build`
- `cd demo && npm run lint`
- `cd demo && npm run test:e2e` — 14 passed
- desktop/mobile visual QA screenshots captured under `demo/test-results/visual-qa` with no overflow or console findings

## Notes
- This does not delete anything from the production database. Production cleanup should be a separate audited step with a concrete deletion list and explicit confirmation.