### PR TITLE
Add one-command local dev stack

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -40,16 +40,25 @@ export function startApiServer(): ReturnType<typeof serve> {
 	const app = createApp({ logger, config: apiConfig });
 	const port = resolveApiPort(apiConfig);
 	const server = serve({ fetch: app.fetch, port });
+	let shuttingDown = false;
 
 	logger.info({ port }, 'API server started');
 
-	process.once('SIGTERM', () => {
-		server.close();
-	});
+	function shutdown(signal: NodeJS.Signals) {
+		if (shuttingDown) {
+			return;
+		}
 
-	process.once('SIGINT', () => {
-		server.close();
-	});
+		shuttingDown = true;
+		logger.info({ signal }, 'API server shutting down');
+		server.close(() => {
+			process.exit(0);
+		});
+		setTimeout(() => process.exit(0), 3000).unref();
+	}
+
+	process.once('SIGTERM', shutdown);
+	process.once('SIGINT', shutdown);
 
 	return server;
 }

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@mulder/dev",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "node ../../demo/scripts/run-demo-stack.mjs"
+	}
+}

--- a/demo/README.md
+++ b/demo/README.md
@@ -20,12 +20,12 @@ the normal upload/pipeline flow.
 From the repository root:
 
 ```sh
-cd demo
-npm run demo:stack
+pnpm dev
 ```
 
-`demo:stack` performs the full local E2E setup:
+This runs the Turbo `dev` task. It performs the full local E2E setup:
 
+- Starts the local `mulder-postgres` Docker Compose service and waits for it to become healthy.
 - Builds `@mulder/core`, retrieval, pipeline, worker, evidence, API, and CLI packages.
 - Runs migrations and seeds the deterministic fixture corpus.
 - Starts the API on `127.0.0.1:8080`.
@@ -34,6 +34,7 @@ npm run demo:stack
 
 Useful single-process commands:
 
+- `pnpm turbo run dev --filter=@mulder/dev` is the direct Turbo form of `pnpm dev`.
 - `npm run demo:prepare` reseeds the guarded local Docker Postgres fixture and writes `.local/storage` artifacts.
 - `npm run demo:api` starts only the API with the demo E2E config.
 - `npm run demo:worker` starts only the worker.

--- a/demo/scripts/run-demo-stack.mjs
+++ b/demo/scripts/run-demo-stack.mjs
@@ -5,6 +5,56 @@ import { fileURLToPath } from 'node:url';
 const DEMO_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ROOT = resolve(DEMO_DIR, '..');
 const CONFIG = 'demo/tests/config/mulder.e2e.config.yaml';
