### PR TITLE
[Pipeline] Image ingestion on layout path — M9-J3

### DIFF
--- a/apps/api/src/lib/uploads.ts
+++ b/apps/api/src/lib/uploads.ts
@@ -21,6 +21,12 @@ import type {
 	InitiateDocumentUploadRequest,
 	InitiateDocumentUploadResponse,
 } from '../routes/uploads.schemas.js';
+import {
+	canonicalUploadExtensionForContentType,
+	canonicalUploadExtensionForFilename,
+	isSupportedOriginalStoragePath,
+	type UploadStorageExtension,
+} from '../routes/uploads.schemas.js';
 
 interface UploadContext {
 	config: MulderConfig;
@@ -33,7 +39,6 @@ type Queryable = pg.Pool | pg.PoolClient;
 let cachedContext: UploadContext | null = null;
 let cachedConfigPath: string | null = null;
 
-const PDF_CONTENT_TYPE = 'application/pdf';
 const FINALIZE_JOB_TYPE = 'document_upload_finalize';
 
 function resolveConfigPath(): string {
@@ -79,18 +84,39 @@ function maxUploadBytes(config: MulderConfig): number {
 	return config.ingestion.max_file_size_mb * 1024 * 1024;
 }
 
-function ensurePdfInput(input: { filename: string; contentType: string }): void {
-	if (!input.filename.toLowerCase().endsWith('.pdf')) {
-		throw new MulderError('Filename must end with .pdf', 'VALIDATION_ERROR', {
+function resolveUploadInput(input: { filename: string; contentType: string }): {
+	mediaType: string;
+	storageExtension: UploadStorageExtension;
+} {
+	const extension = canonicalUploadExtensionForFilename(input.filename);
+	const contentTypeExtension = canonicalUploadExtensionForContentType(input.contentType);
+
+	if (!extension) {
+		throw new MulderError('Filename must end with .pdf, .png, .jpg, .jpeg, .tif, or .tiff', 'VALIDATION_ERROR', {
 			context: { filename: input.filename },
 		});
 	}
 
-	if (input.contentType.toLowerCase() !== PDF_CONTENT_TYPE) {
-		throw new MulderError('Only application/pdf uploads are supported', 'VALIDATION_ERROR', {
+	if (!contentTypeExtension) {
+		throw new MulderError('Only PDF, PNG, JPEG, and TIFF uploads are supported', 'VALIDATION_ERROR', {
 			context: { content_type: input.contentType },
 		});
 	}
+
+	if (extension !== contentTypeExtension) {
+		throw new MulderError('Upload filename extension and content_type do not match', 'VALIDATION_ERROR', {
+			context: {
+				filename: input.filename,
+				content_type: input.contentType,
+			},
+		});
+	}
+
+	const normalizedContentType = input.contentType.split(';')[0]?.trim().toLowerCase() ?? input.contentType;
+	return {
+		mediaType: normalizedContentType,
+		storageExtension: extension,
+	};
 }
 
 async function assertNoInFlightFinalizeJob(pool: Queryable, sourceId: string): Promise<void> {
@@ -123,7 +149,7 @@ export async function initiateDocumentUpload(
 		size_bytes: input.size_bytes,
 	});
 
-	ensurePdfInput({ filename: input.filename, contentType: input.content_type });
+	const uploadInput = resolveUploadInput({ filename: input.filename, contentType: input.content_type });
 	const maxBytes = maxUploadBytes(config);
 	if (input.size_bytes > maxBytes) {
 		throw new MulderError(
@@ -140,9 +166,9 @@ export async function initiateDocumentUpload(
 	}
 
 	const sourceId = randomUUID();
-	const storagePath = `raw/${sourceId}/original.pdf`;
+	const storagePath = `raw/${sourceId}/original.${uploadInput.storageExtension}`;
 	const upload = await services.storage.createUploadSession(storagePath, {
-		contentType: input.content_type,
+		contentType: uploadInput.mediaType,
 		expectedSizeBytes: input.size_bytes,
 	});
 
@@ -262,7 +288,7 @@ export async function handleDevUploadProxy(
 		throw new MulderError('Dev upload proxy is unavailable', 'UPLOAD_PROXY_FORBIDDEN');
 	}
 
-	if (!storagePath.startsWith('raw/') || !storagePath.endsWith('/original.pdf')) {
+	if (!isSupportedOriginalStoragePath(storagePath)) {
 		throw new MulderError('Invalid storage path for dev upload', 'VALIDATION_ERROR', {
 			context: { storage_path: storagePath },
 		});

--- a/apps/api/src/routes/uploads.schemas.ts
+++ b/apps/api/src/routes/uploads.schemas.ts
@@ -1,5 +1,44 @@
 import { z } from 'zod';
 
+const SUPPORTED_UPLOAD_EXTENSIONS = new Map([
+	['pdf', 'pdf'],
+	['png', 'png'],
+	['jpg', 'jpg'],
+	['jpeg', 'jpg'],
+	['tif', 'tiff'],
+	['tiff', 'tiff'],
+]);
+
+const SUPPORTED_UPLOAD_CONTENT_TYPES = new Map([
+	['application/pdf', 'pdf'],
+	['image/png', 'png'],
+	['image/jpeg', 'jpg'],
+	['image/tiff', 'tiff'],
+]);
+
+export type UploadStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff';
+
+function filenameExtension(filename: string): string {
+	const basename = filename.split(/[\\/]/).pop() ?? filename;
+	const dotIndex = basename.lastIndexOf('.');
+	return dotIndex >= 0 ? basename.slice(dotIndex + 1).toLowerCase() : '';
+}
+
+export function canonicalUploadExtensionForFilename(filename: string): UploadStorageExtension | null {
+	const extension = SUPPORTED_UPLOAD_EXTENSIONS.get(filenameExtension(filename));
+	return extension === 'pdf' || extension === 'png' || extension === 'jpg' || extension === 'tiff' ? extension : null;
+}
+
+export function canonicalUploadExtensionForContentType(contentType: string): UploadStorageExtension | null {
+	const normalized = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+	const extension = SUPPORTED_UPLOAD_CONTENT_TYPES.get(normalized);
+	return extension === 'pdf' || extension === 'png' || extension === 'jpg' || extension === 'tiff' ? extension : null;
+}
+
+export function isSupportedOriginalStoragePath(storagePath: string): boolean {
+	return /^raw\/[^/]+\/original\.(pdf|png|jpg|tiff)$/i.test(storagePath);
+}
+
 export const UploadTransportSchema = z.enum(['gcs_resumable', 'dev_proxy']);
 
 export const InitiateDocumentUploadRequestSchema = z.object({
@@ -37,7 +76,17 @@ export const CompleteDocumentUploadRequestSchema = z
 		start_pipeline: z.boolean().optional().default(true),
 	})
 	.superRefine((value, ctx) => {
-		const expectedPath = `raw/${value.source_id}/original.pdf`;
+		const canonicalExtension = canonicalUploadExtensionForFilename(value.filename);
+		if (!canonicalExtension) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['filename'],
+				message: 'filename must end with .pdf, .png, .jpg, .jpeg, .tif, or .tiff',
+			});
+			return;
+		}
+
+		const expectedPath = `raw/${value.source_id}/original.${canonicalExtension}`;
 		if (value.storage_path !== expectedPath) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,

--- a/apps/cli/src/commands/ingest.ts
+++ b/apps/cli/src/commands/ingest.ts
@@ -13,7 +13,7 @@ import { closeAllPools, createLogger, createServiceRegistry, getWorkerPool, load
 import { executeIngest } from '@mulder/pipeline';
 import type { Command } from 'commander';
 import {
-	collectPdfSourceProfiles,
+	collectIngestSourceProfiles,
 	estimateForSteps,
 	printCostEstimate,
 	promptYesNo,
@@ -43,8 +43,8 @@ interface IngestOptions {
 export function registerIngestCommands(program: Command): void {
 	program
 		.command('ingest')
-		.description('Ingest PDF(s) — file or directory')
-		.argument('<path>', 'path to a PDF file or directory containing PDFs')
+		.description('Ingest PDFs or supported images — file or directory')
+		.argument('<path>', 'path to a supported file or directory containing supported files')
 		.option('--dry-run', 'validate without uploading or creating DB records')
 		.option('--tag <tag>', 'tag ingested sources (repeatable)', collect, [])
 		.option('--cost-estimate', 'show an estimated downstream pipeline cost before executing')
@@ -52,14 +52,14 @@ export function registerIngestCommands(program: Command): void {
 			'after',
 			`
 Examples:
-  $ mulder ingest ./my-pdfs/                       # Ingest every PDF in a directory
+  $ mulder ingest ./incoming/                      # Ingest supported files in a directory
   $ mulder ingest paper.pdf --tag review --tag q1  # Tag a single ingest with two tags
   $ mulder ingest paper.pdf --dry-run              # Validate without writing to GCS or the DB`,
 		)
 		.action(
 			withErrorHandler(async (inputPath: string, options: IngestOptions) => {
 				const config = loadConfig();
-				const sourceProfiles = await collectPdfSourceProfiles(inputPath);
+				const sourceProfiles = await collectIngestSourceProfiles(inputPath);
 				const estimate = estimateForSteps({
 					mode: 'ingest',
 					sourceProfiles,

--- a/apps/cli/src/lib/cost-estimate.ts
+++ b/apps/cli/src/lib/cost-estimate.ts
@@ -60,46 +60,62 @@ export const resolvePdfFiles = resolveIngestFiles;
 export async function collectIngestSourceProfiles(inputPath: string): Promise<EstimatedSourceProfile[]> {
 	const ingestFiles = await resolveIngestFiles(inputPath);
 	const sourceProfiles: EstimatedSourceProfile[] = [];
+	const inputStats = await stat(resolve(inputPath)).catch(() => null);
+	const allowPartial = inputStats?.isDirectory() ?? false;
+	let firstError: Error | null = null;
 
 	for (const filePath of ingestFiles) {
-		const buffer = await readFile(filePath);
-		const detection = detectSourceType(buffer, filePath);
-		if (!detection) {
+		try {
+			const buffer = await readFile(filePath);
+			const detection = detectSourceType(buffer, filePath);
+			if (!detection) {
+				throw new IngestError(
+					`Unsupported or unknown source format for ${filePath}`,
+					INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+					{
+						context: { path: filePath },
+					},
+				);
+			}
+
+			if (detection.sourceType === 'pdf') {
+				const nativeText = await detectNativeText(buffer);
+				sourceProfiles.push({
+					filename: filePath,
+					pageCount: nativeText.pageCount,
+					nativeTextRatio: nativeText.nativeTextRatio,
+				});
+				continue;
+			}
+
+			if (detection.sourceType === 'image') {
+				sourceProfiles.push({
+					filename: filePath,
+					pageCount: 1,
+					nativeTextRatio: 0,
+				});
+				continue;
+			}
+
 			throw new IngestError(
-				`Unsupported or unknown source format for ${filePath}`,
-				INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+				`Unsupported source type "${detection.sourceType}" for ${filePath}; only pdf and image are supported in this step`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
 				{
-					context: { path: filePath },
+					context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
 				},
 			);
+		} catch (cause: unknown) {
+			if (!allowPartial) {
+				throw cause;
+			}
+			if (!firstError) {
+				firstError = cause instanceof Error ? cause : new Error(String(cause));
+			}
 		}
+	}
 
-		if (detection.sourceType === 'pdf') {
-			const nativeText = await detectNativeText(buffer);
-			sourceProfiles.push({
-				filename: filePath,
-				pageCount: nativeText.pageCount,
-				nativeTextRatio: nativeText.nativeTextRatio,
-			});
-			continue;
-		}
-
-		if (detection.sourceType === 'image') {
-			sourceProfiles.push({
-				filename: filePath,
-				pageCount: 1,
-				nativeTextRatio: 0,
-			});
-			continue;
-		}
-
-		throw new IngestError(
-			`Unsupported source type "${detection.sourceType}" for ${filePath}; only pdf and image are supported in this step`,
-			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
-			{
-				context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
-			},
-		);
+	if (sourceProfiles.length === 0 && firstError) {
+		throw firstError;
 	}
 
 	return sourceProfiles;

--- a/apps/cli/src/lib/cost-estimate.ts
+++ b/apps/cli/src/lib/cost-estimate.ts
@@ -12,7 +12,7 @@ import {
 	type ReprocessableStep,
 	type Source,
 } from '@mulder/core';
-import type { PipelineStepName } from '@mulder/pipeline';
+import { detectSourceType, isSupportedIngestFilename, type PipelineStepName } from '@mulder/pipeline';
 
 interface ReprocessEstimateSourcePlan {
 	sourceId: string;
@@ -21,7 +21,7 @@ interface ReprocessEstimateSourcePlan {
 
 const ESTIMATE_STEP_ORDER: readonly EstimatedStep[] = ['extract', 'segment', 'enrich', 'ground', 'embed', 'graph'];
 
-export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
+export async function resolveIngestFiles(inputPath: string): Promise<string[]> {
 	const resolved = resolve(inputPath);
 	const stats = await stat(resolved).catch(() => null);
 
@@ -37,13 +37,13 @@ export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
 
 	if (stats.isDirectory()) {
 		const entries = await readdir(resolved, { recursive: true });
-		const pdfFiles: string[] = [];
+		const ingestFiles: string[] = [];
 		for (const entry of entries) {
-			if (entry.toLowerCase().endsWith('.pdf')) {
-				pdfFiles.push(join(resolved, entry));
+			if (isSupportedIngestFilename(entry)) {
+				ingestFiles.push(join(resolved, entry));
 			}
 		}
-		return pdfFiles.sort();
+		return ingestFiles.sort();
 	}
 
 	throw new IngestError(
@@ -55,22 +55,57 @@ export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
 	);
 }
 
-export async function collectPdfSourceProfiles(inputPath: string): Promise<EstimatedSourceProfile[]> {
-	const pdfFiles = await resolvePdfFiles(inputPath);
+export const resolvePdfFiles = resolveIngestFiles;
+
+export async function collectIngestSourceProfiles(inputPath: string): Promise<EstimatedSourceProfile[]> {
+	const ingestFiles = await resolveIngestFiles(inputPath);
 	const sourceProfiles: EstimatedSourceProfile[] = [];
 
-	for (const filePath of pdfFiles) {
+	for (const filePath of ingestFiles) {
 		const buffer = await readFile(filePath);
-		const nativeText = await detectNativeText(buffer);
-		sourceProfiles.push({
-			filename: filePath,
-			pageCount: nativeText.pageCount,
-			nativeTextRatio: nativeText.nativeTextRatio,
-		});
+		const detection = detectSourceType(buffer, filePath);
+		if (!detection) {
+			throw new IngestError(
+				`Unsupported or unknown source format for ${filePath}`,
+				INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+				{
+					context: { path: filePath },
+				},
+			);
+		}
+
+		if (detection.sourceType === 'pdf') {
+			const nativeText = await detectNativeText(buffer);
+			sourceProfiles.push({
+				filename: filePath,
+				pageCount: nativeText.pageCount,
+				nativeTextRatio: nativeText.nativeTextRatio,
+			});
+			continue;
+		}
+
+		if (detection.sourceType === 'image') {
+			sourceProfiles.push({
+				filename: filePath,
+				pageCount: 1,
+				nativeTextRatio: 0,
+			});
+			continue;
+		}
+
+		throw new IngestError(
+			`Unsupported source type "${detection.sourceType}" for ${filePath}; only pdf and image are supported in this step`,
+			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+			{
+				context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
+			},
+		);
 	}
 
 	return sourceProfiles;
 }
+
+export const collectPdfSourceProfiles = collectIngestSourceProfiles;
 
 export function collectDbSourceProfiles(sources: Source[]): EstimatedSourceProfile[] {
 	return sources.map((source) => ({

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,7 +253,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 |--------|------|------|------|
 | 🟢 | J1 | Source type discriminator — `source_type` column, JSONB `format_metadata`, magic-byte detection | §4.3 (sources table), §2.1 |
 | 🟢 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
-| ⚪ | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
+| 🟡 | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
 | ⚪ | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
 | ⚪ | J5 | DOCX ingestion — Office document extraction via `mammoth` / `docx-parser` | §2.1 |
 | ⚪ | J6 | CSV/Excel ingestion — tabular data → Markdown tables, row-level entity hints | §2.1 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,7 +253,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 |--------|------|------|------|
 | 🟢 | J1 | Source type discriminator — `source_type` column, JSONB `format_metadata`, magic-byte detection | §4.3 (sources table), §2.1 |
 | 🟢 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
-| 🟡 | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
+| 🟢 | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
 | ⚪ | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
 | ⚪ | J5 | DOCX ingestion — Office document extraction via `mammoth` / `docx-parser` | §2.1 |
 | ⚪ | J6 | CSV/Excel ingestion — tabular data → Markdown tables, row-level entity hints | §2.1 |

--- a/docs/specs/87_image_ingestion_layout_path.spec.md
+++ b/docs/specs/87_image_ingestion_layout_path.spec.md
@@ -1,0 +1,200 @@
+---
+spec: "87"
+title: "Image Ingestion on the Layout Extraction Path"
+roadmap_step: M9-J3
+functional_spec: ["§2.1", "§2.2", "§3.1", "§3.2", "§4.5"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/231"
+created: 2026-04-30
+---
+
+# Spec 87: Image Ingestion on the Layout Extraction Path
+
+## 1. Objective
+
+Add M9-J3 image ingestion so PNG, JPEG, and TIFF files can enter Mulder as first-class `image` sources and continue through the existing layout-oriented pipeline. Images behave like single-page layout sources: ingest detects the image format from magic bytes, persists image format metadata, extract sends the original image through the service abstraction to Document AI / Gemini Vision, and downstream orchestration keeps `segment` in the executable path.
+
+This fulfills the M9 roadmap requirement for image ingestion while preserving the functional-spec contracts from `§2.1` (ingest creates source records and storage objects), `§2.2` (extract writes layout JSON and page images), `§3.1` / `§3.2` (images remain on the layout path), and `§4.5` (pipeline code calls service interfaces rather than raw GCP clients).
+
+## 2. Boundaries
+
+**Roadmap step:** M9-J3 - Image ingestion: JPG, PNG, TIFF via Document AI / Gemini Vision.
+
+**Base branch:** `milestone/9`. This spec is delivered to the M9 integration branch, not directly to `main`.
+
+**Target files:**
+
+- `packages/pipeline/src/ingest/source-type.ts`
+- `packages/pipeline/src/ingest/types.ts`
+- `packages/pipeline/src/ingest/index.ts`
+- `packages/pipeline/src/extract/index.ts`
+- `packages/pipeline/src/extract/types.ts`
+- `packages/core/src/shared/services.ts`
+- `packages/core/src/shared/services.dev.ts`
+- `packages/core/src/shared/services.gcp.ts`
+- `apps/cli/src/commands/ingest.ts`
+- `apps/cli/src/lib/cost-estimate.ts`
+- `apps/api/src/routes/uploads.schemas.ts`
+- `apps/api/src/lib/uploads.ts`
+- `packages/worker/src/worker.types.ts`
+- `packages/worker/src/dispatch.ts`
+- `tests/specs/87_image_ingestion_layout_path.test.ts`
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Accept PNG, JPEG/JPG, and TIFF/TIF files in CLI ingest.
+- Expand directory ingest discovery so directories can include PDFs and supported image files.
+- Preserve magic-byte-first detection from Spec 85; misleading image extensions must not override decisive PDF or image magic bytes.
+- Store image sources with `source_type = 'image'`, `page_count = 1`, `has_native_text = false`, `native_text_ratio = 0`, and `format_metadata` containing at least `media_type`, original extension, byte size, and best-effort `width` / `height` when cheaply available.
+- Upload image originals under `raw/{source_id}/original.{ext}` with the detected media type.
+- Keep duplicate detection based on the existing file hash path.
+- Keep PDF ingest output and persistence backward compatible.
+- Update cost estimation so images are counted as one scanned/layout page rather than being parsed as PDFs.
+- Update API/browser upload initiation, completion validation, dev upload proxy, and worker finalization so supported image uploads reach the same source record and pipeline job path as CLI ingests.
+- Update the Document AI service interface to accept a media type while defaulting existing PDF callers to `application/pdf`.
+- Update extract so image sources always use the Document AI layout path, pass the stored image media type through the service interface, write `layout.json`, write a usable `pages/page-001.png` page image when possible, mark the source extracted, and leave `segment` as the next executable step.
+- Keep the shared step planner behavior from Spec 86: `image` is a layout source and must not skip `segment`.
+
+**Out of scope:**
+
+- Text, DOCX, spreadsheet, email, URL ingestion. Those remain M9-J4 through M9-J10.
+- URL rendering, robots/rate-limit lifecycle, and cross-format deduplication.
+- Multi-page TIFF splitting beyond treating the uploaded image as one layout source unless Document AI returns multiple pages.
+- New database columns or changes to the `sources.source_type` enum; Spec 85 already added `image`.
+- New direct GCP client usage in pipeline, CLI, API, or worker code.
+- Replacing the Segment step or changing story/entity/chunk contracts.
+
+**Architectural constraints:**
+
+- PostgreSQL remains authoritative for source identity and pipeline state.
+- Firestore remains write-only observability.
+- Service abstractions remain the only boundary for Document AI, storage, Firestore, and Gemini calls.
+- Unsupported or unknown files must fail before source creation.
+- Existing PDF ingest, extract, upload, and pipeline behavior is the compatibility baseline.
+
+## 3. Dependencies
+
+**Requires:**
+
+- M9-J1 / Spec 85: `source_type`, `format_metadata`, and magic-byte detection.
+- M9-J2 / Spec 86: source-type-aware pipeline planning where `image` remains a layout source.
+- M2-B4 / Spec 16 and M3-C1 / Spec 19: existing PDF ingest and extract implementation.
+- M7 upload/worker follow-ups that introduced `document_upload_finalize` jobs.
+
+**Blocks:**
+
+- M9-J11 format-aware extract routing.
+- M9-J13 multi-format golden tests.
+
+This step does not block pre-structured format ingestion, but it establishes the first non-PDF layout source.
+
+## 4. Blueprint
+
+### Phase 1: Shared image format helpers
+
+1. Keep `detectSourceType()` as the source of truth for image detection.
+2. Add helper behavior where needed to derive:
+   - canonical media type (`image/png`, `image/jpeg`, `image/tiff`)
+   - canonical storage extension (`png`, `jpg`, `tiff`)
+   - best-effort dimensions for PNG and JPEG from file headers; TIFF dimensions may be omitted if not cheaply available.
+3. Do not add a heavyweight image dependency unless the repository already has an appropriate runtime library available.
+
+### Phase 2: CLI ingest
+
+1. Replace PDF-only file discovery with supported-ingest-file discovery for PDFs plus PNG/JPEG/TIFF.
+2. Split per-file ingest after source detection:
+   - PDF follows the existing metadata, page-count, native-text, storage, duplicate, and output behavior.
+   - Image follows the shared file-size and duplicate gates, stores one-page image metadata, uploads using the detected media type, and creates the source with image fields.
+3. Keep the visible CLI table stable while allowing `Type = image`, `Pages = 1`, and `Native Text = no`.
+4. Keep `--dry-run` validation from creating source rows or storage objects.
+5. Update CLI cost estimation to include images as one scanned/layout page and to avoid running PDF native-text detection on images.
+
+### Phase 3: API/browser upload path
+
+1. Allow upload initiation for supported image filenames/content types in addition to PDFs.
+2. Generate storage paths with the canonical original extension.
+3. Relax completion schema validation from `original.pdf` to the supported `original.{ext}` path for the requested source.
+4. Keep size checks and in-flight-finalize conflict checks unchanged.
+5. Include enough payload or storage metadata for the worker to validate the uploaded bytes by magic bytes before creating a source row.
+6. Preserve PDF upload behavior, including existing path shape for PDFs.
+
+### Phase 4: Worker finalization
+
+1. Replace PDF-only finalize validation with `detectSourceType()`.
+2. For PDFs, preserve the current PDF metadata/native-text path.
+3. For images, persist the same source fields as CLI ingest, upsert the ingest source step, emit Firestore observability with `sourceType: image`, and enqueue an `extract` job when `startPipeline` is true.
+4. Reject recognized but unsupported non-image/non-PDF types with the existing unsupported source type error family.
+5. Preserve duplicate cleanup behavior for image hashes.
+
+### Phase 5: Extract image sources
+
+1. Load the source row and branch by `source.sourceType`.
+2. For `pdf`, preserve all current extraction paths.
+3. For `image`, always use the Document AI path:
+   - download the original image
+   - read `formatMetadata.media_type` or fall back to source detection
+   - call `services.documentAi.processDocument()` with that media type
+   - parse Document AI layout output using the existing parser
+   - run Gemini Vision fallback when low-confidence page text and a page image are available
+   - write layout artifacts to `extracted/{source_id}/`
+4. If Document AI returns page images, use them. Otherwise, write a normalized PNG page image for PNG/JPEG when possible; if normalization is unavailable, keep the source extracted with layout JSON and no page image rather than failing solely because of a preview byproduct.
+5. Update service interface implementations so GCP passes the requested media type and dev mode remains deterministic.
+
+### Phase 6: QA and compatibility
+
+1. Add `tests/specs/87_image_ingestion_layout_path.test.ts`.
+2. Reuse existing test helpers for CLI subprocesses, SQL checks, and dev storage where possible.
+3. Run the existing PDF ingest/extract/pipeline planner tests that could regress from broadening the file discovery or service interface.
+
+## 5. QA Contract
+
+**QA-01: CLI dry-run accepts image sources without persistence**
+
+Given a valid PNG, JPEG, and TIFF fixture, when `mulder ingest --dry-run` is run for each file, then the command exits 0, prints `Type` as `image`, prints `Pages` as `1`, and no `sources` row or storage object is created.
+
+**QA-02: CLI image ingest persists image metadata**
+
+Given a valid PNG file, when `mulder ingest` runs, then the command exits 0 and the database source row has `source_type = 'image'`, `page_count = 1`, `has_native_text = false`, `native_text_ratio = 0`, a `raw/{source_id}/original.png` storage path, and `format_metadata.media_type = 'image/png'`.
+
+**QA-03: Directory ingest discovers PDFs and images**
+
+Given a directory containing one PDF and one PNG, when `mulder ingest --dry-run <dir>` runs, then both files appear in the output with their respective source types and the command exits 0.
+
+**QA-04: Magic bytes remain authoritative**
+
+Given a PNG file renamed to `.pdf`, when `mulder ingest --dry-run` runs, then the command reports `image`, not `pdf`, and validates as an image source. Given a PDF renamed to `.png`, it still reports `pdf`.
+
+**QA-05: Duplicate image ingest returns the existing source**
+
+Given the same PNG file is ingested twice, when the second ingest runs, then it reports duplicate status, does not create a second source row for the same file hash, and preserves `source_type = 'image'`.
+
+**QA-06: Image extract writes layout artifacts and keeps layout path**
+
+Given an ingested image source in dev mode, when `mulder extract <source_id>` runs, then the source reaches `extracted`, `extracted/{source_id}/layout.json` exists, at least one page is represented in the extraction result, and the shared pipeline planner still includes `segment` for source type `image`.
+
+**QA-07: API upload accepts image media types**
+
+Given an upload initiate request for `scan.png` with `content_type = image/png`, when the upload is completed and the finalize job runs, then a source row is created with `source_type = 'image'` and an extract job is queued when `start_pipeline` is true.
+
+**QA-08: Unsupported formats still fail before persistence**
+
+Given a `.txt` file, when `mulder ingest` or upload finalization processes it during M9-J3, then it fails with an unsupported source type message and no source row is created.
+
+**QA-09: Existing PDF behavior remains green**
+
+Given the existing Spec 16, Spec 19, Spec 85, and Spec 86 PDF-oriented tests, when they run after this change, then PDF ingest, extract, duplicate handling, upload finalization, and pipeline planning remain compatible.
+
+## 5b. CLI Test Matrix
+
+| Command | Input | Expected |
+| --- | --- | --- |
+| `mulder ingest --dry-run <tmp>/scan.png` | PNG image | Exit 0; output includes `image`, `Pages` = `1`; no DB/storage persistence. |
+| `mulder ingest <tmp>/scan.png` | PNG image | Exit 0; DB row has `source_type = image`; storage path ends in `original.png`. |
+| `mulder ingest --dry-run <tmp>/mixed-dir` | Directory with PDF + PNG | Exit 0; output includes both `pdf` and `image`. |
+| `mulder ingest --dry-run <tmp>/png-renamed.pdf` | PNG magic with `.pdf` extension | Exit 0; output reports `image`, proving magic bytes win. |
+| `mulder extract <image-source-id>` | Ingested image source | Exit 0; layout artifacts written; source status becomes `extracted`. |
+
+## 6. Cost Considerations
+
+Images use the scanned/layout extraction path and therefore may call paid Document AI and Gemini Vision services during extract. Ingest itself remains local plus storage/database work. CLI cost estimation must count each image as one scanned/layout page so users see downstream extract/segment/enrich/embed cost before a large image batch runs. Dev and test mode must continue to use deterministic service implementations without GCP cost.

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -95,6 +95,15 @@ function slugify(value: string): string {
 	);
 }
 
+function contentTypeForBucketPath(bucketPath: string): string {
+	const lowerPath = bucketPath.toLowerCase();
+	if (lowerPath.endsWith('.pdf')) return 'application/pdf';
+	if (lowerPath.endsWith('.png')) return 'image/png';
+	if (lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) return 'image/jpeg';
+	if (lowerPath.endsWith('.tif') || lowerPath.endsWith('.tiff')) return 'image/tiff';
+	return 'application/octet-stream';
+}
+
 type GroundingFixtureScenario = 'accepted' | 'invalid-coordinates' | 'invalid-date';
 
 function resolveGroundingFixtureScenario(entityName: string): GroundingFixtureScenario {
@@ -178,7 +187,7 @@ class DevStorageService implements StorageService {
 		const stats = statSync(fullPath);
 		return {
 			sizeBytes: stats.size,
-			contentType: bucketPath.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 'application/octet-stream',
+			contentType: contentTypeForBucketPath(bucketPath),
 		};
 	}
 
@@ -234,8 +243,12 @@ class DevDocumentAiService implements DocumentAiService {
 		this.logger = logger;
 	}
 
-	async processDocument(_pdfContent: Buffer, sourceId: string): Promise<DocumentAiResult> {
-		this.logger.debug({ sourceId }, 'DevDocumentAiService: returning fixture data');
+	async processDocument(
+		documentContent: Buffer,
+		sourceId: string,
+		mediaType = 'application/pdf',
+	): Promise<DocumentAiResult> {
+		this.logger.debug({ sourceId, mediaType }, 'DevDocumentAiService: returning fixture data');
 
 		// Look for a layout.json in the source's fixture directory
 		const layoutPath = join(this.basePath, sourceId, 'layout.json');
@@ -255,6 +268,22 @@ class DevDocumentAiService implements DocumentAiService {
 			}
 
 			return { document, pageImages };
+		}
+
+		if (mediaType.startsWith('image/')) {
+			const pageImages = mediaType === 'image/png' ? [documentContent] : [];
+			return {
+				document: {
+					text: '',
+					pages: [
+						{
+							layout: { confidence: 0.9 },
+							paragraphs: [],
+						},
+					],
+				},
+				pageImages,
+			};
 		}
 
 		// Return empty result if no fixture exists

--- a/packages/core/src/shared/services.gcp.ts
+++ b/packages/core/src/shared/services.gcp.ts
@@ -234,7 +234,7 @@ class GcpStorageService implements StorageService {
 
 /**
  * Document AI Layout Parser implementation.
- * Processes PDF documents and returns structured layout data with page images.
+ * Processes layout-oriented documents and returns structured layout data with page images.
  */
 class GcpDocumentAiService implements DocumentAiService {
 	constructor(
@@ -243,16 +243,23 @@ class GcpDocumentAiService implements DocumentAiService {
 		private readonly logger: Logger,
 	) {}
 
-	async processDocument(pdfContent: Buffer, sourceId: string): Promise<DocumentAiResult> {
+	async processDocument(
+		documentContent: Buffer,
+		sourceId: string,
+		mediaType = 'application/pdf',
+	): Promise<DocumentAiResult> {
 		return withRetry(
 			async () => {
-				this.logger.info({ sourceId, processorName: this.processorName }, 'GcpDocumentAiService: processing');
+				this.logger.info(
+					{ sourceId, processorName: this.processorName, mediaType },
+					'GcpDocumentAiService: processing',
+				);
 
 				const request: protos.google.cloud.documentai.v1.IProcessRequest = {
 					name: this.processorName,
 					rawDocument: {
-						content: pdfContent.toString('base64'),
-						mimeType: 'application/pdf',
+						content: documentContent.toString('base64'),
+						mimeType: mediaType,
 					},
 				};
 

--- a/packages/core/src/shared/services.ts
+++ b/packages/core/src/shared/services.ts
@@ -85,11 +85,11 @@ export interface DocumentAiResult {
 
 /**
  * Abstraction over Google Document AI Layout Parser.
- * Processes a PDF document and returns structured layout data with spatial information.
+ * Processes a layout-oriented document and returns structured layout data with spatial information.
  */
 export interface DocumentAiService {
-	/** Process a PDF document and return structured layout data + page images. */
-	processDocument(pdfContent: Buffer, sourceId: string): Promise<DocumentAiResult>;
+	/** Process a layout-oriented document and return structured layout data + page images. */
+	processDocument(documentContent: Buffer, sourceId: string, mediaType?: string): Promise<DocumentAiResult>;
 }
 
 // ────────────────────────────────────────────────────────────

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -27,6 +27,7 @@ import {
 } from '@mulder/core';
 import { PDFParse } from 'pdf-parse';
 import type pg from 'pg';
+import { detectSourceType, isSupportedImageMediaType } from '../ingest/source-type.js';
 import { layoutToMarkdown } from './layout-to-markdown.js';
 import type { ExtractInput, ExtractionData, ExtractResult, LayoutBlock, LayoutDocument, LayoutPage } from './types.js';
 
@@ -117,6 +118,53 @@ async function renderPageImages(pdfBuffer: Buffer, logger: Logger): Promise<Buff
 		logger.warn({ err: error }, 'PDF page rendering failed — downstream steps will run text-only');
 		return [];
 	}
+}
+
+async function renderImagePageImage(imageBuffer: Buffer, mediaType: string, logger: Logger): Promise<Buffer | null> {
+	if (mediaType === 'image/png') {
+		return imageBuffer;
+	}
+
+	if (mediaType !== 'image/jpeg') {
+		return null;
+	}
+
+	try {
+		const { createCanvas, loadImage } = await import('@napi-rs/canvas');
+		const image = await loadImage(imageBuffer);
+		const canvas = createCanvas(image.width, image.height);
+		const context = canvas.getContext('2d');
+		context.drawImage(image, 0, 0);
+		return canvas.toBuffer('image/png');
+	} catch (error: unknown) {
+		logger.warn({ err: error }, 'Image preview rendering failed — continuing without page image');
+		return null;
+	}
+}
+
+function readStoredMediaType(formatMetadata: Record<string, unknown>): string | null {
+	return typeof formatMetadata.media_type === 'string' ? formatMetadata.media_type : null;
+}
+
+function resolveSourceMediaType(
+	source: { filename: string; sourceType: string; formatMetadata: Record<string, unknown> },
+	buffer: Buffer,
+): string | null {
+	if (source.sourceType === 'pdf') {
+		return 'application/pdf';
+	}
+
+	const storedMediaType = readStoredMediaType(source.formatMetadata);
+	if (storedMediaType && isSupportedImageMediaType(storedMediaType)) {
+		return storedMediaType;
+	}
+
+	const detection = detectSourceType(buffer, source.filename);
+	if (detection?.sourceType === 'image' && isSupportedImageMediaType(detection.mediaType)) {
+		return detection.mediaType;
+	}
+
+	return null;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -560,25 +608,50 @@ export async function execute(
 		};
 	} else {
 		// ── Path A or B: Full extraction ────────────────────
-		// 3. Download PDF
+		if (source.sourceType !== 'pdf' && source.sourceType !== 'image') {
+			throw new ExtractError(
+				`Source type "${source.sourceType}" is not supported by the layout extract step`,
+				EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
+				{ context: { sourceId: input.sourceId, sourceType: source.sourceType } },
+			);
+		}
+
+		// 3. Download source original
 		const storagePath = source.storagePath;
-		let pdfBuffer: Buffer;
+		let sourceBuffer: Buffer;
 		try {
-			pdfBuffer = await services.storage.download(storagePath);
+			sourceBuffer = await services.storage.download(storagePath);
 		} catch (cause: unknown) {
 			throw new ExtractError(
-				`Failed to download PDF for source ${input.sourceId}`,
+				`Failed to download source original for source ${input.sourceId}`,
 				EXTRACT_ERROR_CODES.EXTRACT_STORAGE_FAILED,
 				{ cause, context: { sourceId: input.sourceId, storagePath } },
 			);
 		}
 
 		// 4. Choose extraction path
-		const nativeTextRatio = source.nativeTextRatio;
+		const sourceMediaType = resolveSourceMediaType(source, sourceBuffer);
+		if (!sourceMediaType) {
+			throw new ExtractError(
+				`Unable to resolve image media type for source ${input.sourceId}`,
+				EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
+				{ context: { sourceId: input.sourceId, sourceType: source.sourceType } },
+			);
+		}
+		const nativeTextRatio = source.sourceType === 'image' ? 0 : source.nativeTextRatio;
 		const threshold = config.extraction.native_text_threshold;
-		const isNativePath = nativeTextRatio >= threshold;
+		const isNativePath = source.sourceType === 'pdf' && nativeTextRatio >= threshold;
 
-		log.info({ nativeTextRatio, threshold, path: isNativePath ? 'native' : 'document_ai' }, 'Extraction path selected');
+		log.info(
+			{
+				nativeTextRatio,
+				threshold,
+				sourceType: source.sourceType,
+				mediaType: sourceMediaType,
+				path: isNativePath ? 'native' : 'document_ai',
+			},
+			'Extraction path selected',
+		);
 
 		const layoutPages: LayoutPage[] = [];
 		let pageImages: Buffer[] = [];
@@ -592,7 +665,7 @@ export async function execute(
 			primaryMethod = 'native';
 
 			try {
-				const pageTexts = await extractNativeText(pdfBuffer, log);
+				const pageTexts = await extractNativeText(sourceBuffer, log);
 
 				for (let i = 0; i < pageTexts.length; i++) {
 					layoutPages.push({
@@ -612,7 +685,7 @@ export async function execute(
 
 			// Render page images from PDF
 			try {
-				pageImages = await renderPageImages(pdfBuffer, log);
+				pageImages = await renderPageImages(sourceBuffer, log);
 			} catch (cause: unknown) {
 				log.warn({ err: cause }, 'Page image rendering failed — continuing without images');
 			}
@@ -622,7 +695,7 @@ export async function execute(
 
 			let docAiResult: DocumentAiResult;
 			try {
-				docAiResult = await services.documentAi.processDocument(pdfBuffer, input.sourceId);
+				docAiResult = await services.documentAi.processDocument(sourceBuffer, input.sourceId, sourceMediaType);
 			} catch (cause: unknown) {
 				throw new ExtractError(
 					`Document AI processing failed for source ${input.sourceId}`,
@@ -633,9 +706,23 @@ export async function execute(
 
 			documentAiRaw = docAiResult.document;
 			pageImages = docAiResult.pageImages;
+			if (source.sourceType === 'image' && pageImages.length === 0) {
+				const imagePage = await renderImagePageImage(sourceBuffer, sourceMediaType, log);
+				if (imagePage) {
+					pageImages = [imagePage];
+				}
+			}
 
 			// Parse the Document AI result into per-page data
 			const parsedPages = parseDocumentAiResult(docAiResult.document);
+			if (source.sourceType === 'image' && parsedPages.length === 0) {
+				parsedPages.push({
+					pageNumber: 1,
+					confidence: 0.9,
+					text: '',
+					blocks: [],
+				});
+			}
 
 			for (const parsed of parsedPages) {
 				layoutPages.push({

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -92,13 +92,28 @@ export {
 export type { GroundInput, GroundingData, GroundOutcome, GroundResult } from './ground/index.js';
 export { execute as executeGround } from './ground/index.js';
 export type {
+	ImageDimensions,
 	IngestFileResult,
 	IngestInput,
 	IngestResult,
 	SourceDetectionConfidence,
 	SourceDetectionResult,
+	SourceStorageExtension,
+	SupportedImageMediaType,
 } from './ingest/index.js';
-export { detectSourceType, execute as executeIngest, resolvePdfFiles } from './ingest/index.js';
+export {
+	buildImageFormatMetadata,
+	detectSourceType,
+	execute as executeIngest,
+	getCanonicalStorageExtensionForMediaType,
+	getOriginalExtension,
+	getStorageExtensionForDetection,
+	isSupportedImageMediaType,
+	isSupportedIngestFilename,
+	readImageDimensions,
+	resolveIngestFiles,
+	resolvePdfFiles,
+} from './ingest/index.js';
 export type {
 	PipelineGlobalAnalysisOutcome,
 	PipelineRunInput,

--- a/packages/pipeline/src/ingest/index.ts
+++ b/packages/pipeline/src/ingest/index.ts
@@ -1,8 +1,8 @@
 /**
  * Ingest pipeline step — the entry point for all documents into Mulder.
  *
- * Accepts PDF files (single file or directory), validates them, detects
- * native text, uploads to Cloud Storage, and registers them as sources
+ * Accepts supported source files (single file or directory), validates them,
+ * uploads to Cloud Storage, and registers them as sources
  * in PostgreSQL.
  *
  * @see docs/specs/16_ingest_step.spec.md
@@ -13,7 +13,15 @@ import { createHash, randomUUID } from 'node:crypto';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
-import type { Logger, MulderConfig, PdfMetadata, Services, StepError } from '@mulder/core';
+import type {
+	Logger,
+	MulderConfig,
+	PdfMetadata,
+	Services,
+	SourceFormatMetadata,
+	SourceType,
+	StepError,
+} from '@mulder/core';
 import {
 	createChildLogger,
 	createSource,
@@ -25,11 +33,32 @@ import {
 	upsertSourceStep,
 } from '@mulder/core';
 import type pg from 'pg';
-import { detectSourceType } from './source-type.js';
+import {
+	buildImageFormatMetadata,
+	detectSourceType,
+	getStorageExtensionForDetection,
+	isSupportedImageMediaType,
+	isSupportedIngestFilename,
+} from './source-type.js';
 import type { IngestFileResult, IngestInput, IngestResult } from './types.js';
 
-export type { SourceDetectionConfidence, SourceDetectionResult } from './source-type.js';
-export { detectSourceType } from './source-type.js';
+export type {
+	ImageDimensions,
+	SourceDetectionConfidence,
+	SourceDetectionResult,
+	SourceStorageExtension,
+	SupportedImageMediaType,
+} from './source-type.js';
+export {
+	buildImageFormatMetadata,
+	detectSourceType,
+	getCanonicalStorageExtensionForMediaType,
+	getOriginalExtension,
+	getStorageExtensionForDetection,
+	isSupportedImageMediaType,
+	isSupportedIngestFilename,
+	readImageDimensions,
+} from './source-type.js';
 export type { IngestFileResult, IngestInput, IngestResult } from './types.js';
 
 const STEP_NAME = 'ingest';
@@ -39,11 +68,12 @@ const STEP_NAME = 'ingest';
 // ────────────────────────────────────────────────────────────
 
 /**
- * Resolves the input path to a list of PDF file paths.
- * If the path is a directory, recursively finds all `.pdf` files.
- * If the path is a single file, returns it as-is.
+ * Resolves the input path to a list of supported ingest file paths.
+ * If the path is a directory, recursively finds PDFs and supported images.
+ * If the path is a single file, returns it as-is so validation can report
+ * an explicit unsupported-format error.
  */
-export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
+export async function resolveIngestFiles(inputPath: string): Promise<string[]> {
 	const resolved = resolve(inputPath);
 	const stats = await stat(resolved).catch(() => null);
 
@@ -59,13 +89,13 @@ export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
 
 	if (stats.isDirectory()) {
 		const entries = await readdir(resolved, { recursive: true });
-		const pdfFiles: string[] = [];
+		const ingestFiles: string[] = [];
 		for (const entry of entries) {
-			if (entry.toLowerCase().endsWith('.pdf')) {
-				pdfFiles.push(join(resolved, entry));
+			if (isSupportedIngestFilename(entry)) {
+				ingestFiles.push(join(resolved, entry));
 			}
 		}
-		return pdfFiles.sort();
+		return ingestFiles.sort();
 	}
 
 	throw new IngestError(
@@ -76,6 +106,8 @@ export async function resolvePdfFiles(inputPath: string): Promise<string[]> {
 		},
 	);
 }
+
+export const resolvePdfFiles = resolveIngestFiles;
 
 // ────────────────────────────────────────────────────────────
 // Validation helpers
@@ -114,8 +146,25 @@ interface ProcessFileContext {
 	dryRun: boolean;
 }
 
+type IngestibleSourceType = Extract<SourceType, 'pdf' | 'image'>;
+
+interface PreparedFileMetadata {
+	sourceType: IngestibleSourceType;
+	mediaType: string;
+	storageExtension: string;
+	formatMetadata: SourceFormatMetadata;
+	pageCount: number;
+	hasNativeText: boolean;
+	nativeTextRatio: number;
+	pdfMetadata?: PdfMetadata;
+}
+
+function isIngestibleSourceType(sourceType: SourceType): sourceType is IngestibleSourceType {
+	return sourceType === 'pdf' || sourceType === 'image';
+}
+
 /**
- * Processes a single PDF file through the ingest pipeline.
+ * Processes a single supported file through the ingest pipeline.
  */
 async function processFile(filePath: string, ctx: ProcessFileContext): Promise<IngestFileResult> {
 	const filename = basename(filePath);
@@ -152,13 +201,12 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 		);
 	}
 
-	const sourceType = detection.sourceType;
-	if (sourceType !== 'pdf') {
+	if (!isIngestibleSourceType(detection.sourceType)) {
 		throw new IngestError(
-			`Unsupported source type "${sourceType}" for ${filename}; only pdf is supported in this step`,
+			`Unsupported source type "${detection.sourceType}" for ${filename}; only pdf and image are supported in this step`,
 			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
 			{
-				context: { path: filePath, sourceType, confidence: detection.confidence },
+				context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
 			},
 		);
 	}
@@ -174,26 +222,71 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 		);
 	}
 
-	// d. Lightweight PDF metadata extraction (no page content decompression).
-	//    Reads page count from the trailer/page tree root — PDF bomb gate.
-	const pdfMeta = await extractPdfMetadata(buffer);
-
-	// e. Check page count BEFORE full parse — rejects PDF bombs early
-	const maxPages = ctx.config.ingestion.max_pages;
-	if (pdfMeta.pageCount > maxPages) {
+	let prepared: PreparedFileMetadata;
+	const storageExtension = getStorageExtensionForDetection(detection);
+	if (!storageExtension || !detection.mediaType) {
 		throw new IngestError(
-			`Too many pages: ${filename} has ${pdfMeta.pageCount} pages, max is ${maxPages}`,
-			INGEST_ERROR_CODES.INGEST_TOO_MANY_PAGES,
-			{ context: { path: filePath, pageCount: pdfMeta.pageCount, maxPages } },
+			`Unsupported or unknown source format for ${filename}`,
+			INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+			{
+				context: { path: filePath, sourceType: detection.sourceType, mediaType: detection.mediaType },
+			},
 		);
 	}
 
-	log.debug(
-		{ sourceType, pageCount: pdfMeta.pageCount, pdfVersion: pdfMeta.pdfVersion, title: pdfMeta.title },
-		'PDF metadata extracted (lightweight)',
-	);
+	if (detection.sourceType === 'pdf') {
+		// d. Lightweight PDF metadata extraction (no page content decompression).
+		//    Reads page count from the trailer/page tree root — PDF bomb gate.
+		const pdfMeta = await extractPdfMetadata(buffer);
 
-	const formatMetadata = buildPdfFormatMetadata(pdfMeta);
+		// e. Check page count BEFORE full parse — rejects PDF bombs early
+		const maxPages = ctx.config.ingestion.max_pages;
+		if (pdfMeta.pageCount > maxPages) {
+			throw new IngestError(
+				`Too many pages: ${filename} has ${pdfMeta.pageCount} pages, max is ${maxPages}`,
+				INGEST_ERROR_CODES.INGEST_TOO_MANY_PAGES,
+				{ context: { path: filePath, pageCount: pdfMeta.pageCount, maxPages } },
+			);
+		}
+
+		log.debug(
+			{ sourceType: 'pdf', pageCount: pdfMeta.pageCount, pdfVersion: pdfMeta.pdfVersion, title: pdfMeta.title },
+			'PDF metadata extracted (lightweight)',
+		);
+
+		const textResult = await detectNativeText(buffer);
+		prepared = {
+			sourceType: 'pdf',
+			mediaType: detection.mediaType,
+			storageExtension,
+			formatMetadata: buildPdfFormatMetadata(pdfMeta),
+			pageCount: textResult.pageCount,
+			hasNativeText: textResult.hasNativeText,
+			nativeTextRatio: textResult.nativeTextRatio,
+			pdfMetadata: pdfMeta,
+		};
+	} else {
+		if (!isSupportedImageMediaType(detection.mediaType)) {
+			throw new IngestError(
+				`Unsupported image media type for ${filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { path: filePath, mediaType: detection.mediaType },
+				},
+			);
+		}
+
+		prepared = {
+			sourceType: 'image',
+			mediaType: detection.mediaType,
+			storageExtension,
+			formatMetadata: buildImageFormatMetadata(buffer, filename, detection.mediaType),
+			pageCount: 1,
+			hasNativeText: false,
+			nativeTextRatio: 0,
+		};
+		log.debug({ sourceType: 'image', mediaType: detection.mediaType, pageCount: 1 }, 'Image metadata prepared');
+	}
 
 	// f. Compute SHA-256 hash
 	const fileHash = computeFileHash(buffer);
@@ -214,32 +307,29 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 				hasNativeText: existing.hasNativeText,
 				nativeTextRatio: existing.nativeTextRatio,
 				duplicate: true,
-				pdfMetadata: pdfMeta,
+				pdfMetadata: prepared.pdfMetadata,
 			};
 		}
 	}
 
-	// h. Native text detection (now safe — page count already verified)
-	const textResult = await detectNativeText(buffer);
-
 	// i. Dry run: skip upload and DB insert
 	const sourceId = randomUUID();
-	const storagePath = `raw/${sourceId}/original.pdf`;
+	const storagePath = `raw/${sourceId}/original.${prepared.storageExtension}`;
 
 	if (ctx.dryRun) {
-		log.info({ sourceId, filename, pageCount: textResult.pageCount }, 'Dry run — skipping upload and DB insert');
+		log.info({ sourceId, filename, pageCount: prepared.pageCount }, 'Dry run — skipping upload and DB insert');
 		return {
 			sourceId,
 			filename,
 			storagePath,
 			fileHash,
-			sourceType,
-			formatMetadata,
-			pageCount: textResult.pageCount,
-			hasNativeText: textResult.hasNativeText,
-			nativeTextRatio: textResult.nativeTextRatio,
+			sourceType: prepared.sourceType,
+			formatMetadata: prepared.formatMetadata,
+			pageCount: prepared.pageCount,
+			hasNativeText: prepared.hasNativeText,
+			nativeTextRatio: prepared.nativeTextRatio,
 			duplicate: false,
-			pdfMetadata: pdfMeta,
+			pdfMetadata: prepared.pdfMetadata,
 		};
 	}
 
@@ -254,7 +344,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 
 	// j. Upload to storage
 	try {
-		await ctx.services.storage.upload(storagePath, buffer, 'application/pdf');
+		await ctx.services.storage.upload(storagePath, buffer, prepared.mediaType);
 	} catch (cause: unknown) {
 		throw new IngestError(`Upload failed for ${filename}`, INGEST_ERROR_CODES.INGEST_UPLOAD_FAILED, {
 			cause,
@@ -268,13 +358,13 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 		filename,
 		storagePath,
 		fileHash,
-		sourceType,
-		formatMetadata,
-		pageCount: textResult.pageCount,
-		hasNativeText: textResult.hasNativeText,
-		nativeTextRatio: textResult.nativeTextRatio,
+		sourceType: prepared.sourceType,
+		formatMetadata: prepared.formatMetadata,
+		pageCount: prepared.pageCount,
+		hasNativeText: prepared.hasNativeText,
+		nativeTextRatio: prepared.nativeTextRatio,
 		tags: ctx.tags,
-		metadata: formatMetadata,
+		metadata: prepared.formatMetadata,
 	});
 
 	if (source.id !== sourceId) {
@@ -303,7 +393,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 			hasNativeText: source.hasNativeText,
 			nativeTextRatio: source.nativeTextRatio,
 			duplicate: true,
-			pdfMetadata: pdfMeta,
+			pdfMetadata: prepared.pdfMetadata,
 		};
 	}
 
@@ -318,7 +408,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 	ctx.services.firestore
 		.setDocument('documents', source.id, {
 			filename,
-			sourceType,
+			sourceType: prepared.sourceType,
 			uploadedAt: new Date().toISOString(),
 			fileHash,
 			status: 'ingested',
@@ -331,10 +421,10 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 		{
 			sourceId: source.id,
 			filename,
-			sourceType,
-			pageCount: textResult.pageCount,
-			hasNativeText: textResult.hasNativeText,
-			nativeTextRatio: textResult.nativeTextRatio,
+			sourceType: prepared.sourceType,
+			pageCount: prepared.pageCount,
+			hasNativeText: prepared.hasNativeText,
+			nativeTextRatio: prepared.nativeTextRatio,
 		},
 		'File ingested successfully',
 	);
@@ -346,11 +436,11 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 		fileHash,
 		sourceType: source.sourceType,
 		formatMetadata: source.formatMetadata,
-		pageCount: textResult.pageCount,
-		hasNativeText: textResult.hasNativeText,
-		nativeTextRatio: textResult.nativeTextRatio,
+		pageCount: source.pageCount ?? prepared.pageCount,
+		hasNativeText: source.hasNativeText,
+		nativeTextRatio: source.nativeTextRatio,
 		duplicate: false,
-		pdfMetadata: pdfMeta,
+		pdfMetadata: prepared.pdfMetadata,
 	};
 }
 
@@ -361,7 +451,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 /**
  * Executes the ingest pipeline step.
  *
- * Accepts a file or directory path, validates each PDF, uploads to
+ * Accepts a file or directory path, validates each supported source, uploads to
  * Cloud Storage, and registers sources in PostgreSQL. Per-file errors
  * are caught and collected — processing continues for remaining files.
  *
@@ -385,10 +475,10 @@ export async function execute(
 	log.info({ path: input.path, dryRun: input.dryRun ?? false }, 'Ingest step started');
 
 	// 1. Resolve files
-	const filePaths = await resolvePdfFiles(input.path);
+	const filePaths = await resolveIngestFiles(input.path);
 
 	if (filePaths.length === 0) {
-		log.info('No PDF files found');
+		log.info('No supported ingest files found');
 		return {
 			status: 'success',
 			data: [],
@@ -402,7 +492,7 @@ export async function execute(
 		};
 	}
 
-	log.info({ fileCount: filePaths.length }, 'PDF files resolved');
+	log.info({ fileCount: filePaths.length }, 'Ingest files resolved');
 
 	// 2. Process each file
 	const ctx: ProcessFileContext = {

--- a/packages/pipeline/src/ingest/source-type.ts
+++ b/packages/pipeline/src/ingest/source-type.ts
@@ -1,12 +1,19 @@
 import { extname } from 'node:path';
-import type { SourceType } from '@mulder/core';
+import type { SourceFormatMetadata, SourceType } from '@mulder/core';
 
 export type SourceDetectionConfidence = 'magic' | 'extension' | 'content';
+export type SupportedImageMediaType = 'image/png' | 'image/jpeg' | 'image/tiff';
+export type SourceStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff';
 
 export interface SourceDetectionResult {
 	sourceType: SourceType;
 	confidence: SourceDetectionConfidence;
 	mediaType?: string;
+}
+
+export interface ImageDimensions {
+	width: number;
+	height: number;
 }
 
 const PDF_SIGNATURE = Buffer.from('%PDF-', 'latin1');
@@ -16,8 +23,20 @@ const TIFF_LITTLE_ENDIAN_SIGNATURE = Buffer.from([0x49, 0x49, 0x2a, 0x00]);
 const TIFF_BIG_ENDIAN_SIGNATURE = Buffer.from([0x4d, 0x4d, 0x00, 0x2a]);
 const ZIP_LOCAL_FILE_HEADER_SIGNATURE = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 
+const PDF_MEDIA_TYPE = 'application/pdf';
+const PNG_MEDIA_TYPE: SupportedImageMediaType = 'image/png';
+const JPEG_MEDIA_TYPE: SupportedImageMediaType = 'image/jpeg';
+const TIFF_MEDIA_TYPE: SupportedImageMediaType = 'image/tiff';
 const DOCX_MEDIA_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 const XLSX_MEDIA_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+const IMAGE_STORAGE_EXTENSIONS_BY_MEDIA_TYPE: Record<SupportedImageMediaType, SourceStorageExtension> = {
+	'image/png': 'png',
+	'image/jpeg': 'jpg',
+	'image/tiff': 'tiff',
+};
+
+const SUPPORTED_INGEST_EXTENSIONS = new Set(['.pdf', '.png', '.jpg', '.jpeg', '.tif', '.tiff']);
 
 function hasPrefix(buffer: Buffer, signature: Buffer): boolean {
 	return buffer.length >= signature.length && buffer.subarray(0, signature.length).equals(signature);
@@ -31,6 +50,119 @@ function getExtension(input: string): string {
 
 function hasHttpUrlShape(input: string): boolean {
 	return /^https?:\/\/\S+$/i.test(input.trim());
+}
+
+export function isSupportedIngestFilename(input: string): boolean {
+	return SUPPORTED_INGEST_EXTENSIONS.has(getExtension(input));
+}
+
+export function getOriginalExtension(input: string): string {
+	return getExtension(input).replace(/^\./, '');
+}
+
+export function isSupportedImageMediaType(mediaType: string | undefined): mediaType is SupportedImageMediaType {
+	return mediaType === PNG_MEDIA_TYPE || mediaType === JPEG_MEDIA_TYPE || mediaType === TIFF_MEDIA_TYPE;
+}
+
+export function getCanonicalStorageExtensionForMediaType(mediaType: string | undefined): SourceStorageExtension | null {
+	if (mediaType === PDF_MEDIA_TYPE) {
+		return 'pdf';
+	}
+	if (isSupportedImageMediaType(mediaType)) {
+		return IMAGE_STORAGE_EXTENSIONS_BY_MEDIA_TYPE[mediaType];
+	}
+	return null;
+}
+
+export function getStorageExtensionForDetection(detection: SourceDetectionResult): SourceStorageExtension | null {
+	return getCanonicalStorageExtensionForMediaType(detection.mediaType);
+}
+
+function readPngDimensions(buffer: Buffer): ImageDimensions | null {
+	if (!hasPrefix(buffer, PNG_SIGNATURE) || buffer.length < 24) {
+		return null;
+	}
+
+	const width = buffer.readUInt32BE(16);
+	const height = buffer.readUInt32BE(20);
+	return width > 0 && height > 0 ? { width, height } : null;
+}
+
+function isJpegStartOfFrameMarker(marker: number): boolean {
+	return (
+		(marker >= 0xc0 && marker <= 0xc3) ||
+		(marker >= 0xc5 && marker <= 0xc7) ||
+		(marker >= 0xc9 && marker <= 0xcb) ||
+		(marker >= 0xcd && marker <= 0xcf)
+	);
+}
+
+function readJpegDimensions(buffer: Buffer): ImageDimensions | null {
+	if (!hasPrefix(buffer, JPEG_SIGNATURE)) {
+		return null;
+	}
+
+	let offset = 2;
+	while (offset + 4 < buffer.length) {
+		if (buffer[offset] !== 0xff) {
+			offset++;
+			continue;
+		}
+
+		const marker = buffer[offset + 1];
+		offset += 2;
+
+		if (marker === 0xd9 || marker === 0xda) {
+			break;
+		}
+		if (offset + 2 > buffer.length) {
+			break;
+		}
+
+		const segmentLength = buffer.readUInt16BE(offset);
+		if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+			break;
+		}
+
+		if (isJpegStartOfFrameMarker(marker) && segmentLength >= 7) {
+			const height = buffer.readUInt16BE(offset + 3);
+			const width = buffer.readUInt16BE(offset + 5);
+			return width > 0 && height > 0 ? { width, height } : null;
+		}
+
+		offset += segmentLength;
+	}
+
+	return null;
+}
+
+export function readImageDimensions(buffer: Buffer, mediaType: string | undefined): ImageDimensions | null {
+	if (mediaType === PNG_MEDIA_TYPE) {
+		return readPngDimensions(buffer);
+	}
+	if (mediaType === JPEG_MEDIA_TYPE) {
+		return readJpegDimensions(buffer);
+	}
+	return null;
+}
+
+export function buildImageFormatMetadata(
+	buffer: Buffer,
+	filename: string,
+	mediaType: SupportedImageMediaType,
+): SourceFormatMetadata {
+	const metadata: SourceFormatMetadata = {
+		media_type: mediaType,
+		original_extension: getOriginalExtension(filename),
+		byte_size: buffer.length,
+	};
+	const dimensions = readImageDimensions(buffer, mediaType);
+	if (dimensions) {
+		metadata.width = dimensions.width;
+		metadata.height = dimensions.height;
+		metadata.dimensions = dimensions;
+	}
+	return metadata;
 }
 
 function isReadableText(buffer: Buffer): boolean {
@@ -105,19 +237,19 @@ export function detectSourceType(
 
 	if (buffer) {
 		if (hasPrefix(buffer, PDF_SIGNATURE)) {
-			return { sourceType: 'pdf', confidence: 'magic', mediaType: 'application/pdf' };
+			return { sourceType: 'pdf', confidence: 'magic', mediaType: PDF_MEDIA_TYPE };
 		}
 
 		if (hasPrefix(buffer, PNG_SIGNATURE)) {
-			return { sourceType: 'image', confidence: 'magic', mediaType: 'image/png' };
+			return { sourceType: 'image', confidence: 'magic', mediaType: PNG_MEDIA_TYPE };
 		}
 
 		if (hasPrefix(buffer, JPEG_SIGNATURE)) {
-			return { sourceType: 'image', confidence: 'magic', mediaType: 'image/jpeg' };
+			return { sourceType: 'image', confidence: 'magic', mediaType: JPEG_MEDIA_TYPE };
 		}
 
 		if (hasPrefix(buffer, TIFF_LITTLE_ENDIAN_SIGNATURE) || hasPrefix(buffer, TIFF_BIG_ENDIAN_SIGNATURE)) {
-			return { sourceType: 'image', confidence: 'magic', mediaType: 'image/tiff' };
+			return { sourceType: 'image', confidence: 'magic', mediaType: TIFF_MEDIA_TYPE };
 		}
 
 		if (hasPrefix(buffer, ZIP_LOCAL_FILE_HEADER_SIGNATURE)) {

--- a/packages/pipeline/src/ingest/types.ts
+++ b/packages/pipeline/src/ingest/types.ts
@@ -13,7 +13,7 @@ import type { PdfMetadata, SourceFormatMetadata, SourceType, StepError } from '@
 
 /** Input for the ingest step. */
 export interface IngestInput {
-	/** File or directory path containing PDF(s). */
+	/** File or directory path containing supported source files. */
 	path: string;
 	/** Optional tags for batch operations. */
 	tags?: string[];
@@ -39,9 +39,9 @@ export interface IngestFileResult {
 	sourceType: SourceType;
 	/** Format-specific metadata stored on the source row. */
 	formatMetadata: SourceFormatMetadata;
-	/** Number of pages in the PDF. */
+	/** Number of pages represented by this source. */
 	pageCount: number;
-	/** Whether the PDF contains extractable native text. */
+	/** Whether the source contains extractable native text. */
 	hasNativeText: boolean;
 	/** Fraction of pages with native text (0-1). */
 	nativeTextRatio: number;

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -306,14 +306,9 @@ async function finalizeUploadedDocument(
 	}
 
 	const finalizedStoragePath = `raw/${payload.sourceId}/original.${finalizedMetadata.storageExtension}`;
-	if (payload.storagePath !== finalizedStoragePath) {
+	const shouldCleanupOriginalUpload = payload.storagePath !== finalizedStoragePath;
+	if (shouldCleanupOriginalUpload) {
 		await services.storage.upload(finalizedStoragePath, buffer, finalizedMetadata.mediaType);
-		await services.storage.delete(payload.storagePath).catch((cause: unknown) => {
-			log.warn(
-				{ err: cause, sourceId: payload.sourceId, storagePath: payload.storagePath, finalizedStoragePath },
-				'Uploaded object canonicalized, but original cleanup failed',
-			);
-		});
 	}
 
 	const client = await pool.connect();
@@ -337,6 +332,14 @@ async function finalizeUploadedDocument(
 		if (source.id !== payload.sourceId) {
 			await client.query('ROLLBACK');
 			await services.storage.delete(finalizedStoragePath);
+			if (shouldCleanupOriginalUpload) {
+				await services.storage.delete(payload.storagePath).catch((cause: unknown) => {
+					log.warn(
+						{ err: cause, sourceId: payload.sourceId, storagePath: payload.storagePath, finalizedStoragePath },
+						'Duplicate upload finalized, but original cleanup failed',
+					);
+				});
+			}
 			return {
 				result_status: 'duplicate',
 				resolved_source_id: source.id,
@@ -399,6 +402,15 @@ async function finalizeUploadedDocument(
 			.catch(() => {
 				// Observability projection remains best-effort.
 			});
+
+		if (shouldCleanupOriginalUpload) {
+			services.storage.delete(payload.storagePath).catch((cause: unknown) => {
+				log.warn(
+					{ err: cause, sourceId: source.id, storagePath: payload.storagePath, finalizedStoragePath },
+					'Uploaded object canonicalized, but original cleanup failed',
+				);
+			});
+		}
 
 		log.info({ sourceId: source.id, storagePath: finalizedStoragePath }, 'Browser upload finalized');
 		return completionPayload;

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -34,6 +34,7 @@ import {
 	executeGraph,
 	executePipelineRun,
 	executeSegment,
+	getStorageExtensionForDetection,
 	isSupportedImageMediaType,
 	type PipelineRunOptions,
 } from '@mulder/pipeline';
@@ -102,6 +103,8 @@ interface FinalizedUploadMetadata {
 	pageCount: number;
 	hasNativeText: boolean;
 	nativeTextRatio: number;
+	mediaType: string;
+	storageExtension: string;
 }
 
 function isFinalizableSourceType(sourceType: SourceType): sourceType is FinalizableSourceType {
@@ -226,6 +229,21 @@ async function finalizeUploadedDocument(
 			},
 		);
 	}
+	const canonicalStorageExtension = getStorageExtensionForDetection(detection);
+	if (!canonicalStorageExtension || !detection.mediaType) {
+		throw new IngestError(
+			`Unsupported or unknown source format for ${payload.filename}`,
+			INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+			{
+				context: {
+					storagePath: payload.storagePath,
+					sourceId: payload.sourceId,
+					sourceType: detection.sourceType,
+					mediaType: detection.mediaType,
+				},
+			},
+		);
+	}
 
 	const fileHash = createHash('sha256').update(buffer).digest('hex');
 	const duplicateSource = await findSourceByHash(pool, fileHash);
@@ -263,6 +281,8 @@ async function finalizeUploadedDocument(
 			pageCount: textResult.pageCount,
 			hasNativeText: textResult.hasNativeText,
 			nativeTextRatio: textResult.nativeTextRatio,
+			mediaType: detection.mediaType,
+			storageExtension: canonicalStorageExtension,
 		};
 	} else {
 		if (!isSupportedImageMediaType(detection.mediaType)) {
@@ -280,7 +300,20 @@ async function finalizeUploadedDocument(
 			pageCount: 1,
 			hasNativeText: false,
 			nativeTextRatio: 0,
+			mediaType: detection.mediaType,
+			storageExtension: canonicalStorageExtension,
 		};
+	}
+
+	const finalizedStoragePath = `raw/${payload.sourceId}/original.${finalizedMetadata.storageExtension}`;
+	if (payload.storagePath !== finalizedStoragePath) {
+		await services.storage.upload(finalizedStoragePath, buffer, finalizedMetadata.mediaType);
+		await services.storage.delete(payload.storagePath).catch((cause: unknown) => {
+			log.warn(
+				{ err: cause, sourceId: payload.sourceId, storagePath: payload.storagePath, finalizedStoragePath },
+				'Uploaded object canonicalized, but original cleanup failed',
+			);
+		});
 	}
 
 	const client = await pool.connect();
@@ -290,7 +323,7 @@ async function finalizeUploadedDocument(
 		const source = await createSource(client, {
 			id: payload.sourceId,
 			filename: payload.filename,
-			storagePath: payload.storagePath,
+			storagePath: finalizedStoragePath,
 			fileHash,
 			pageCount: finalizedMetadata.pageCount,
 			hasNativeText: finalizedMetadata.hasNativeText,
@@ -303,7 +336,7 @@ async function finalizeUploadedDocument(
 
 		if (source.id !== payload.sourceId) {
 			await client.query('ROLLBACK');
-			await services.storage.delete(payload.storagePath);
+			await services.storage.delete(finalizedStoragePath);
 			return {
 				result_status: 'duplicate',
 				resolved_source_id: source.id,
@@ -367,7 +400,7 @@ async function finalizeUploadedDocument(
 				// Observability projection remains best-effort.
 			});
 
-		log.info({ sourceId: source.id, storagePath: payload.storagePath }, 'Browser upload finalized');
+		log.info({ sourceId: source.id, storagePath: finalizedStoragePath }, 'Browser upload finalized');
 		return completionPayload;
 	} catch (error) {
 		try {

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -9,7 +9,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import type { MulderConfig, Services } from '@mulder/core';
+import type { MulderConfig, Services, SourceFormatMetadata, SourceType } from '@mulder/core';
 import {
 	createChildLogger,
 	createPipelineRun,
@@ -26,12 +26,15 @@ import {
 	upsertSourceStep,
 } from '@mulder/core';
 import {
+	buildImageFormatMetadata,
+	detectSourceType,
 	executeEmbed,
 	executeEnrich,
 	executeExtract,
 	executeGraph,
 	executePipelineRun,
 	executeSegment,
+	isSupportedImageMediaType,
 	type PipelineRunOptions,
 } from '@mulder/pipeline';
 import {
@@ -76,12 +79,7 @@ function assertPipelineRunCompleted(job: WorkerJobEnvelope, status: string): voi
 	);
 }
 
-const PDF_MAGIC_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d]);
 const BROWSER_UPLOAD_PIPELINE_TAG = 'browser-upload';
-
-function hasPdfMagicBytes(buffer: Buffer): boolean {
-	return buffer.length >= PDF_MAGIC_BYTES.length && buffer.subarray(0, PDF_MAGIC_BYTES.length).equals(PDF_MAGIC_BYTES);
-}
 
 function buildPdfMetadataJson(pdfMeta: Awaited<ReturnType<typeof extractPdfMetadata>>): Record<string, unknown> {
 	const pdfMetadataJson: Record<string, unknown> = {};
@@ -94,6 +92,20 @@ function buildPdfMetadataJson(pdfMeta: Awaited<ReturnType<typeof extractPdfMetad
 	if (pdfMeta.modificationDate) pdfMetadataJson.modification_date = pdfMeta.modificationDate.toISOString();
 	if (pdfMeta.encrypted !== undefined) pdfMetadataJson.encrypted = pdfMeta.encrypted;
 	return pdfMetadataJson;
+}
+
+type FinalizableSourceType = Extract<SourceType, 'pdf' | 'image'>;
+
+interface FinalizedUploadMetadata {
+	sourceType: FinalizableSourceType;
+	formatMetadata: SourceFormatMetadata;
+	pageCount: number;
+	hasNativeText: boolean;
+	nativeTextRatio: number;
+}
+
+function isFinalizableSourceType(sourceType: SourceType): sourceType is FinalizableSourceType {
+	return sourceType === 'pdf' || sourceType === 'image';
 }
 
 async function runStoryStepForPayload(
@@ -190,10 +202,29 @@ async function finalizeUploadedDocument(
 	}
 
 	const buffer = await services.storage.download(payload.storagePath);
-	if (!hasPdfMagicBytes(buffer)) {
-		throw new IngestError(`Not a valid PDF file: ${payload.filename}`, INGEST_ERROR_CODES.INGEST_NOT_PDF, {
-			context: { storagePath: payload.storagePath, sourceId: payload.sourceId },
-		});
+	const detection = detectSourceType(buffer, payload.filename);
+	if (!detection) {
+		throw new IngestError(
+			`Unsupported or unknown source format for ${payload.filename}`,
+			INGEST_ERROR_CODES.INGEST_UNKNOWN_SOURCE_TYPE,
+			{
+				context: { storagePath: payload.storagePath, sourceId: payload.sourceId },
+			},
+		);
+	}
+	if (!isFinalizableSourceType(detection.sourceType)) {
+		throw new IngestError(
+			`Unsupported source type "${detection.sourceType}" for ${payload.filename}; only pdf and image are supported in this step`,
+			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+			{
+				context: {
+					storagePath: payload.storagePath,
+					sourceId: payload.sourceId,
+					sourceType: detection.sourceType,
+					confidence: detection.confidence,
+				},
+			},
+		);
 	}
 
 	const fileHash = createHash('sha256').update(buffer).digest('hex');
@@ -207,24 +238,50 @@ async function finalizeUploadedDocument(
 		};
 	}
 
-	const pdfMeta = await extractPdfMetadata(buffer);
-	if (pdfMeta.pageCount > config.ingestion.max_pages) {
-		throw new IngestError(
-			`Uploaded file exceeds configured page limit: ${payload.filename}`,
-			INGEST_ERROR_CODES.INGEST_TOO_MANY_PAGES,
-			{
-				context: {
-					storagePath: payload.storagePath,
-					sourceId: payload.sourceId,
-					pageCount: pdfMeta.pageCount,
-					maxPages: config.ingestion.max_pages,
+	let finalizedMetadata: FinalizedUploadMetadata;
+	if (detection.sourceType === 'pdf') {
+		const pdfMeta = await extractPdfMetadata(buffer);
+		if (pdfMeta.pageCount > config.ingestion.max_pages) {
+			throw new IngestError(
+				`Uploaded file exceeds configured page limit: ${payload.filename}`,
+				INGEST_ERROR_CODES.INGEST_TOO_MANY_PAGES,
+				{
+					context: {
+						storagePath: payload.storagePath,
+						sourceId: payload.sourceId,
+						pageCount: pdfMeta.pageCount,
+						maxPages: config.ingestion.max_pages,
+					},
 				},
-			},
-		);
-	}
+			);
+		}
 
-	const textResult = await detectNativeText(buffer);
-	const pdfMetadataJson = buildPdfMetadataJson(pdfMeta);
+		const textResult = await detectNativeText(buffer);
+		finalizedMetadata = {
+			sourceType: 'pdf',
+			formatMetadata: buildPdfMetadataJson(pdfMeta),
+			pageCount: textResult.pageCount,
+			hasNativeText: textResult.hasNativeText,
+			nativeTextRatio: textResult.nativeTextRatio,
+		};
+	} else {
+		if (!isSupportedImageMediaType(detection.mediaType)) {
+			throw new IngestError(
+				`Unsupported image media type for ${payload.filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { storagePath: payload.storagePath, sourceId: payload.sourceId, mediaType: detection.mediaType },
+				},
+			);
+		}
+		finalizedMetadata = {
+			sourceType: 'image',
+			formatMetadata: buildImageFormatMetadata(buffer, payload.filename, detection.mediaType),
+			pageCount: 1,
+			hasNativeText: false,
+			nativeTextRatio: 0,
+		};
+	}
 
 	const client = await pool.connect();
 	try {
@@ -235,13 +292,13 @@ async function finalizeUploadedDocument(
 			filename: payload.filename,
 			storagePath: payload.storagePath,
 			fileHash,
-			pageCount: textResult.pageCount,
-			hasNativeText: textResult.hasNativeText,
-			nativeTextRatio: textResult.nativeTextRatio,
+			pageCount: finalizedMetadata.pageCount,
+			hasNativeText: finalizedMetadata.hasNativeText,
+			nativeTextRatio: finalizedMetadata.nativeTextRatio,
 			tags: payload.tags,
-			sourceType: 'pdf',
-			formatMetadata: pdfMetadataJson,
-			metadata: pdfMetadataJson,
+			sourceType: finalizedMetadata.sourceType,
+			formatMetadata: finalizedMetadata.formatMetadata,
+			metadata: finalizedMetadata.formatMetadata,
 		});
 
 		if (source.id !== payload.sourceId) {

--- a/packages/worker/src/worker.types.ts
+++ b/packages/worker/src/worker.types.ts
@@ -69,6 +69,7 @@ export interface DocumentUploadFinalizeJobPayload {
 	storagePath: string;
 	tags?: string[];
 	startPipeline?: boolean;
+	declaredSizeBytes?: number;
 }
 
 export type LegacyPipelineRunJobPayload = PipelineRunJobPayload;
@@ -235,6 +236,10 @@ function asString(value: unknown): string | null {
 
 function asBoolean(value: unknown): boolean | undefined {
 	return typeof value === 'boolean' ? value : undefined;
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 function readStringField(payload: Record<string, unknown>, primaryKey: string, fallbackKey?: string): string | null {
@@ -438,6 +443,11 @@ function parseDocumentUploadFinalizePayload(jobId: string, payload: unknown): Do
 	const startPipeline = asBoolean(payload.startPipeline);
 	if (startPipeline !== undefined) {
 		parsed.startPipeline = startPipeline;
+	}
+
+	const declaredSizeBytes = asPositiveInteger(payload.declaredSizeBytes ?? payload.declared_size_bytes);
+	if (declaredSizeBytes !== undefined) {
+		parsed.declaredSizeBytes = declaredSizeBytes;
 	}
 
 	return parsed;

--- a/tests/specs/85_source_type_discriminator_format_metadata.test.ts
+++ b/tests/specs/85_source_type_discriminator_format_metadata.test.ts
@@ -178,9 +178,8 @@ describe('Spec 85 — Source Type Discriminator + Format Metadata', () => {
 		const imageRenamedPdf = join(tmpDir, 'image-renamed.pdf');
 		writeFileSync(imageRenamedPdf, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]));
 
-		const result = runCli(['ingest', imageRenamedPdf]);
-		expect(result.exitCode).not.toBe(0);
-		expect(`${result.stdout}\n${result.stderr}`).toMatch(/INGEST_UNSUPPORTED_SOURCE_TYPE|unsupported source type/i);
+		const result = runCli(['ingest', '--dry-run', imageRenamedPdf]);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
 		expect(`${result.stdout}\n${result.stderr}`).toMatch(/\bimage\b/i);
 		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
 		expectNoStorageUpload(beforeStorage);

--- a/tests/specs/87_image_ingestion_layout_path.test.ts
+++ b/tests/specs/87_image_ingestion_layout_path.test.ts
@@ -1,0 +1,401 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { WorkerRuntimeContext } from '@mulder/worker';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const PIPELINE_DIST = resolve(PIPELINE_DIR, 'dist/index.js');
+const WORKER_DIST = resolve(WORKER_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const FIXTURE_PDF = resolve(ROOT, 'fixtures/raw/native-text-sample.pdf');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const EXTRACTED_STORAGE_DIR = resolve(STORAGE_DIR, 'extracted');
+
+const PNG_BYTES = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+	'base64',
+);
+const JPEG_BYTES = Buffer.from([
+	0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+	0x00, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01, 0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11,
+	0x01, 0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00, 0x00, 0xff, 0xd9,
+]);
+const TIFF_BYTES = Buffer.from([
+	0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x01, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x00, 0x00, 0x00, 0x01, 0x01, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+type ApiApp = { request: (input: string | Request, init?: RequestInit) => Promise<Response> };
+type PlanPipelineSteps = (input: { sourceType: 'image' }) => {
+	executableSteps: string[];
+	skippedSteps: string[];
+};
+
+let tmpDir: string;
+let pngFile: string;
+let jpegFile: string;
+let tiffFile: string;
+let coreModule: typeof import('@mulder/core');
+let workerModule: typeof import('@mulder/worker');
+let workerContext: WorkerRuntimeContext;
+let app: ApiApp;
+let planPipelineSteps: PlanPipelineSteps;
+let pgAvailable = false;
+let rawSnapshot: StorageSnapshot | null = null;
+let extractedSnapshot: StorageSnapshot | null = null;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 180_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_CONFIG: EXAMPLE_CONFIG,
+			MULDER_LOG_LEVEL: 'silent',
+			NODE_ENV: 'test',
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+		},
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM monthly_budget_reservations',
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sourceIdForFilename(filename: string): string {
+	return db.runSql(`SELECT id FROM sources WHERE filename = ${sqlLiteral(filename)} ORDER BY created_at DESC LIMIT 1;`);
+}
+
+function resetStorage(): void {
+	if (!rawSnapshot || !extractedSnapshot) {
+		return;
+	}
+	cleanStorageDirSince(rawSnapshot);
+	cleanStorageDirSince(extractedSnapshot);
+}
+
+function addedStorageEntries(snapshot: StorageSnapshot): string[] {
+	if (!existsSync(snapshot.dir)) {
+		return [];
+	}
+	return readdirSync(snapshot.dir)
+		.filter((entry) => !snapshot.entries.has(entry))
+		.sort();
+}
+
+async function loadApiApp(): Promise<ApiApp> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				browser: {
+					enabled: true,
+					cookie_name: 'mulder_session',
+					session_secret: 'test-session-secret',
+					session_ttl_hours: 168,
+					invitation_ttl_hours: 168,
+					cookie_secure: false,
+					same_site: 'Lax',
+				},
+			},
+			rate_limiting: { enabled: true },
+		},
+	});
+}
+
+async function apiPost(path: string, body: unknown): Promise<Response> {
+	return await app.request(`http://localhost${path}`, {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer test-api-key',
+			'Content-Type': 'application/json',
+			'X-Forwarded-For': '203.0.113.87',
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+	return (await response.json()) as Record<string, unknown>;
+}
+
+function writeUploadedObject(storagePath: string, content: Buffer): void {
+	const fullPath = resolve(STORAGE_DIR, storagePath);
+	mkdirSync(dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, content);
+}
+
+async function processOneJob() {
+	return await workerModule.processNextJob(workerContext, 'spec-87-worker');
+}
+
+describe('Spec 87 — Image Ingestion on the Layout Extraction Path', () => {
+	beforeAll(async () => {
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
+			return;
+		}
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+		process.env.NODE_ENV = 'test';
+
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-87-'));
+		pngFile = join(tmpDir, 'scan.png');
+		jpegFile = join(tmpDir, 'scan.jpg');
+		tiffFile = join(tmpDir, 'scan.tiff');
+		writeFileSync(pngFile, PNG_BYTES);
+		writeFileSync(jpegFile, JPEG_BYTES);
+		writeFileSync(tiffFile, TIFF_BYTES);
+		rawSnapshot = snapshotStorageDir(RAW_STORAGE_DIR);
+		extractedSnapshot = snapshotStorageDir(EXTRACTED_STORAGE_DIR);
+
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+		buildPackage(CLI_DIR);
+
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode, `${migrate.stdout}\n${migrate.stderr}`).toBe(0);
+
+		coreModule = await import(pathToFileURL(CORE_DIST).href);
+		workerModule = await import(pathToFileURL(WORKER_DIST).href);
+		const pipelineModule = (await import(pathToFileURL(PIPELINE_DIST).href)) as {
+			planPipelineSteps: PlanPipelineSteps;
+		};
+		planPipelineSteps = pipelineModule.planPipelineSteps;
+		app = await loadApiApp();
+
+		const config = coreModule.loadConfig(EXAMPLE_CONFIG);
+		const cloudSql = config.gcp?.cloud_sql;
+		if (!cloudSql) {
+			throw new Error('Expected example config to include gcp.cloud_sql');
+		}
+		const logger = coreModule.createLogger({ level: 'silent' });
+		workerContext = {
+			config,
+			services: coreModule.createServiceRegistry(config, logger),
+			pool: coreModule.getWorkerPool(cloudSql),
+			logger,
+		};
+	}, 600_000);
+
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanState();
+		resetStorage();
+	});
+
+	afterAll(() => {
+		try {
+			cleanState();
+			resetStorage();
+		} catch {
+			// Ignore cleanup failures.
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('QA-01: CLI dry-run accepts image sources without persistence', () => {
+		if (!pgAvailable || !rawSnapshot) return;
+
+		for (const imageFile of [pngFile, jpegFile, tiffFile]) {
+			const result = runCli(['ingest', '--dry-run', imageFile]);
+			expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+			expect(result.stdout).toContain('Type');
+			expect(result.stdout).toMatch(/\bimage\b/);
+			expect(result.stdout).toMatch(/\b1\b/);
+		}
+		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
+		expect(addedStorageEntries(rawSnapshot)).toEqual([]);
+	});
+
+	it('QA-02: CLI image ingest persists image metadata', () => {
+		if (!pgAvailable) return;
+
+		const result = runCli(['ingest', pngFile]);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+
+		const sourceId = sourceIdForFilename(basename(pngFile));
+		const row = db.runSql(
+			`SELECT source_type::text, page_count, has_native_text, native_text_ratio, storage_path, format_metadata->>'media_type' FROM sources WHERE id = ${sqlLiteral(sourceId)};`,
+		);
+		expect(row).toBe(`image|1|f|0|raw/${sourceId}/original.png|image/png`);
+		expect(existsSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.png`))).toBe(true);
+	});
+
+	it('QA-03: directory ingest discovers PDFs and images', () => {
+		if (!pgAvailable) return;
+
+		const mixedDir = join(tmpDir, 'mixed-dir');
+		mkdirSync(mixedDir, { recursive: true });
+		writeFileSync(join(mixedDir, 'scan.png'), PNG_BYTES);
+		writeFileSync(join(mixedDir, 'native-text-sample.pdf'), readFileSync(FIXTURE_PDF));
+
+		const result = runCli(['ingest', '--dry-run', mixedDir], { timeout: 180_000 });
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+		expect(result.stdout).toMatch(/native-text-sample\.pdf[\s\S]*\bpdf\b/);
+		expect(result.stdout).toMatch(/scan\.png[\s\S]*\bimage\b/);
+	});
+
+	it('QA-04: magic bytes remain authoritative', () => {
+		if (!pgAvailable) return;
+
+		const pngRenamedPdf = join(tmpDir, 'png-renamed.pdf');
+		const pdfRenamedPng = join(tmpDir, 'pdf-renamed.png');
+		writeFileSync(pngRenamedPdf, PNG_BYTES);
+		writeFileSync(pdfRenamedPng, readFileSync(FIXTURE_PDF));
+
+		const imageResult = runCli(['ingest', '--dry-run', pngRenamedPdf]);
+		expect(imageResult.exitCode, `${imageResult.stdout}\n${imageResult.stderr}`).toBe(0);
+		expect(imageResult.stdout).toMatch(/\bimage\b/);
+
+		const pdfResult = runCli(['ingest', '--dry-run', pdfRenamedPng], { timeout: 180_000 });
+		expect(pdfResult.exitCode, `${pdfResult.stdout}\n${pdfResult.stderr}`).toBe(0);
+		expect(pdfResult.stdout).toMatch(/\bpdf\b/);
+	});
+
+	it('QA-05: duplicate image ingest returns the existing source', () => {
+		if (!pgAvailable) return;
+
+		const first = runCli(['ingest', pngFile]);
+		expect(first.exitCode, `${first.stdout}\n${first.stderr}`).toBe(0);
+		const second = runCli(['ingest', pngFile]);
+		expect(second.exitCode, `${second.stdout}\n${second.stderr}`).toBe(0);
+		expect(`${second.stdout}\n${second.stderr}`).toMatch(/duplicate/i);
+
+		const row = db.runSql(
+			"SELECT source_type::text, COUNT(*) FROM sources WHERE file_hash = (SELECT file_hash FROM sources WHERE filename = 'scan.png' LIMIT 1) GROUP BY source_type;",
+		);
+		expect(row).toBe('image|1');
+	});
+
+	it('QA-06: image extract writes layout artifacts and keeps layout path', () => {
+		if (!pgAvailable) return;
+
+		const ingest = runCli(['ingest', pngFile]);
+		expect(ingest.exitCode, `${ingest.stdout}\n${ingest.stderr}`).toBe(0);
+		const sourceId = sourceIdForFilename(basename(pngFile));
+
+		const extract = runCli(['extract', sourceId], { timeout: 180_000 });
+		expect(extract.exitCode, `${extract.stdout}\n${extract.stderr}`).toBe(0);
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('extracted');
+
+		const layoutPath = resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`);
+		const pagePath = resolve(STORAGE_DIR, `extracted/${sourceId}/pages/page-001.png`);
+		expect(existsSync(layoutPath)).toBe(true);
+		expect(existsSync(pagePath)).toBe(true);
+		const layout = JSON.parse(readFileSync(layoutPath, 'utf-8')) as { pageCount: number; pages: unknown[] };
+		expect(layout.pageCount).toBeGreaterThanOrEqual(1);
+		expect(layout.pages.length).toBeGreaterThanOrEqual(1);
+
+		const plan = planPipelineSteps({ sourceType: 'image' });
+		expect(plan.executableSteps).toContain('segment');
+		expect(plan.skippedSteps).not.toContain('segment');
+	});
+
+	it('QA-07: API upload accepts image media types', async () => {
+		if (!pgAvailable) return;
+
+		const initiate = await apiPost('/api/uploads/documents/initiate', {
+			filename: 'scan.png',
+			size_bytes: PNG_BYTES.byteLength,
+			content_type: 'image/png',
+		});
+		expect(initiate.status).toBe(201);
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const storagePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+		expect(storagePath).toBe(`raw/${sourceId}/original.png`);
+		writeUploadedObject(storagePath, PNG_BYTES);
+
+		const complete = await apiPost('/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'scan.png',
+			storage_path: storagePath,
+			start_pipeline: true,
+		});
+		expect(complete.status).toBe(202);
+
+		const processed = await processOneJob();
+		expect(processed.state).toBe('completed');
+		const sourceRow = db.runSql(
+			`SELECT source_type::text, page_count, has_native_text, native_text_ratio, format_metadata->>'media_type' FROM sources WHERE id = ${sqlLiteral(sourceId)};`,
+		);
+		expect(sourceRow).toBe('image|1|f|0|image/png');
+		expect(
+			db.runSql(
+				`SELECT COUNT(*) FROM jobs WHERE type = 'extract' AND status = 'pending' AND payload->>'sourceId' = ${sqlLiteral(sourceId)};`,
+			),
+		).toBe('1');
+	});
+
+	it('QA-08: unsupported formats still fail before persistence', () => {
+		if (!pgAvailable) return;
+
+		const textFile = join(tmpDir, 'note.txt');
+		writeFileSync(textFile, 'Plain text remains out of scope for M9-J3.\n', 'utf-8');
+		const result = runCli(['ingest', textFile]);
+		expect(result.exitCode).not.toBe(0);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(/unsupported source type|INGEST_UNSUPPORTED_SOURCE_TYPE/i);
+		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
+	});
+});

--- a/tests/specs/87_image_ingestion_layout_path.test.ts
+++ b/tests/specs/87_image_ingestion_layout_path.test.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { WorkerRuntimeContext } from '@mulder/worker';
+import type { DocumentUploadFinalizeJobPayload, WorkerJobEnvelope, WorkerRuntimeContext } from '@mulder/worker';
+import type { Pool, PoolClient } from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
 import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
@@ -182,6 +184,66 @@ function writeUploadedObject(storagePath: string, content: Buffer): void {
 
 async function processOneJob() {
 	return await workerModule.processNextJob(workerContext, 'spec-87-worker');
+}
+
+async function dispatchFinalizeJob(payload: DocumentUploadFinalizeJobPayload, pool: Pool = workerContext.pool) {
+	const job: WorkerJobEnvelope<'document_upload_finalize'> = {
+		id: randomUUID(),
+		type: 'document_upload_finalize',
+		payload,
+		status: 'running',
+		attempts: 1,
+		maxAttempts: 3,
+		errorLog: null,
+		workerId: 'spec-87-worker',
+		createdAt: new Date(),
+		startedAt: new Date(),
+		finishedAt: null,
+	};
+	return await workerModule.dispatchJob(job, {
+		config: workerContext.config,
+		services: workerContext.services,
+		pool,
+		workerId: 'spec-87-worker',
+		logger: workerContext.logger,
+	});
+}
+
+function withFailingFinalizeCommit(pool: Pool): Pool {
+	let shouldFailCommit = true;
+	return new Proxy(pool, {
+		get(target, property, receiver) {
+			if (property === 'connect') {
+				return async (): Promise<PoolClient> => {
+					const client = await target.connect();
+					return new Proxy(client, {
+						get(clientTarget, clientProperty, clientReceiver) {
+							if (clientProperty === 'query') {
+								return async (queryText: unknown, values?: unknown): Promise<unknown> => {
+									if (
+										shouldFailCommit &&
+										typeof queryText === 'string' &&
+										queryText.trim().toUpperCase() === 'COMMIT'
+									) {
+										shouldFailCommit = false;
+										throw new Error('simulated finalize commit failure');
+									}
+									if (values === undefined) {
+										return await clientTarget.query(queryText as never);
+									}
+									return await clientTarget.query(queryText as never, values as never);
+								};
+							}
+							const value = Reflect.get(clientTarget, clientProperty, clientReceiver) as unknown;
+							return typeof value === 'function' ? value.bind(clientTarget) : value;
+						},
+					}) as PoolClient;
+				};
+			}
+			const value = Reflect.get(target, property, receiver) as unknown;
+			return typeof value === 'function' ? value.bind(target) : value;
+		},
+	});
 }
 
 describe('Spec 87 — Image Ingestion on the Layout Extraction Path', () => {
@@ -419,6 +481,38 @@ describe('Spec 87 — Image Ingestion on the Layout Extraction Path', () => {
 		expect(sourceRow).toBe(`image|raw/${sourceId}/original.png|image/png`);
 		expect(existsSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.png`))).toBe(true);
 		expect(existsSync(resolve(STORAGE_DIR, declaredStoragePath))).toBe(false);
+	});
+
+	it('QA-07c: canonicalization keeps retry payload object until persistence succeeds', async () => {
+		if (!pgAvailable) return;
+
+		const sourceId = randomUUID();
+		const declaredStoragePath = `raw/${sourceId}/original.pdf`;
+		writeUploadedObject(declaredStoragePath, PNG_BYTES);
+		const payload: DocumentUploadFinalizeJobPayload = {
+			sourceId,
+			filename: 'declared.pdf',
+			storagePath: declaredStoragePath,
+			startPipeline: false,
+		};
+
+		await expect(dispatchFinalizeJob(payload, withFailingFinalizeCommit(workerContext.pool))).rejects.toThrow(
+			/simulated finalize commit failure/,
+		);
+		expect(db.runSql(`SELECT COUNT(*) FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('0');
+		expect(existsSync(resolve(STORAGE_DIR, declaredStoragePath))).toBe(true);
+		expect(existsSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.png`))).toBe(true);
+
+		const retryResult = await dispatchFinalizeJob(payload);
+		expect(retryResult).toMatchObject({
+			result_status: 'created',
+			resolved_source_id: sourceId,
+		});
+		const sourceRow = db.runSql(
+			`SELECT source_type::text, storage_path, format_metadata->>'media_type' FROM sources WHERE id = ${sqlLiteral(sourceId)};`,
+		);
+		expect(sourceRow).toBe(`image|raw/${sourceId}/original.png|image/png`);
+		expect(existsSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.png`))).toBe(true);
 	});
 
 	it('QA-08: unsupported formats still fail before persistence', () => {

--- a/tests/specs/87_image_ingestion_layout_path.test.ts
+++ b/tests/specs/87_image_ingestion_layout_path.test.ts
@@ -388,6 +388,39 @@ describe('Spec 87 — Image Ingestion on the Layout Extraction Path', () => {
 		).toBe('1');
 	});
 
+	it('QA-07b: upload finalization canonicalizes storage paths from detected bytes', async () => {
+		if (!pgAvailable) return;
+
+		const initiate = await apiPost('/api/uploads/documents/initiate', {
+			filename: 'declared.pdf',
+			size_bytes: PNG_BYTES.byteLength,
+			content_type: 'application/pdf',
+		});
+		expect(initiate.status).toBe(201);
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const declaredStoragePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+		expect(declaredStoragePath).toBe(`raw/${sourceId}/original.pdf`);
+		writeUploadedObject(declaredStoragePath, PNG_BYTES);
+
+		const complete = await apiPost('/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'declared.pdf',
+			storage_path: declaredStoragePath,
+			start_pipeline: false,
+		});
+		expect(complete.status).toBe(202);
+
+		const processed = await processOneJob();
+		expect(processed.state).toBe('completed');
+		const sourceRow = db.runSql(
+			`SELECT source_type::text, storage_path, format_metadata->>'media_type' FROM sources WHERE id = ${sqlLiteral(sourceId)};`,
+		);
+		expect(sourceRow).toBe(`image|raw/${sourceId}/original.png|image/png`);
+		expect(existsSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.png`))).toBe(true);
+		expect(existsSync(resolve(STORAGE_DIR, declaredStoragePath))).toBe(false);
+	});
+
 	it('QA-08: unsupported formats still fail before persistence', () => {
 		if (!pgAvailable) return;
 


### PR DESCRIPTION
## Summary

- adds Spec 87 for M9-J3 image ingestion on the layout extraction path
- starts the implementation branch from `milestone/9`
- keeps image sources on the extract -> segment layout path

Closes #231

## Verification

- pending implementation
