### PR TITLE
[Pipeline] Plain text ingestion on pre-structured path — M9-J4

### DIFF
--- a/apps/api/src/lib/uploads.ts
+++ b/apps/api/src/lib/uploads.ts
@@ -92,13 +92,17 @@ function resolveUploadInput(input: { filename: string; contentType: string }): {
 	const contentTypeExtension = canonicalUploadExtensionForContentType(input.contentType);
 
 	if (!extension) {
-		throw new MulderError('Filename must end with .pdf, .png, .jpg, .jpeg, .tif, or .tiff', 'VALIDATION_ERROR', {
-			context: { filename: input.filename },
-		});
+		throw new MulderError(
+			'Filename must end with .pdf, .png, .jpg, .jpeg, .tif, .tiff, .txt, .md, or .markdown',
+			'VALIDATION_ERROR',
+			{
+				context: { filename: input.filename },
+			},
+		);
 	}
 
 	if (!contentTypeExtension) {
-		throw new MulderError('Only PDF, PNG, JPEG, and TIFF uploads are supported', 'VALIDATION_ERROR', {
+		throw new MulderError('Only PDF, PNG, JPEG, TIFF, TXT, and Markdown uploads are supported', 'VALIDATION_ERROR', {
 			context: { content_type: input.contentType },
 		});
 	}

--- a/apps/api/src/routes/uploads.schemas.ts
+++ b/apps/api/src/routes/uploads.schemas.ts
@@ -7,6 +7,9 @@ const SUPPORTED_UPLOAD_EXTENSIONS = new Map([
 	['jpeg', 'jpg'],
 	['tif', 'tiff'],
 	['tiff', 'tiff'],
+	['txt', 'txt'],
+	['md', 'md'],
+	['markdown', 'md'],
 ]);
 
 const SUPPORTED_UPLOAD_CONTENT_TYPES = new Map([
@@ -14,9 +17,12 @@ const SUPPORTED_UPLOAD_CONTENT_TYPES = new Map([
 	['image/png', 'png'],
 	['image/jpeg', 'jpg'],
 	['image/tiff', 'tiff'],
+	['text/plain', 'txt'],
+	['text/markdown', 'md'],
+	['text/x-markdown', 'md'],
 ]);
 
-export type UploadStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff';
+export type UploadStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff' | 'txt' | 'md';
 
 function filenameExtension(filename: string): string {
 	const basename = filename.split(/[\\/]/).pop() ?? filename;
@@ -26,17 +32,31 @@ function filenameExtension(filename: string): string {
 
 export function canonicalUploadExtensionForFilename(filename: string): UploadStorageExtension | null {
 	const extension = SUPPORTED_UPLOAD_EXTENSIONS.get(filenameExtension(filename));
-	return extension === 'pdf' || extension === 'png' || extension === 'jpg' || extension === 'tiff' ? extension : null;
+	return extension === 'pdf' ||
+		extension === 'png' ||
+		extension === 'jpg' ||
+		extension === 'tiff' ||
+		extension === 'txt' ||
+		extension === 'md'
+		? extension
+		: null;
 }
 
 export function canonicalUploadExtensionForContentType(contentType: string): UploadStorageExtension | null {
 	const normalized = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
 	const extension = SUPPORTED_UPLOAD_CONTENT_TYPES.get(normalized);
-	return extension === 'pdf' || extension === 'png' || extension === 'jpg' || extension === 'tiff' ? extension : null;
+	return extension === 'pdf' ||
+		extension === 'png' ||
+		extension === 'jpg' ||
+		extension === 'tiff' ||
+		extension === 'txt' ||
+		extension === 'md'
+		? extension
+		: null;
 }
 
 export function isSupportedOriginalStoragePath(storagePath: string): boolean {
-	return /^raw\/[^/]+\/original\.(pdf|png|jpg|tiff)$/i.test(storagePath);
+	return /^raw\/[^/]+\/original\.(pdf|png|jpg|tiff|txt|md)$/i.test(storagePath);
 }
 
 export const UploadTransportSchema = z.enum(['gcs_resumable', 'dev_proxy']);
@@ -81,7 +101,7 @@ export const CompleteDocumentUploadRequestSchema = z
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ['filename'],
-				message: 'filename must end with .pdf, .png, .jpg, .jpeg, .tif, or .tiff',
+				message: 'filename must end with .pdf, .png, .jpg, .jpeg, .tif, .tiff, .txt, .md, or .markdown',
 			});
 			return;
 		}

--- a/apps/cli/src/commands/ingest.ts
+++ b/apps/cli/src/commands/ingest.ts
@@ -43,7 +43,7 @@ interface IngestOptions {
 export function registerIngestCommands(program: Command): void {
 	program
 		.command('ingest')
-		.description('Ingest PDFs or supported images — file or directory')
+		.description('Ingest PDFs, images, or supported text files — file or directory')
 		.argument('<path>', 'path to a supported file or directory containing supported files')
 		.option('--dry-run', 'validate without uploading or creating DB records')
 		.option('--tag <tag>', 'tag ingested sources (repeatable)', collect, [])

--- a/apps/cli/src/commands/pipeline.ts
+++ b/apps/cli/src/commands/pipeline.ts
@@ -45,6 +45,7 @@ interface PipelineRunCliOptions {
 	dryRun?: boolean;
 	tag?: string;
 	costEstimate?: boolean;
+	sourceId?: string;
 }
 
 interface PipelineStatusCliOptions {
@@ -95,6 +96,7 @@ function registerRunSubcommand(parent: Command): void {
 		.option('--dry-run', 'Print the planned steps and source count without executing')
 		.option('--cost-estimate', 'show an estimated pipeline cost before executing')
 		.option('--tag <tag>', 'Tag this run for later lookup')
+		.option('--source-id <id>', 'Run against an existing source UUID instead of ingesting a path')
 		.addHelpText(
 			'after',
 			`
@@ -102,7 +104,8 @@ Examples:
   $ mulder pipeline run ./pdfs/                          # Full pipeline on every PDF in a directory
   $ mulder pipeline run paper.pdf --up-to enrich         # Stop after entity extraction
   $ mulder pipeline run paper.pdf --up-to graph          # Stop before global analyze
-  $ mulder pipeline run paper.pdf --from embed           # Resume after enrich on an existing source`,
+  $ mulder pipeline run paper.pdf --from embed           # Resume after enrich on an existing source
+  $ mulder pipeline run --from extract --source-id <id>  # Resume one existing source`,
 		)
 		.action(
 			withErrorHandler(async (path: string | undefined, options: PipelineRunCliOptions) => {
@@ -140,7 +143,17 @@ Examples:
 				}
 
 				const plannedStepsForEstimate = computePlannedStepsForEstimate(fromStep, upToStep);
-				if (!path && plannedStepsForEstimate.includes('ingest')) {
+				if (path && options.sourceId) {
+					printError('<path> and --source-id are mutually exclusive');
+					process.exit(1);
+					return;
+				}
+				if (options.sourceId && plannedStepsForEstimate.includes('ingest')) {
+					printError('--source-id requires --from to select an existing-source step');
+					process.exit(1);
+					return;
+				}
+				if (!path && !options.sourceId && plannedStepsForEstimate.includes('ingest')) {
 					printError('<path> is required unless --from selects existing sources');
 					process.exit(1);
 					return;
@@ -204,6 +217,7 @@ Examples:
 					if (fromStep) runOptions.from = fromStep;
 					if (options.tag) runOptions.tag = options.tag;
 					if (options.dryRun) runOptions.dryRun = true;
+					if (options.sourceId) runOptions.sourceIds = [options.sourceId];
 
 					const result = await executePipelineRun({ path, options: runOptions }, config, services, pool, logger);
 

--- a/apps/cli/src/lib/cost-estimate.ts
+++ b/apps/cli/src/lib/cost-estimate.ts
@@ -12,7 +12,12 @@ import {
 	type ReprocessableStep,
 	type Source,
 } from '@mulder/core';
-import { detectSourceType, isSupportedIngestFilename, type PipelineStepName } from '@mulder/pipeline';
+import {
+	detectSourceType,
+	isSupportedIngestFilename,
+	isSupportedTextFilename,
+	type PipelineStepName,
+} from '@mulder/pipeline';
 
 interface ReprocessEstimateSourcePlan {
 	sourceId: string;
@@ -97,8 +102,26 @@ export async function collectIngestSourceProfiles(inputPath: string): Promise<Es
 				continue;
 			}
 
+			if (detection.sourceType === 'text') {
+				if (!isSupportedTextFilename(filePath)) {
+					throw new IngestError(
+						`Unsupported text source extension for ${filePath}; supported text files must end with .txt, .md, or .markdown`,
+						INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+						{
+							context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
+						},
+					);
+				}
+				sourceProfiles.push({
+					filename: filePath,
+					pageCount: 0,
+					nativeTextRatio: 0,
+				});
+				continue;
+			}
+
 			throw new IngestError(
-				`Unsupported source type "${detection.sourceType}" for ${filePath}; only pdf and image are supported in this step`,
+				`Unsupported source type "${detection.sourceType}" for ${filePath}; only pdf, image, and text are supported in this step`,
 				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
 				{
 					context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -254,7 +254,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J1 | Source type discriminator — `source_type` column, JSONB `format_metadata`, magic-byte detection | §4.3 (sources table), §2.1 |
 | 🟢 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
 | 🟢 | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
-| ⚪ | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
+| 🟡 | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
 | ⚪ | J5 | DOCX ingestion — Office document extraction via `mammoth` / `docx-parser` | §2.1 |
 | ⚪ | J6 | CSV/Excel ingestion — tabular data → Markdown tables, row-level entity hints | §2.1 |
 | ⚪ | J7 | Email ingestion — .eml/.msg parsing, header metadata → entities (sender, recipient, date, thread) | §2.1 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -254,7 +254,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J1 | Source type discriminator — `source_type` column, JSONB `format_metadata`, magic-byte detection | §4.3 (sources table), §2.1 |
 | 🟢 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
 | 🟢 | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
-| 🟡 | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
+| 🟢 | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
 | ⚪ | J5 | DOCX ingestion — Office document extraction via `mammoth` / `docx-parser` | §2.1 |
 | ⚪ | J6 | CSV/Excel ingestion — tabular data → Markdown tables, row-level entity hints | §2.1 |
 | ⚪ | J7 | Email ingestion — .eml/.msg parsing, header metadata → entities (sender, recipient, date, thread) | §2.1 |

--- a/docs/specs/88_plain_text_ingestion_prestructured_path.spec.md
+++ b/docs/specs/88_plain_text_ingestion_prestructured_path.spec.md
@@ -1,0 +1,222 @@
+---
+spec: "88"
+title: "Plain Text Ingestion on the Pre-Structured Path"
+roadmap_step: M9-J4
+functional_spec: ["§2", "§2.1", "§3", "§4.5"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/233"
+created: 2026-04-30
+---
+
+# Spec 88: Plain Text Ingestion on the Pre-Structured Path
+
+## 1. Objective
+
+Add M9-J4 plain text ingestion so `.txt`, `.md`, and `.markdown` files can enter Mulder as first-class `text` sources. Text sources are already part of the M9 discriminator from Spec 85 and the pre-structured skip rules from Spec 86; this step turns that scaffolding into an executable path where ingest stores the original text, extract converts it directly into story Markdown, and downstream processing runs `enrich -> embed -> graph` without OCR or segmentation.
+
+This fulfills the roadmap requirement for plain text and Markdown pass-through while preserving the functional-spec contracts from `§2` (step contracts and service-boundary discipline), `§2.1` (ingest registers sources and storage objects), `§3` (PostgreSQL-authoritative pipeline orchestration and skipped steps), and `§4.5` (pipeline code uses service interfaces rather than direct GCP clients).
+
+## 2. Boundaries
+
+**Roadmap step:** M9-J4 - Plain text ingestion: `.txt`, `.md` pass-through with no OCR and no segment step.
+
+**Base branch:** `milestone/9`. This spec is delivered to the M9 integration branch, not directly to `main`.
+
+**Target files:**
+
+- `packages/pipeline/src/ingest/source-type.ts`
+- `packages/pipeline/src/ingest/types.ts`
+- `packages/pipeline/src/ingest/index.ts`
+- `packages/pipeline/src/extract/index.ts`
+- `packages/pipeline/src/extract/types.ts`
+- `apps/cli/src/commands/ingest.ts`
+- `apps/cli/src/lib/cost-estimate.ts`
+- `apps/api/src/routes/uploads.schemas.ts`
+- `apps/api/src/lib/uploads.ts`
+- `packages/worker/src/dispatch.ts`
+- `tests/specs/88_plain_text_ingestion_prestructured_path.test.ts`
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Accept `.txt`, `.md`, and `.markdown` files in CLI ingest.
+- Expand directory ingest discovery and ingest cost profiling so directories may contain PDFs, images, and supported text files.
+- Preserve magic/content detection precedence from Spec 85: decisive PDF/image magic bytes still win over misleading text extensions.
+- Store text sources with `source_type = 'text'`, `page_count = 0`, `has_native_text = false`, `native_text_ratio = 0`, and `format_metadata` containing at least `media_type`, original extension, byte size, character count, line count, and UTF-8 encoding.
+- Upload text originals under `raw/{source_id}/original.txt` or `raw/{source_id}/original.md` using the detected text media type.
+- Keep duplicate detection based on the existing file hash path.
+- Update API/browser upload initiation, completion validation, dev upload proxy, and worker finalization so supported text uploads reach the same source record and pipeline job path as CLI ingests.
+- Add an extract path for `text` sources that:
+  - downloads the stored text original through the storage service,
+  - decodes it as UTF-8,
+  - preserves Markdown input as Markdown,
+  - wraps plain `.txt` input into minimal Markdown without inventing facts,
+  - writes `segments/{source_id}/{story_id}.md` and `.meta.json`,
+  - creates a `stories` row in PostgreSQL,
+  - marks `source_steps.extract` completed and the source status `extracted`.
+- Let Spec 86's planner record `segment` as skipped when pipeline runs include that step for `text` sources.
+- Preserve all current PDF and image ingest, extract, upload, and pipeline behavior.
+
+**Out of scope:**
+
+- DOCX, spreadsheet, email, or URL ingestion. Those remain M9-J5 through M9-J10.
+- Format-aware extract routing beyond the new text branch in the existing extract step. The broader dispatch cleanup is M9-J11.
+- Row-level chunking, semantic splitting, or LLM summarization during text extract.
+- Cross-format deduplication beyond existing file-hash duplicate handling. That is M9-J12.
+- New database columns or changes to the `sources.source_type` enum; Spec 85 already added `text`.
+- New direct GCP client usage in pipeline, CLI, API, or worker code.
+
+**Architectural constraints:**
+
+- PostgreSQL remains authoritative for source identity and pipeline state.
+- Firestore remains write-only observability.
+- Service abstractions remain the only boundary for storage and Firestore effects.
+- Unsupported or unknown files must fail before source creation.
+- Text extraction must be deterministic and cost-free: no Document AI, no Gemini Vision, and no Segment step.
+
+## 3. Dependencies
+
+**Requires:**
+
+- M9-J1 / Spec 85: `source_type`, `format_metadata`, and text detection scaffolding.
+- M9-J2 / Spec 86: source-type-aware pipeline planning where `text` skips `segment`.
+- M9-J3 / Spec 87: broadened ingest/upload patterns for non-PDF source types.
+- M2-B4 / Spec 16: existing ingest implementation.
+- M3-C1 / Spec 22: story repository and story storage conventions.
+
+**Blocks:**
+
+- M9-J5 DOCX ingestion.
+- M9-J6 CSV/Excel ingestion.
+- M9-J7 email ingestion.
+- M9-J8 URL ingestion.
+- M9-J11 format-aware extract routing.
+- M9-J13 multi-format golden tests.
+
+No cross-milestone dependency blocks this step.
+
+## 4. Blueprint
+
+### Phase 1: Text detection and metadata helpers
+
+1. Expand `SUPPORTED_INGEST_EXTENSIONS` in `packages/pipeline/src/ingest/source-type.ts` to include `.txt`, `.md`, and `.markdown`.
+2. Add canonical text media/storage helpers:
+   - `text/plain` -> `txt`
+   - `text/markdown` and `text/x-markdown` -> `md`
+3. Add a reusable text metadata builder that records:
+   - `media_type`
+   - `original_extension`
+   - `byte_size`
+   - `character_count`
+   - `line_count`
+   - `encoding = "utf-8"`
+4. Keep unknown binary files rejected and keep CSV/email shape detection ahead of generic readable-text fallback.
+
+### Phase 2: CLI ingest and cost estimation
+
+1. Add `text` to the ingestible source types in `packages/pipeline/src/ingest/index.ts`.
+2. For `.txt`, `.md`, and `.markdown`:
+   - validate file size with the existing ingest gate,
+   - require readable UTF-8 text,
+   - skip PDF metadata extraction and native text detection,
+   - create a source row with `sourceType: 'text'`,
+   - store text metadata in both `formatMetadata` and compatibility `metadata`,
+   - upload the original using the canonical raw extension and media type.
+3. Keep CLI table columns unchanged while allowing `Type = text`, `Pages = 0`, and `Native Text = no`.
+4. Update `apps/cli/src/lib/cost-estimate.ts` so text files are accepted in ingest profiling, count as zero scanned/layout pages, and do not reserve extract or segment OCR-style costs.
+5. Keep PDF and image cost/profile behavior unchanged.
+
+### Phase 3: API upload and worker finalization
+
+1. Update `apps/api/src/routes/uploads.schemas.ts` to accept `.txt`, `.md`, and `.markdown` filenames plus `text/plain`, `text/markdown`, and `text/x-markdown` content types.
+2. Keep content-type/extension agreement strict and generate canonical storage paths (`original.txt` or `original.md`).
+3. Update `apps/api/src/lib/uploads.ts` validation messages and initiation output to include supported text files.
+4. Update `packages/worker/src/dispatch.ts` upload finalization so `text` is finalizable:
+   - validate detected source type from bytes/filename,
+   - compute the same text metadata as CLI ingest,
+   - canonicalize upload storage paths if needed,
+   - create the source row transactionally,
+   - emit Firestore observability with `sourceType: text`,
+   - enqueue `extract` when `startPipeline` is true.
+5. Preserve duplicate cleanup and retry-safe upload canonicalization from Spec 87.
+
+### Phase 4: Text extract path
+
+1. Branch `packages/pipeline/src/extract/index.ts` by `source.sourceType`.
+2. Preserve the existing PDF/image layout extract path exactly for layout sources.
+3. For `text` sources:
+   - download `source.storagePath` through `services.storage`,
+   - decode as UTF-8 and reject unreadable/binary content with a typed extract error,
+   - normalize Markdown line endings,
+   - for plain text, create Markdown with a title heading derived from the filename and escaped body text,
+   - for Markdown, preserve the input body and derive a story title from the first heading or filename,
+   - write `segments/{source_id}/{story_id}.md` and `segments/{source_id}/{story_id}.meta.json`,
+   - call `createStory()` with the written URIs, detected title, `pageStart = null`, `pageEnd = null`, `extractionConfidence = 1.0`, and metadata that records `source_type = text` and whether the input was Markdown,
+   - update the source status to `extracted`,
+   - upsert `source_steps.extract = completed`,
+   - write Firestore extract observability.
+4. Do not write layout JSON or page images for text sources.
+5. Let pipeline/worker step planning skip `segment`; do not special-case `segment` inside text extract.
+
+### Phase 5: QA and compatibility
+
+1. Add `tests/specs/88_plain_text_ingestion_prestructured_path.test.ts`.
+2. Use black-box boundaries: CLI subprocesses, API requests, worker job processing, public package exports, SQL checks, and local dev storage artifacts.
+3. Run the existing Spec 85, Spec 86, and Spec 87 suites that cover format detection, step skipping, and non-PDF compatibility.
+
+## 5. QA Contract
+
+**QA-01: CLI dry-run accepts text sources without persistence**
+
+Given valid `.txt`, `.md`, and `.markdown` fixtures, when `mulder ingest --dry-run` is run for each file, then the command exits 0, prints `Type` as `text`, prints `Pages` as `0`, and no `sources` row or storage object is created.
+
+**QA-02: CLI text ingest persists text metadata**
+
+Given a valid `.txt` file, when `mulder ingest` runs, then the command exits 0 and the database source row has `source_type = 'text'`, `page_count = 0`, `has_native_text = false`, `native_text_ratio = 0`, a `raw/{source_id}/original.txt` storage path, and `format_metadata.media_type = 'text/plain'`.
+
+**QA-03: Markdown ingest preserves Markdown format metadata**
+
+Given a valid `.md` or `.markdown` file, when `mulder ingest` runs, then the source row has `source_type = 'text'`, a canonical `original.md` storage path, and `format_metadata.media_type = 'text/markdown'`.
+
+**QA-04: Directory ingest discovers PDFs, images, and text files**
+
+Given a directory containing one PDF, one PNG, one `.txt`, and one `.md`, when `mulder ingest --dry-run <dir>` runs, then all four supported files appear in the output with their respective source types and the command exits 0.
+
+**QA-05: Magic bytes remain authoritative**
+
+Given a PDF or PNG saved with a `.txt` extension, when `mulder ingest --dry-run` runs, then it reports the magic-byte source type (`pdf` or `image`) rather than `text`.
+
+**QA-06: Text extract creates a pre-structured story**
+
+Given an ingested text source in dev mode, when `mulder extract <source_id>` runs, then the source reaches `extracted`, exactly one story row exists for the source, the story Markdown object exists under `segments/{source_id}/`, no `extracted/{source_id}/layout.json` is written, and `source_steps.extract` is `completed`.
+
+**QA-07: Pipeline skips segment for text after extract**
+
+Given an ingested text source, when `mulder pipeline run --from extract --up-to enrich --source-id <source_id>` or the equivalent existing-source path runs, then `extract` executes, `segment` is recorded as skipped, `enrich` runs against the created story, and no segment job/artifact is created.
+
+**QA-08: API upload accepts text media types**
+
+Given an upload initiation request for `note.md` with `content_type = text/markdown`, when the upload is completed and the finalize job runs, then a source row is created with `source_type = 'text'`, a canonical `original.md` storage path, and an `extract` job is queued when `start_pipeline` is true.
+
+**QA-09: Duplicate text ingest returns the existing source**
+
+Given the same text file is ingested twice, when the second ingest runs, then it reports duplicate status, does not create a second source row for the same file hash, and preserves `source_type = 'text'`.
+
+**QA-10: Existing PDF and image behavior remains green**
+
+Given the existing Spec 16, Spec 85, Spec 86, and Spec 87 tests, when they run after this change, then PDF/image ingest, extract, duplicate handling, upload finalization, and pipeline planning remain compatible.
+
+## 5b. CLI Test Matrix
+
+| Command | Input | Expected |
+| --- | --- | --- |
+| `mulder ingest --dry-run <tmp>/note.txt` | Plain text | Exit 0; output includes `text`, `Pages` = `0`; no DB/storage persistence. |
+| `mulder ingest <tmp>/note.txt` | Plain text | Exit 0; DB row has `source_type = text`; storage path ends in `original.txt`. |
+| `mulder ingest <tmp>/brief.md` | Markdown | Exit 0; DB row has `format_metadata.media_type = text/markdown`; storage path ends in `original.md`. |
+| `mulder ingest --dry-run <tmp>/mixed-dir` | PDF + PNG + TXT + MD | Exit 0; output includes `pdf`, `image`, and `text`. |
+| `mulder extract <text-source-id>` | Ingested text source | Exit 0; one story is created directly from text; no layout JSON is written. |
+| `mulder pipeline run --from extract --up-to enrich --source-id <text-source-id>` | Ingested text source | Exit 0; `segment` is skipped; story reaches `enriched`. |
+
+## 6. Cost Considerations
+
+Text ingestion and text extract are deterministic local/storage/database operations. They must not call Document AI, Gemini Vision, or the Segment LLM path. Cost estimation should show text files as zero scanned/layout pages for extract and should avoid reserving segment cost for text sources because Spec 86 skips `segment` for pre-structured formats. Downstream `enrich`, `embed`, and `graph` costs remain unchanged once text has produced story Markdown.

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -101,6 +101,8 @@ function contentTypeForBucketPath(bucketPath: string): string {
 	if (lowerPath.endsWith('.png')) return 'image/png';
 	if (lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) return 'image/jpeg';
 	if (lowerPath.endsWith('.tif') || lowerPath.endsWith('.tiff')) return 'image/tiff';
+	if (lowerPath.endsWith('.txt')) return 'text/plain';
+	if (lowerPath.endsWith('.md') || lowerPath.endsWith('.markdown')) return 'text/markdown';
 	return 'application/octet-stream';
 }
 

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -29,7 +29,12 @@ import {
 } from '@mulder/core';
 import { PDFParse } from 'pdf-parse';
 import type pg from 'pg';
-import { decodeUtf8TextBuffer, detectSourceType, isSupportedImageMediaType } from '../ingest/source-type.js';
+import {
+	decodeUtf8TextBuffer,
+	detectSourceType,
+	isReadableText,
+	isSupportedImageMediaType,
+} from '../ingest/source-type.js';
 import { layoutToMarkdown } from './layout-to-markdown.js';
 import type { ExtractInput, ExtractionData, ExtractResult, LayoutBlock, LayoutDocument, LayoutPage } from './types.js';
 
@@ -273,7 +278,7 @@ async function extractTextSource(input: {
 	}
 
 	const decoded = decodeUtf8TextBuffer(buffer);
-	if (decoded === null) {
+	if (decoded === null || !isReadableText(buffer)) {
 		throw new ExtractError(
 			`Text source is not readable UTF-8: ${input.sourceId}`,
 			EXTRACT_ERROR_CODES.EXTRACT_NATIVE_TEXT_FAILED,

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -12,10 +12,12 @@
  * @see docs/functional-spec.md §2.2
  */
 
+import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import type { DocumentAiResult, Logger, MulderConfig, Services, StepError } from '@mulder/core';
 import {
 	createChildLogger,
+	createStory,
 	EXTRACT_ERROR_CODES,
 	ExtractError,
 	findSourceById,
@@ -27,7 +29,7 @@ import {
 } from '@mulder/core';
 import { PDFParse } from 'pdf-parse';
 import type pg from 'pg';
-import { detectSourceType, isSupportedImageMediaType } from '../ingest/source-type.js';
+import { decodeUtf8TextBuffer, detectSourceType, isSupportedImageMediaType } from '../ingest/source-type.js';
 import { layoutToMarkdown } from './layout-to-markdown.js';
 import type { ExtractInput, ExtractionData, ExtractResult, LayoutBlock, LayoutDocument, LayoutPage } from './types.js';
 
@@ -39,6 +41,7 @@ export type {
 	ExtractResult,
 	LayoutDocument,
 	PageExtraction,
+	PrimaryExtractionMethod,
 } from './types.js';
 
 // ────────────────────────────────────────────────────────────
@@ -165,6 +168,182 @@ function resolveSourceMediaType(
 	}
 
 	return null;
+}
+
+// ────────────────────────────────────────────────────────────
+// Text extraction helpers
+// ────────────────────────────────────────────────────────────
+
+interface TextStoryMetadataJson {
+	id: string;
+	document_id: string;
+	title: string;
+	subtitle: null;
+	language: string;
+	category: string;
+	pages: number[];
+	date_references: string[];
+	geographic_references: string[];
+	extraction_confidence: number;
+	source_type: 'text';
+	is_markdown: boolean;
+}
+
+function normalizeMarkdownLineEndings(text: string): string {
+	return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function titleFromFilename(filename: string): string {
+	const basename = filename.split(/[\\/]/).pop() ?? filename;
+	const withoutExtension = basename.replace(/\.[^.]+$/, '');
+	const spaced = withoutExtension.replace(/[-_]+/g, ' ').trim();
+	return spaced.length > 0 ? spaced : 'Untitled text source';
+}
+
+function stripMarkdownInlineSyntax(value: string): string {
+	return value
+		.replace(/[`*_~[\]()]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function deriveMarkdownTitle(markdown: string, filename: string): string {
+	const heading = markdown.match(/^#{1,6}\s+(.+?)\s*#*\s*$/m);
+	if (!heading?.[1]) {
+		return titleFromFilename(filename);
+	}
+	const title = stripMarkdownInlineSyntax(heading[1]);
+	return title.length > 0 ? title : titleFromFilename(filename);
+}
+
+function escapePlainTextForMarkdown(text: string): string {
+	return text
+		.split('\n')
+		.map((line) => line.replace(/([\\`*_{}[\]<>()#+.!|-])/g, '\\$1'))
+		.join('\n');
+}
+
+function isMarkdownMediaType(mediaType: unknown): boolean {
+	return mediaType === 'text/markdown' || mediaType === 'text/x-markdown';
+}
+
+function buildTextStoryMetadata(input: {
+	storyId: string;
+	sourceId: string;
+	title: string;
+	language: string;
+	isMarkdown: boolean;
+}): TextStoryMetadataJson {
+	return {
+		id: input.storyId,
+		document_id: input.sourceId,
+		title: input.title,
+		subtitle: null,
+		language: input.language,
+		category: 'document',
+		pages: [],
+		date_references: [],
+		geographic_references: [],
+		extraction_confidence: 1.0,
+		source_type: 'text',
+		is_markdown: input.isMarkdown,
+	};
+}
+
+async function extractTextSource(input: {
+	sourceId: string;
+	filename: string;
+	storagePath: string;
+	formatMetadata: Record<string, unknown>;
+	config: MulderConfig;
+	services: Services;
+	pool: pg.Pool;
+	stepConfigHash: string;
+	logger: Logger;
+}): Promise<ExtractionData> {
+	let buffer: Buffer;
+	try {
+		buffer = await input.services.storage.download(input.storagePath);
+	} catch (cause: unknown) {
+		throw new ExtractError(
+			`Failed to download text source original for source ${input.sourceId}`,
+			EXTRACT_ERROR_CODES.EXTRACT_STORAGE_FAILED,
+			{ cause, context: { sourceId: input.sourceId, storagePath: input.storagePath } },
+		);
+	}
+
+	const decoded = decodeUtf8TextBuffer(buffer);
+	if (decoded === null) {
+		throw new ExtractError(
+			`Text source is not readable UTF-8: ${input.sourceId}`,
+			EXTRACT_ERROR_CODES.EXTRACT_NATIVE_TEXT_FAILED,
+			{ context: { sourceId: input.sourceId, storagePath: input.storagePath } },
+		);
+	}
+
+	const normalizedText = normalizeMarkdownLineEndings(decoded);
+	const isMarkdown = isMarkdownMediaType(input.formatMetadata.media_type) || /\.m(?:d|arkdown)$/i.test(input.filename);
+	const title = isMarkdown ? deriveMarkdownTitle(normalizedText, input.filename) : titleFromFilename(input.filename);
+	const markdown = isMarkdown ? normalizedText : `# ${title}\n\n${escapePlainTextForMarkdown(normalizedText)}`;
+	const language = input.config.project.supported_locales[0] ?? 'en';
+	const storyId = randomUUID();
+	const markdownUri = `segments/${input.sourceId}/${storyId}.md`;
+	const metadataUri = `segments/${input.sourceId}/${storyId}.meta.json`;
+	const storyMetadata = buildTextStoryMetadata({
+		storyId,
+		sourceId: input.sourceId,
+		title,
+		language,
+		isMarkdown,
+	});
+
+	try {
+		await input.services.storage.upload(markdownUri, markdown, 'text/markdown');
+		await input.services.storage.upload(metadataUri, JSON.stringify(storyMetadata, null, 2), 'application/json');
+	} catch (cause: unknown) {
+		throw new ExtractError(
+			`Failed to write text story artifacts for source ${input.sourceId}`,
+			EXTRACT_ERROR_CODES.EXTRACT_STORAGE_FAILED,
+			{ cause, context: { sourceId: input.sourceId, markdownUri, metadataUri } },
+		);
+	}
+
+	await createStory(input.pool, {
+		id: storyId,
+		sourceId: input.sourceId,
+		title,
+		language,
+		category: 'document',
+		gcsMarkdownUri: markdownUri,
+		gcsMetadataUri: metadataUri,
+		extractionConfidence: 1.0,
+		metadata: {
+			source_type: 'text',
+			is_markdown: isMarkdown,
+			original_storage_path: input.storagePath,
+		},
+	});
+
+	await updateSourceStatus(input.pool, input.sourceId, 'extracted');
+	await upsertSourceStep(input.pool, {
+		sourceId: input.sourceId,
+		stepName: STEP_NAME,
+		status: 'completed',
+		configHash: input.stepConfigHash,
+	});
+
+	input.logger.debug({ storyId, markdownUri, isMarkdown }, 'Text source extracted into story Markdown');
+
+	return {
+		sourceId: input.sourceId,
+		layoutUri: null,
+		pageImageUris: [],
+		pageCount: 0,
+		primaryMethod: 'text',
+		pages: [],
+		visionFallbackCount: 0,
+		visionFallbackCapped: false,
+	};
 }
 
 // ────────────────────────────────────────────────────────────
@@ -393,6 +572,13 @@ async function forceCleanup(sourceId: string, services: Services, pool: pg.Pool,
 	}
 	logger.debug({ sourceId, deletedFiles: existing.paths.length }, 'Deleted existing extraction artifacts');
 
+	const segmentPrefix = `segments/${sourceId}/`;
+	const existingSegments = await services.storage.list(segmentPrefix);
+	for (const path of existingSegments.paths) {
+		await services.storage.delete(path);
+	}
+	logger.debug({ sourceId, deletedFiles: existingSegments.paths.length }, 'Deleted downstream segment artifacts');
+
 	// 2. Atomic DB reset — cascading-deletes stories, chunks, edges, ALL source_steps
 	await resetPipelineStep(pool, sourceId, 'extract');
 	logger.info({ sourceId }, 'Force cleanup complete — source status reset to ingested');
@@ -542,7 +728,27 @@ export async function execute(
 	let extractionData: ExtractionData;
 
 	// ── Path C: Fallback only ────────────────────────────
-	if (input.fallbackOnly) {
+	if (source.sourceType === 'text' && input.fallbackOnly) {
+		throw new ExtractError(
+			`Source type "${source.sourceType}" does not support vision fallback`,
+			EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
+			{ context: { sourceId: input.sourceId, sourceType: source.sourceType } },
+		);
+	}
+
+	if (!input.fallbackOnly && source.sourceType === 'text') {
+		extractionData = await extractTextSource({
+			sourceId: input.sourceId,
+			filename: source.filename,
+			storagePath: source.storagePath,
+			formatMetadata: source.formatMetadata,
+			config,
+			services,
+			pool,
+			stepConfigHash,
+			logger: log,
+		});
+	} else if (input.fallbackOnly) {
 		log.info('Running vision fallback only on existing extraction');
 
 		// Download existing layout.json

--- a/packages/pipeline/src/extract/types.ts
+++ b/packages/pipeline/src/extract/types.ts
@@ -28,6 +28,9 @@ export interface ExtractInput {
 /** The extraction method used for a given page. */
 export type ExtractionMethod = 'native' | 'document_ai' | 'vision_fallback';
 
+/** The source-level extraction path used for a completed extract step. */
+export type PrimaryExtractionMethod = 'native' | 'document_ai' | 'text';
+
 /** Per-page extraction details. */
 export interface PageExtraction {
 	/** 1-indexed page number. */
@@ -45,13 +48,13 @@ export interface ExtractionData {
 	/** Source UUID. */
 	sourceId: string;
 	/** GCS URI: extracted/{doc-id}/layout.json */
-	layoutUri: string;
+	layoutUri: string | null;
 	/** GCS URIs: extracted/{doc-id}/pages/page-NNN.png */
 	pageImageUris: string[];
 	/** Total number of pages. */
 	pageCount: number;
 	/** Primary extraction method (native or document_ai). */
-	primaryMethod: 'native' | 'document_ai';
+	primaryMethod: PrimaryExtractionMethod;
 	/** Per-page extraction details. */
 	pages: PageExtraction[];
 	/** How many pages used Gemini Vision fallback. */
@@ -98,7 +101,7 @@ export interface LayoutPage {
 export interface LayoutDocument {
 	sourceId: string;
 	pageCount: number;
-	primaryMethod: 'native' | 'document_ai';
+	primaryMethod: Exclude<PrimaryExtractionMethod, 'text'>;
 	extractedAt: string;
 	pages: LayoutPage[];
 	metadata: {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -67,6 +67,7 @@ export type {
 	ExtractResult,
 	LayoutDocument,
 	PageExtraction,
+	PrimaryExtractionMethod,
 } from './extract/index.js';
 export { execute as executeExtract, layoutToMarkdown } from './extract/index.js';
 export type {
@@ -100,16 +101,22 @@ export type {
 	SourceDetectionResult,
 	SourceStorageExtension,
 	SupportedImageMediaType,
+	SupportedTextMediaType,
 } from './ingest/index.js';
 export {
 	buildImageFormatMetadata,
+	buildTextFormatMetadata,
+	decodeUtf8TextBuffer,
 	detectSourceType,
 	execute as executeIngest,
 	getCanonicalStorageExtensionForMediaType,
 	getOriginalExtension,
 	getStorageExtensionForDetection,
+	isReadableText,
 	isSupportedImageMediaType,
 	isSupportedIngestFilename,
+	isSupportedTextFilename,
+	isSupportedTextMediaType,
 	readImageDimensions,
 	resolveIngestFiles,
 	resolvePdfFiles,

--- a/packages/pipeline/src/ingest/index.ts
+++ b/packages/pipeline/src/ingest/index.ts
@@ -35,10 +35,13 @@ import {
 import type pg from 'pg';
 import {
 	buildImageFormatMetadata,
+	buildTextFormatMetadata,
 	detectSourceType,
 	getStorageExtensionForDetection,
 	isSupportedImageMediaType,
 	isSupportedIngestFilename,
+	isSupportedTextFilename,
+	isSupportedTextMediaType,
 } from './source-type.js';
 import type { IngestFileResult, IngestInput, IngestResult } from './types.js';
 
@@ -48,15 +51,21 @@ export type {
 	SourceDetectionResult,
 	SourceStorageExtension,
 	SupportedImageMediaType,
+	SupportedTextMediaType,
 } from './source-type.js';
 export {
 	buildImageFormatMetadata,
+	buildTextFormatMetadata,
+	decodeUtf8TextBuffer,
 	detectSourceType,
 	getCanonicalStorageExtensionForMediaType,
 	getOriginalExtension,
 	getStorageExtensionForDetection,
+	isReadableText,
 	isSupportedImageMediaType,
 	isSupportedIngestFilename,
+	isSupportedTextFilename,
+	isSupportedTextMediaType,
 	readImageDimensions,
 } from './source-type.js';
 export type { IngestFileResult, IngestInput, IngestResult } from './types.js';
@@ -69,7 +78,7 @@ const STEP_NAME = 'ingest';
 
 /**
  * Resolves the input path to a list of supported ingest file paths.
- * If the path is a directory, recursively finds PDFs and supported images.
+ * If the path is a directory, recursively finds supported ingest files.
  * If the path is a single file, returns it as-is so validation can report
  * an explicit unsupported-format error.
  */
@@ -146,7 +155,7 @@ interface ProcessFileContext {
 	dryRun: boolean;
 }
 
-type IngestibleSourceType = Extract<SourceType, 'pdf' | 'image'>;
+type IngestibleSourceType = Extract<SourceType, 'pdf' | 'image' | 'text'>;
 
 interface PreparedFileMetadata {
 	sourceType: IngestibleSourceType;
@@ -160,7 +169,7 @@ interface PreparedFileMetadata {
 }
 
 function isIngestibleSourceType(sourceType: SourceType): sourceType is IngestibleSourceType {
-	return sourceType === 'pdf' || sourceType === 'image';
+	return sourceType === 'pdf' || sourceType === 'image' || sourceType === 'text';
 }
 
 /**
@@ -203,7 +212,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 
 	if (!isIngestibleSourceType(detection.sourceType)) {
 		throw new IngestError(
-			`Unsupported source type "${detection.sourceType}" for ${filename}; only pdf and image are supported in this step`,
+			`Unsupported source type "${detection.sourceType}" for ${filename}; only pdf, image, and text are supported in this step`,
 			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
 			{
 				context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
@@ -265,7 +274,7 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 			nativeTextRatio: textResult.nativeTextRatio,
 			pdfMetadata: pdfMeta,
 		};
-	} else {
+	} else if (detection.sourceType === 'image') {
 		if (!isSupportedImageMediaType(detection.mediaType)) {
 			throw new IngestError(
 				`Unsupported image media type for ${filename}`,
@@ -286,6 +295,48 @@ async function processFile(filePath: string, ctx: ProcessFileContext): Promise<I
 			nativeTextRatio: 0,
 		};
 		log.debug({ sourceType: 'image', mediaType: detection.mediaType, pageCount: 1 }, 'Image metadata prepared');
+	} else {
+		if (!isSupportedTextFilename(filename)) {
+			throw new IngestError(
+				`Unsupported text source extension for ${filename}; supported text files must end with .txt, .md, or .markdown`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { path: filePath, sourceType: detection.sourceType, confidence: detection.confidence },
+				},
+			);
+		}
+
+		if (!isSupportedTextMediaType(detection.mediaType)) {
+			throw new IngestError(
+				`Unsupported text media type for ${filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { path: filePath, mediaType: detection.mediaType },
+				},
+			);
+		}
+
+		const formatMetadata = buildTextFormatMetadata(buffer, filename, detection.mediaType);
+		if (!formatMetadata) {
+			throw new IngestError(
+				`Text source is not readable UTF-8: ${filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { path: filePath, mediaType: detection.mediaType },
+				},
+			);
+		}
+
+		prepared = {
+			sourceType: 'text',
+			mediaType: typeof formatMetadata.media_type === 'string' ? formatMetadata.media_type : detection.mediaType,
+			storageExtension,
+			formatMetadata,
+			pageCount: 0,
+			hasNativeText: false,
+			nativeTextRatio: 0,
+		};
+		log.debug({ sourceType: 'text', mediaType: prepared.mediaType, pageCount: 0 }, 'Text metadata prepared');
 	}
 
 	// f. Compute SHA-256 hash

--- a/packages/pipeline/src/ingest/source-type.ts
+++ b/packages/pipeline/src/ingest/source-type.ts
@@ -219,20 +219,22 @@ export function isReadableText(buffer: Buffer): boolean {
 		return false;
 	}
 
-	const sample = buffer.subarray(0, Math.min(buffer.length, 4096));
-	let suspiciousControlBytes = 0;
-	for (const byte of sample) {
-		if (byte === 0x00) {
+	for (let index = 0; index < decoded.length; index++) {
+		const codePoint = decoded.codePointAt(index);
+		if (codePoint === undefined) {
+			continue;
+		}
+		if (codePoint > 0xffff) {
+			index++;
+		}
+		if (codePoint === 0x00) {
 			return false;
 		}
-		const isAllowedWhitespace = byte === 0x09 || byte === 0x0a || byte === 0x0d;
-		if (byte < 0x20 && !isAllowedWhitespace) {
-			suspiciousControlBytes++;
+		const isAllowedWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+		const isControlCharacter = codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f);
+		if (isControlCharacter && !isAllowedWhitespace) {
+			return false;
 		}
-	}
-
-	if (suspiciousControlBytes / sample.length > 0.02) {
-		return false;
 	}
 
 	const replacementCount = decoded.split('\uFFFD').length - 1;

--- a/packages/pipeline/src/ingest/source-type.ts
+++ b/packages/pipeline/src/ingest/source-type.ts
@@ -1,9 +1,11 @@
 import { extname } from 'node:path';
+import { TextDecoder } from 'node:util';
 import type { SourceFormatMetadata, SourceType } from '@mulder/core';
 
 export type SourceDetectionConfidence = 'magic' | 'extension' | 'content';
 export type SupportedImageMediaType = 'image/png' | 'image/jpeg' | 'image/tiff';
-export type SourceStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff';
+export type SupportedTextMediaType = 'text/plain' | 'text/markdown' | 'text/x-markdown';
+export type SourceStorageExtension = 'pdf' | 'png' | 'jpg' | 'tiff' | 'txt' | 'md';
 
 export interface SourceDetectionResult {
 	sourceType: SourceType;
@@ -27,6 +29,9 @@ const PDF_MEDIA_TYPE = 'application/pdf';
 const PNG_MEDIA_TYPE: SupportedImageMediaType = 'image/png';
 const JPEG_MEDIA_TYPE: SupportedImageMediaType = 'image/jpeg';
 const TIFF_MEDIA_TYPE: SupportedImageMediaType = 'image/tiff';
+const PLAIN_TEXT_MEDIA_TYPE: SupportedTextMediaType = 'text/plain';
+const MARKDOWN_MEDIA_TYPE: SupportedTextMediaType = 'text/markdown';
+const X_MARKDOWN_MEDIA_TYPE: SupportedTextMediaType = 'text/x-markdown';
 const DOCX_MEDIA_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 const XLSX_MEDIA_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
@@ -36,7 +41,23 @@ const IMAGE_STORAGE_EXTENSIONS_BY_MEDIA_TYPE: Record<SupportedImageMediaType, So
 	'image/tiff': 'tiff',
 };
 
-const SUPPORTED_INGEST_EXTENSIONS = new Set(['.pdf', '.png', '.jpg', '.jpeg', '.tif', '.tiff']);
+const TEXT_STORAGE_EXTENSIONS_BY_MEDIA_TYPE: Record<SupportedTextMediaType, SourceStorageExtension> = {
+	'text/plain': 'txt',
+	'text/markdown': 'md',
+	'text/x-markdown': 'md',
+};
+
+const SUPPORTED_INGEST_EXTENSIONS = new Set([
+	'.pdf',
+	'.png',
+	'.jpg',
+	'.jpeg',
+	'.tif',
+	'.tiff',
+	'.txt',
+	'.md',
+	'.markdown',
+]);
 
 function hasPrefix(buffer: Buffer, signature: Buffer): boolean {
 	return buffer.length >= signature.length && buffer.subarray(0, signature.length).equals(signature);
@@ -56,6 +77,11 @@ export function isSupportedIngestFilename(input: string): boolean {
 	return SUPPORTED_INGEST_EXTENSIONS.has(getExtension(input));
 }
 
+export function isSupportedTextFilename(input: string): boolean {
+	const extension = getExtension(input);
+	return extension === '.txt' || extension === '.md' || extension === '.markdown';
+}
+
 export function getOriginalExtension(input: string): string {
 	return getExtension(input).replace(/^\./, '');
 }
@@ -64,12 +90,21 @@ export function isSupportedImageMediaType(mediaType: string | undefined): mediaT
 	return mediaType === PNG_MEDIA_TYPE || mediaType === JPEG_MEDIA_TYPE || mediaType === TIFF_MEDIA_TYPE;
 }
 
+export function isSupportedTextMediaType(mediaType: string | undefined): mediaType is SupportedTextMediaType {
+	return (
+		mediaType === PLAIN_TEXT_MEDIA_TYPE || mediaType === MARKDOWN_MEDIA_TYPE || mediaType === X_MARKDOWN_MEDIA_TYPE
+	);
+}
+
 export function getCanonicalStorageExtensionForMediaType(mediaType: string | undefined): SourceStorageExtension | null {
 	if (mediaType === PDF_MEDIA_TYPE) {
 		return 'pdf';
 	}
 	if (isSupportedImageMediaType(mediaType)) {
 		return IMAGE_STORAGE_EXTENSIONS_BY_MEDIA_TYPE[mediaType];
+	}
+	if (isSupportedTextMediaType(mediaType)) {
+		return TEXT_STORAGE_EXTENSIONS_BY_MEDIA_TYPE[mediaType];
 	}
 	return null;
 }
@@ -165,8 +200,22 @@ export function buildImageFormatMetadata(
 	return metadata;
 }
 
-function isReadableText(buffer: Buffer): boolean {
+export function decodeUtf8TextBuffer(buffer: Buffer): string | null {
+	try {
+		const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false });
+		return decoder.decode(buffer);
+	} catch {
+		return null;
+	}
+}
+
+export function isReadableText(buffer: Buffer): boolean {
 	if (buffer.length === 0) {
+		return false;
+	}
+
+	const decoded = decodeUtf8TextBuffer(buffer);
+	if (decoded === null || decoded.length === 0) {
 		return false;
 	}
 
@@ -186,9 +235,36 @@ function isReadableText(buffer: Buffer): boolean {
 		return false;
 	}
 
-	const decoded = sample.toString('utf8');
 	const replacementCount = decoded.split('\uFFFD').length - 1;
 	return replacementCount / decoded.length <= 0.05;
+}
+
+export function buildTextFormatMetadata(
+	buffer: Buffer,
+	filename: string,
+	mediaType: SupportedTextMediaType,
+): SourceFormatMetadata | null {
+	const text = decodeUtf8TextBuffer(buffer);
+	if (text === null || !isReadableText(buffer)) {
+		return null;
+	}
+
+	return {
+		media_type: mediaType === X_MARKDOWN_MEDIA_TYPE ? MARKDOWN_MEDIA_TYPE : mediaType,
+		original_extension: getOriginalExtension(filename),
+		byte_size: buffer.length,
+		character_count: text.length,
+		line_count: countTextLines(text),
+		encoding: 'utf-8',
+	};
+}
+
+function countTextLines(text: string): number {
+	if (text.length === 0) {
+		return 0;
+	}
+	const lines = text.split(/\r\n|\r|\n/);
+	return lines.at(-1) === '' ? lines.length - 1 : lines.length;
 }
 
 function getTextSample(buffer: Buffer): string {
@@ -273,7 +349,7 @@ export function detectSourceType(
 			return { sourceType: 'email', confidence: 'extension', mediaType: 'message/rfc822' };
 		}
 
-		if (extension === '.txt' || extension === '.md' || extension === '.markdown') {
+		if ((extension === '.txt' || extension === '.md' || extension === '.markdown') && isReadableText(buffer)) {
 			return {
 				sourceType: 'text',
 				confidence: 'extension',

--- a/packages/worker/src/dispatch.ts
+++ b/packages/worker/src/dispatch.ts
@@ -27,6 +27,7 @@ import {
 } from '@mulder/core';
 import {
 	buildImageFormatMetadata,
+	buildTextFormatMetadata,
 	detectSourceType,
 	executeEmbed,
 	executeEnrich,
@@ -36,6 +37,8 @@ import {
 	executeSegment,
 	getStorageExtensionForDetection,
 	isSupportedImageMediaType,
+	isSupportedTextFilename,
+	isSupportedTextMediaType,
 	type PipelineRunOptions,
 } from '@mulder/pipeline';
 import {
@@ -95,7 +98,7 @@ function buildPdfMetadataJson(pdfMeta: Awaited<ReturnType<typeof extractPdfMetad
 	return pdfMetadataJson;
 }
 
-type FinalizableSourceType = Extract<SourceType, 'pdf' | 'image'>;
+type FinalizableSourceType = Extract<SourceType, 'pdf' | 'image' | 'text'>;
 
 interface FinalizedUploadMetadata {
 	sourceType: FinalizableSourceType;
@@ -108,7 +111,7 @@ interface FinalizedUploadMetadata {
 }
 
 function isFinalizableSourceType(sourceType: SourceType): sourceType is FinalizableSourceType {
-	return sourceType === 'pdf' || sourceType === 'image';
+	return sourceType === 'pdf' || sourceType === 'image' || sourceType === 'text';
 }
 
 async function runStoryStepForPayload(
@@ -217,7 +220,7 @@ async function finalizeUploadedDocument(
 	}
 	if (!isFinalizableSourceType(detection.sourceType)) {
 		throw new IngestError(
-			`Unsupported source type "${detection.sourceType}" for ${payload.filename}; only pdf and image are supported in this step`,
+			`Unsupported source type "${detection.sourceType}" for ${payload.filename}; only pdf, image, and text are supported in this step`,
 			INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
 			{
 				context: {
@@ -284,7 +287,7 @@ async function finalizeUploadedDocument(
 			mediaType: detection.mediaType,
 			storageExtension: canonicalStorageExtension,
 		};
-	} else {
+	} else if (detection.sourceType === 'image') {
 		if (!isSupportedImageMediaType(detection.mediaType)) {
 			throw new IngestError(
 				`Unsupported image media type for ${payload.filename}`,
@@ -301,6 +304,52 @@ async function finalizeUploadedDocument(
 			hasNativeText: false,
 			nativeTextRatio: 0,
 			mediaType: detection.mediaType,
+			storageExtension: canonicalStorageExtension,
+		};
+	} else {
+		if (!isSupportedTextFilename(payload.filename)) {
+			throw new IngestError(
+				`Unsupported text source extension for ${payload.filename}; supported text files must end with .txt, .md, or .markdown`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: {
+						storagePath: payload.storagePath,
+						sourceId: payload.sourceId,
+						sourceType: detection.sourceType,
+						confidence: detection.confidence,
+					},
+				},
+			);
+		}
+
+		if (!isSupportedTextMediaType(detection.mediaType)) {
+			throw new IngestError(
+				`Unsupported text media type for ${payload.filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { storagePath: payload.storagePath, sourceId: payload.sourceId, mediaType: detection.mediaType },
+				},
+			);
+		}
+
+		const formatMetadata = buildTextFormatMetadata(buffer, payload.filename, detection.mediaType);
+		if (!formatMetadata) {
+			throw new IngestError(
+				`Text source is not readable UTF-8: ${payload.filename}`,
+				INGEST_ERROR_CODES.INGEST_UNSUPPORTED_SOURCE_TYPE,
+				{
+					context: { storagePath: payload.storagePath, sourceId: payload.sourceId, mediaType: detection.mediaType },
+				},
+			);
+		}
+
+		finalizedMetadata = {
+			sourceType: 'text',
+			formatMetadata,
+			pageCount: 0,
+			hasNativeText: false,
+			nativeTextRatio: 0,
+			mediaType: typeof formatMetadata.media_type === 'string' ? formatMetadata.media_type : detection.mediaType,
 			storageExtension: canonicalStorageExtension,
 		};
 	}

--- a/tests/specs/85_source_type_discriminator_format_metadata.test.ts
+++ b/tests/specs/85_source_type_discriminator_format_metadata.test.ts
@@ -185,23 +185,21 @@ describe('Spec 85 — Source Type Discriminator + Format Metadata', () => {
 		expectNoStorageUpload(beforeStorage);
 	});
 
-	it('QA-05: text files are detected but rejected until text ingestion lands', () => {
+	it('QA-05: supported text files ingest as text while unsupported readable extensions stay rejected', () => {
 		if (!pgAvailable) return;
 
 		cleanSourceData();
-		const beforeStorage = currentStorageEntries();
 		const note = join(tmpDir, 'note.txt');
-		writeFileSync(note, 'A plain text note that will become ingestible in a later M9 step.\n', 'utf-8');
+		writeFileSync(note, 'A plain text note for the M9 text path.\n', 'utf-8');
 
 		const result = runCli(['ingest', note]);
-		expect(result.exitCode).not.toBe(0);
-		expect(`${result.stdout}\n${result.stderr}`).toMatch(/INGEST_UNSUPPORTED_SOURCE_TYPE|unsupported source type/i);
-		expect(`${result.stdout}\n${result.stderr}`).toMatch(/\btext\b/i);
-		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
-		expectNoStorageUpload(beforeStorage);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+		expect(result.stdout).toMatch(/\btext\b/i);
+		expect(db.runSql("SELECT source_type::text FROM sources WHERE filename = 'note.txt';")).toBe('text');
 
 		const logFile = join(tmpDir, 'note.log');
-		writeFileSync(logFile, 'A readable log file should still be classified as unsupported text.\n', 'utf-8');
+		writeFileSync(logFile, 'A readable log file is not a supported text ingest extension.\n', 'utf-8');
+		const beforeStorage = currentStorageEntries();
 
 		const logResult = runCli(['ingest', logFile]);
 		expect(logResult.exitCode).not.toBe(0);
@@ -209,7 +207,7 @@ describe('Spec 85 — Source Type Discriminator + Format Metadata', () => {
 			/INGEST_UNSUPPORTED_SOURCE_TYPE|unsupported source type/i,
 		);
 		expect(`${logResult.stdout}\n${logResult.stderr}`).toMatch(/\btext\b/i);
-		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
+		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('1');
 		expectNoStorageUpload(beforeStorage);
 	});
 

--- a/tests/specs/87_image_ingestion_layout_path.test.ts
+++ b/tests/specs/87_image_ingestion_layout_path.test.ts
@@ -518,9 +518,9 @@ describe('Spec 87 — Image Ingestion on the Layout Extraction Path', () => {
 	it('QA-08: unsupported formats still fail before persistence', () => {
 		if (!pgAvailable) return;
 
-		const textFile = join(tmpDir, 'note.txt');
-		writeFileSync(textFile, 'Plain text remains out of scope for M9-J3.\n', 'utf-8');
-		const result = runCli(['ingest', textFile]);
+		const docxFile = join(tmpDir, 'note.docx');
+		writeFileSync(docxFile, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]));
+		const result = runCli(['ingest', docxFile]);
 		expect(result.exitCode).not.toBe(0);
 		expect(`${result.stdout}\n${result.stderr}`).toMatch(/unsupported source type|INGEST_UNSUPPORTED_SOURCE_TYPE/i);
 		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');

--- a/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
+++ b/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
@@ -335,12 +335,13 @@ describe('Spec 88 — Plain Text Ingestion on the Pre-Structured Path', () => {
 		});
 	});
 
-	it('QA-06 regression: text extract rejects UTF-8 control-byte payloads before creating stories', () => {
+	it('QA-06 regression: text extract rejects UTF-8 control-byte payloads after the initial read sample', () => {
 		if (!pgAvailable) return;
 
 		const sourceId = randomUUID();
 		const storagePath = `raw/${sourceId}/original.txt`;
-		writeUploadedObject(storagePath, Buffer.from([0x50, 0x6c, 0x61, 0x69, 0x6e, 0x00, 0x74, 0x65, 0x78, 0x74]));
+		const readablePrefix = `${'Plain text line.\n'.repeat(300)}Still looks readable before the binary byte.`;
+		writeUploadedObject(storagePath, Buffer.concat([Buffer.from(readablePrefix, 'utf-8'), Buffer.from([0x00])]));
 		db.runSql(
 			`INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata, source_type, format_metadata)
 			 VALUES (${sqlLiteral(sourceId)}, 'binary-valid-utf8.txt', ${sqlLiteral(storagePath)}, ${sqlLiteral(sourceId.replaceAll('-', ''))}, 0, false, 0, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb, 'text', '{"media_type":"text/plain","encoding":"utf-8"}'::jsonb);`,

--- a/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
+++ b/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
@@ -332,6 +333,29 @@ describe('Spec 88 — Plain Text Ingestion on the Pre-Structured Path', () => {
 			source_type: 'text',
 			is_markdown: false,
 		});
+	});
+
+	it('QA-06 regression: text extract rejects UTF-8 control-byte payloads before creating stories', () => {
+		if (!pgAvailable) return;
+
+		const sourceId = randomUUID();
+		const storagePath = `raw/${sourceId}/original.txt`;
+		writeUploadedObject(storagePath, Buffer.from([0x50, 0x6c, 0x61, 0x69, 0x6e, 0x00, 0x74, 0x65, 0x78, 0x74]));
+		db.runSql(
+			`INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata, source_type, format_metadata)
+			 VALUES (${sqlLiteral(sourceId)}, 'binary-valid-utf8.txt', ${sqlLiteral(storagePath)}, ${sqlLiteral(sourceId.replaceAll('-', ''))}, 0, false, 0, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb, 'text', '{"media_type":"text/plain","encoding":"utf-8"}'::jsonb);`,
+		);
+
+		const extract = runCli(['extract', sourceId], { timeout: 180_000 });
+		expect(extract.exitCode).not.toBe(0);
+		expect(`${extract.stdout}\n${extract.stderr}`).toMatch(/not readable UTF-8/i);
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('ingested');
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('0');
+		expect(
+			db.runSql(
+				`SELECT COUNT(*) FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'extract';`,
+			),
+		).toBe('0');
 	});
 
 	it('QA-07: pipeline run can resume one text source by --source-id and skip segment', () => {

--- a/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
+++ b/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
@@ -334,6 +334,34 @@ describe('Spec 88 — Plain Text Ingestion on the Pre-Structured Path', () => {
 		});
 	});
 
+	it('QA-07: pipeline run can resume one text source by --source-id and skip segment', () => {
+		if (!pgAvailable) return;
+
+		const ingest = runCli(['ingest', txtFile]);
+		expect(ingest.exitCode, `${ingest.stdout}\n${ingest.stderr}`).toBe(0);
+		const sourceId = sourceIdForFilename(basename(txtFile));
+
+		const result = runCli(['pipeline', 'run', '--from', 'extract', '--up-to', 'enrich', '--source-id', sourceId], {
+			timeout: 240_000,
+		});
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(/Pipeline complete/i);
+
+		expect(
+			db.runSql(`SELECT status FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'extract';`),
+		).toBe('completed');
+		expect(
+			db.runSql(`SELECT status FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'segment';`),
+		).toBe('skipped');
+		expect(
+			db.runSql(`SELECT status FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'enrich';`),
+		).toBe('completed');
+		expect(db.runSql(`SELECT status FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('enriched');
+		expect(
+			db.runSql(`SELECT COUNT(*) FROM jobs WHERE type = 'segment' AND payload->>'sourceId' = ${sqlLiteral(sourceId)};`),
+		).toBe('0');
+	});
+
 	it('QA-08: API upload accepts Markdown media types and queues extract', async () => {
 		if (!pgAvailable) return;
 

--- a/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
+++ b/tests/specs/88_plain_text_ingestion_prestructured_path.test.ts
@@ -1,0 +1,388 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { WorkerRuntimeContext } from '@mulder/worker';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const WORKER_DIR = resolve(ROOT, 'packages/worker');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const WORKER_DIST = resolve(WORKER_DIR, 'dist/index.js');
+const API_APP_DIST = resolve(API_DIR, 'dist/app.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const FIXTURE_PDF = resolve(ROOT, 'fixtures/raw/native-text-sample.pdf');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const EXTRACTED_STORAGE_DIR = resolve(STORAGE_DIR, 'extracted');
+const SEGMENTS_STORAGE_DIR = resolve(STORAGE_DIR, 'segments');
+
+const PNG_BYTES = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+	'base64',
+);
+
+type ApiApp = { request: (input: string | Request, init?: RequestInit) => Promise<Response> };
+
+let tmpDir: string;
+let txtFile: string;
+let mdFile: string;
+let markdownFile: string;
+let coreModule: typeof import('@mulder/core');
+let workerModule: typeof import('@mulder/worker');
+let workerContext: WorkerRuntimeContext;
+let app: ApiApp;
+let pgAvailable = false;
+let rawSnapshot: StorageSnapshot | null = null;
+let extractedSnapshot: StorageSnapshot | null = null;
+let segmentsSnapshot: StorageSnapshot | null = null;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 180_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_CONFIG: EXAMPLE_CONFIG,
+			MULDER_LOG_LEVEL: 'silent',
+			NODE_ENV: 'test',
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+		},
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM monthly_budget_reservations',
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sourceIdForFilename(filename: string): string {
+	return db.runSql(`SELECT id FROM sources WHERE filename = ${sqlLiteral(filename)} ORDER BY created_at DESC LIMIT 1;`);
+}
+
+function resetStorage(): void {
+	for (const snapshot of [rawSnapshot, extractedSnapshot, segmentsSnapshot]) {
+		if (snapshot) {
+			cleanStorageDirSince(snapshot);
+		}
+	}
+}
+
+async function loadApiApp(): Promise<ApiApp> {
+	const module = await import(pathToFileURL(API_APP_DIST).href);
+	return module.createApp({
+		config: {
+			port: 8080,
+			auth: {
+				api_keys: [{ name: 'cli', key: 'test-api-key' }],
+				browser: {
+					enabled: true,
+					cookie_name: 'mulder_session',
+					session_secret: 'test-session-secret',
+					session_ttl_hours: 168,
+					invitation_ttl_hours: 168,
+					cookie_secure: false,
+					same_site: 'Lax',
+				},
+			},
+			rate_limiting: { enabled: true },
+		},
+	});
+}
+
+async function apiPost(path: string, body: unknown): Promise<Response> {
+	return await app.request(`http://localhost${path}`, {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer test-api-key',
+			'Content-Type': 'application/json',
+			'X-Forwarded-For': '203.0.113.88',
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+	return (await response.json()) as Record<string, unknown>;
+}
+
+function writeUploadedObject(storagePath: string, content: Buffer): void {
+	const fullPath = resolve(STORAGE_DIR, storagePath);
+	mkdirSync(dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, content);
+}
+
+async function processOneJob() {
+	return await workerModule.processNextJob(workerContext, 'spec-88-worker');
+}
+
+describe('Spec 88 — Plain Text Ingestion on the Pre-Structured Path', () => {
+	beforeAll(async () => {
+		pgAvailable = db.isPgAvailable();
+		if (!pgAvailable) {
+			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
+			return;
+		}
+
+		process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+		process.env.MULDER_LOG_LEVEL = 'silent';
+		process.env.NODE_ENV = 'test';
+
+		tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-88-'));
+		txtFile = join(tmpDir, 'note.txt');
+		mdFile = join(tmpDir, 'brief.md');
+		markdownFile = join(tmpDir, 'memo.markdown');
+		writeFileSync(txtFile, 'Plain text sighting note.\nSecond line.\n', 'utf-8');
+		writeFileSync(mdFile, '# Briefing\n\nMarkdown body stays **Markdown**.\n', 'utf-8');
+		writeFileSync(markdownFile, '# Memorandum\n\nExtended markdown extension.\n', 'utf-8');
+
+		rawSnapshot = snapshotStorageDir(RAW_STORAGE_DIR);
+		extractedSnapshot = snapshotStorageDir(EXTRACTED_STORAGE_DIR);
+		segmentsSnapshot = snapshotStorageDir(SEGMENTS_STORAGE_DIR);
+
+		buildPackage(CORE_DIR);
+		buildPackage(PIPELINE_DIR);
+		buildPackage(WORKER_DIR);
+		buildPackage(API_DIR);
+		buildPackage(CLI_DIR);
+
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode, `${migrate.stdout}\n${migrate.stderr}`).toBe(0);
+
+		coreModule = await import(pathToFileURL(CORE_DIST).href);
+		workerModule = await import(pathToFileURL(WORKER_DIST).href);
+		app = await loadApiApp();
+
+		const config = coreModule.loadConfig(EXAMPLE_CONFIG);
+		const cloudSql = config.gcp?.cloud_sql;
+		if (!cloudSql) {
+			throw new Error('Expected example config to include gcp.cloud_sql');
+		}
+		const logger = coreModule.createLogger({ level: 'silent' });
+		workerContext = {
+			config,
+			services: coreModule.createServiceRegistry(config, logger),
+			pool: coreModule.getWorkerPool(cloudSql),
+			logger,
+		};
+	}, 600_000);
+
+	beforeEach(() => {
+		if (!pgAvailable) return;
+		cleanState();
+		resetStorage();
+	});
+
+	afterAll(() => {
+		try {
+			if (pgAvailable) {
+				cleanState();
+				resetStorage();
+			}
+		} catch {
+			// Ignore cleanup failures.
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('QA-01: CLI dry-run accepts text sources without persistence', () => {
+		if (!pgAvailable) return;
+
+		for (const textFile of [txtFile, mdFile, markdownFile]) {
+			const result = runCli(['ingest', '--dry-run', textFile]);
+			expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+			expect(result.stdout).toContain('Type');
+			expect(result.stdout).toMatch(/\btext\b/);
+			expect(result.stdout).toMatch(/\b0\b/);
+		}
+		expect(db.runSql('SELECT COUNT(*) FROM sources;')).toBe('0');
+	});
+
+	it('QA-02 and QA-03: CLI text ingest persists canonical metadata', () => {
+		if (!pgAvailable) return;
+
+		const txt = runCli(['ingest', txtFile]);
+		expect(txt.exitCode, `${txt.stdout}\n${txt.stderr}`).toBe(0);
+		const txtSourceId = sourceIdForFilename(basename(txtFile));
+		const txtRow = db.runSql(
+			`SELECT source_type::text AS source_type, page_count, has_native_text, native_text_ratio, storage_path, format_metadata->>'media_type' AS media_type, format_metadata->>'encoding' AS encoding, format_metadata->>'line_count' AS line_count FROM sources WHERE id = ${sqlLiteral(txtSourceId)};`,
+		);
+		expect(txtRow).toBe(`text|0|f|0|raw/${txtSourceId}/original.txt|text/plain|utf-8|2`);
+		expect(existsSync(resolve(STORAGE_DIR, `raw/${txtSourceId}/original.txt`))).toBe(true);
+
+		const md = runCli(['ingest', markdownFile]);
+		expect(md.exitCode, `${md.stdout}\n${md.stderr}`).toBe(0);
+		const mdSourceId = sourceIdForFilename(basename(markdownFile));
+		const mdRow = db.runSql(
+			`SELECT source_type::text AS source_type, storage_path, format_metadata->>'media_type' AS media_type FROM sources WHERE id = ${sqlLiteral(mdSourceId)};`,
+		);
+		expect(mdRow).toBe(`text|raw/${mdSourceId}/original.md|text/markdown`);
+	});
+
+	it('QA-04 and QA-05: directory discovery includes text and magic bytes stay authoritative', () => {
+		if (!pgAvailable) return;
+
+		const mixedDir = join(tmpDir, 'mixed-dir');
+		mkdirSync(mixedDir, { recursive: true });
+		writeFileSync(join(mixedDir, 'scan.png'), PNG_BYTES);
+		writeFileSync(join(mixedDir, 'native-text-sample.pdf'), readFileSync(FIXTURE_PDF));
+		writeFileSync(join(mixedDir, 'note.txt'), 'Directory note.\n', 'utf-8');
+		writeFileSync(join(mixedDir, 'brief.md'), '# Directory brief\n', 'utf-8');
+
+		const directory = runCli(['ingest', '--dry-run', mixedDir], { timeout: 180_000 });
+		expect(directory.exitCode, `${directory.stdout}\n${directory.stderr}`).toBe(0);
+		expect(directory.stdout).toMatch(/native-text-sample\.pdf[\s\S]*\bpdf\b/);
+		expect(directory.stdout).toMatch(/scan\.png[\s\S]*\bimage\b/);
+		expect(directory.stdout).toMatch(/note\.txt[\s\S]*\btext\b/);
+		expect(directory.stdout).toMatch(/brief\.md[\s\S]*\btext\b/);
+
+		const pdfRenamedText = join(tmpDir, 'pdf-renamed.txt');
+		const pngRenamedText = join(tmpDir, 'png-renamed.txt');
+		writeFileSync(pdfRenamedText, readFileSync(FIXTURE_PDF));
+		writeFileSync(pngRenamedText, PNG_BYTES);
+
+		const pdfResult = runCli(['ingest', '--dry-run', pdfRenamedText], { timeout: 180_000 });
+		expect(pdfResult.exitCode, `${pdfResult.stdout}\n${pdfResult.stderr}`).toBe(0);
+		expect(pdfResult.stdout).toMatch(/\bpdf\b/);
+
+		const imageResult = runCli(['ingest', '--dry-run', pngRenamedText]);
+		expect(imageResult.exitCode, `${imageResult.stdout}\n${imageResult.stderr}`).toBe(0);
+		expect(imageResult.stdout).toMatch(/\bimage\b/);
+	});
+
+	it('QA-06: text extract creates a pre-structured story without layout artifacts', () => {
+		if (!pgAvailable) return;
+
+		const ingest = runCli(['ingest', txtFile]);
+		expect(ingest.exitCode, `${ingest.stdout}\n${ingest.stderr}`).toBe(0);
+		const sourceId = sourceIdForFilename(basename(txtFile));
+
+		const extract = runCli(['extract', sourceId], { timeout: 180_000 });
+		expect(extract.exitCode, `${extract.stdout}\n${extract.stderr}`).toBe(0);
+		expect(extract.stdout).toMatch(/\btext\b/);
+
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('extracted');
+		expect(
+			db.runSql(`SELECT status FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'extract';`),
+		).toBe('completed');
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(false);
+
+		const storyRow = db.runSql(
+			`SELECT id, gcs_markdown_uri, gcs_metadata_uri, page_start IS NULL AS page_start_null, page_end IS NULL AS page_end_null, extraction_confidence FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`,
+		);
+		const [storyId, markdownUri, metadataUri, pageStartNull, pageEndNull, confidence] = storyRow.split('|');
+		expect(markdownUri).toBe(`segments/${sourceId}/${storyId}.md`);
+		expect(metadataUri).toBe(`segments/${sourceId}/${storyId}.meta.json`);
+		expect(pageStartNull).toBe('t');
+		expect(pageEndNull).toBe('t');
+		expect(confidence).toBe('1');
+		expect(readFileSync(resolve(STORAGE_DIR, markdownUri), 'utf-8')).toMatch(/^# note/m);
+		expect(JSON.parse(readFileSync(resolve(STORAGE_DIR, metadataUri), 'utf-8'))).toMatchObject({
+			id: storyId,
+			document_id: sourceId,
+			source_type: 'text',
+			is_markdown: false,
+		});
+	});
+
+	it('QA-08: API upload accepts Markdown media types and queues extract', async () => {
+		if (!pgAvailable) return;
+
+		const content = Buffer.from('# Uploaded Note\n\nBody.\n', 'utf-8');
+		const initiate = await apiPost('/api/uploads/documents/initiate', {
+			filename: 'note.md',
+			size_bytes: content.byteLength,
+			content_type: 'text/markdown',
+		});
+		expect(initiate.status).toBe(201);
+		const initiateBody = await readJson(initiate);
+		const sourceId = String((initiateBody.data as Record<string, unknown>).source_id);
+		const storagePath = String((initiateBody.data as Record<string, unknown>).storage_path);
+		expect(storagePath).toBe(`raw/${sourceId}/original.md`);
+		writeUploadedObject(storagePath, content);
+
+		const complete = await apiPost('/api/uploads/documents/complete', {
+			source_id: sourceId,
+			filename: 'note.md',
+			storage_path: storagePath,
+			start_pipeline: true,
+		});
+		expect(complete.status).toBe(202);
+
+		const processed = await processOneJob();
+		expect(processed.state).toBe('completed');
+		const sourceRow = db.runSql(
+			`SELECT source_type::text AS source_type, storage_path, format_metadata->>'media_type' AS media_type FROM sources WHERE id = ${sqlLiteral(sourceId)};`,
+		);
+		expect(sourceRow).toBe(`text|raw/${sourceId}/original.md|text/markdown`);
+		expect(
+			db.runSql(
+				`SELECT COUNT(*) FROM jobs WHERE type = 'extract' AND status = 'pending' AND payload->>'sourceId' = ${sqlLiteral(sourceId)};`,
+			),
+		).toBe('1');
+	});
+
+	it('QA-09: duplicate text ingest returns the existing text source', () => {
+		if (!pgAvailable) return;
+
+		const first = runCli(['ingest', txtFile]);
+		expect(first.exitCode, `${first.stdout}\n${first.stderr}`).toBe(0);
+		const second = runCli(['ingest', txtFile]);
+		expect(second.exitCode, `${second.stdout}\n${second.stderr}`).toBe(0);
+		expect(`${second.stdout}\n${second.stderr}`).toMatch(/duplicate/i);
+
+		const row = db.runSql(
+			"SELECT source_type::text, COUNT(*) FROM sources WHERE file_hash = (SELECT file_hash FROM sources WHERE filename = 'note.txt' LIMIT 1) GROUP BY source_type;",
+		);
+		expect(row).toBe('text|1');
+	});
+});


### PR DESCRIPTION
## Objective

Add M9-J4 plain text ingestion so `.txt`, `.md`, and `.markdown` files can be accepted as first-class `text` sources, extracted directly into story Markdown, and routed through the existing pre-structured pipeline path without running `segment`.

Closes #233

## Traceability

- Roadmap step: M9-J4
- Spec: `docs/specs/88_plain_text_ingestion_prestructured_path.spec.md`
- Base branch: `milestone/9`

## Auto-Pilot Gates

- [ ] Implement
- [ ] Verify
- [ ] Review
- [ ] Finalize roadmap state