+const POSTGRES_CONTAINER = process.env.MULDER_E2E_POSTGRES_CONTAINER ?? 'mulder-postgres';
+
+function runDockerComposePostgres() {
+  if (process.env.MULDER_DEMO_SKIP_DOCKER === '1') {
+    console.log('[demo:stack] Skipping Docker startup because MULDER_DEMO_SKIP_DOCKER=1');
+    return;
+  }
+
+  console.log('[demo:stack] Starting local Postgres via docker compose...');
+  const result = spawnSync('docker', ['compose', 'up', '-d', 'postgres'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    console.error('[demo:stack] Failed to start local Postgres. Is Docker running?');
+    process.exit(result.status ?? 1);
+  }
+}
+
+async function waitForPostgres() {
+  if (process.env.MULDER_DEMO_SKIP_DOCKER === '1') {
+    return;
+  }
+
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const result = spawnSync('docker', ['inspect', '--format', '{{.State.Health.Status}}', POSTGRES_CONTAINER], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const status = result.stdout.trim();
+    if (status === 'healthy') {
+      console.log('[demo:stack] Local Postgres is healthy.');
+      return;
+    }
+
+    if (status === 'unhealthy') {
+      console.error(`[demo:stack] Local Postgres reported unhealthy status.`);
+      process.exit(1);
+    }
+
+    await new Promise((resolveTimeout) => setTimeout(resolveTimeout, 1000));
+  }
+
+  console.error('[demo:stack] Timed out waiting for local Postgres to become healthy.');
+  process.exit(1);
+}
 
 function runPrepare() {
   const result = spawnSync('npm', ['run', 'demo:prepare'], {
@@ -56,13 +106,27 @@ function shutdown(code = 0) {
   }
 
   shuttingDown = true;
+  let remaining = children.length;
+  if (remaining === 0) {
+    process.exit(code);
+  }
+
+  let force;
   for (const child of children) {
+    child.once('exit', () => {
+      remaining -= 1;
+      if (remaining === 0) {
+        clearTimeout(force);
+        process.exit(code);
+      }
+    });
+
     if (!child.killed) {
       child.kill('SIGTERM');
     }
   }
 
-  const force = setTimeout(() => {
+  force = setTimeout(() => {
     for (const child of children) {
       if (!child.killed) {
         child.kill('SIGKILL');
@@ -70,13 +134,13 @@ function shutdown(code = 0) {
     }
     process.exit(code);
   }, 3000);
-
-  force.unref();
 }
 
 process.on('SIGINT', () => shutdown(0));
 process.on('SIGTERM', () => shutdown(0));
 
+runDockerComposePostgres();
+await waitForPostgres();
 runPrepare();
 
 children = [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"node": ">=20.0.0"
 	},
 	"scripts": {
+		"dev": "turbo run dev --filter=@mulder/dev",
 		"build": "turbo run build",
 		"typecheck": "turbo run typecheck",
 		"lint": "biome check .",

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -155,7 +155,7 @@ export function createLogger(options?: LoggerOptions): Logger {
 		},
 	};
 
-	if (shouldPrettyPrint(options?.pretty)) {
+	if (level !== 'silent' && shouldPrettyPrint(options?.pretty)) {
 		return pino(
 			pinoOptions,
 			pino.transport({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,8 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
 
+  apps/dev: {}
+
   packages/core:
     dependencies:
       '@google-cloud/documentai':

--- a/tests/specs/05_logger_setup.test.ts
+++ b/tests/specs/05_logger_setup.test.ts
@@ -158,6 +158,27 @@ const { createLogger, createChildLogger, withDuration, ConfigError } = core;`;
 			expect(infoLines.length).toBe(0);
 			expect(warnLines.length).toBe(1);
 		});
+
+		it('does not allocate pretty transports or warn when silent loggers are created repeatedly', () => {
+			const { stdout, stderr, exitCode } = runScriptFull(
+				[
+					importCore,
+					'for (let i = 0; i < 20; i += 1) {',
+					'  createLogger();',
+					'}',
+					'await new Promise(r => setTimeout(r, 100));',
+				],
+				{
+					MULDER_LOG_LEVEL: 'silent',
+					MULDER_LOG_PRETTY: 'true',
+					NODE_OPTIONS: '--trace-warnings',
+				},
+			);
+
+			expect(exitCode).toBe(0);
+			expect(stdout).toBe('');
+			expect(stderr).not.toContain('MaxListenersExceededWarning');
+		});
 	});
 
 	// ─── QA-03: Child logger binds context ───

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "https://turbo.build/schema.json",
 	"tasks": {
+		"dev": {
+			"cache": false,
+			"persistent": true
+		},
 		"build": {
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**"]


### PR DESCRIPTION
## Summary
- add a Turbo-backed `pnpm dev` entrypoint through `@mulder/dev`
- make the local demo stack start/wait for Docker Postgres before guarded fixture seeding
- fix API shutdown so Ctrl-C does not orphan the local API process
- avoid pino-pretty listener warnings when local dev runs with `MULDER_LOG_LEVEL=silent`

## Verification
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run tests/specs/05_logger_setup.test.ts`
- `cd demo && npm run build`
- `pnpm dev` real run: Docker Postgres healthy, API `/api/health` 200, Vite 200, unauthenticated session 401
- Browser smoke: login with local owner fixture, Desk renders, zero console errors
- Ctrl-C cleanup: no API/Vite/worker listeners left on 8080/5173
