### PR TITLE
Clean up app naming and remove demo remnants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,5 +182,5 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build product app
+      - name: Build app
         run: pnpm --filter @mulder/app build

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,4 +1,4 @@
-name: Deploy Product App
+name: Deploy App
 
 on:
   workflow_dispatch:
@@ -51,7 +51,7 @@ jobs:
             --project "${{ inputs.project_id }}" \
             --location "${{ inputs.region }}" \
             --repository-format docker \
-            --description "Mulder product app containers"
+            --description "Mulder API and worker containers"
 
       - name: Configure Docker auth
         run: gcloud auth configure-docker "${{ inputs.region }}-docker.pkg.dev" --quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ mulder/
 ├── apps/
 │   ├── cli/                      # CLI application (commands/ + lib/)
 │   ├── api/                      # HTTP API (routes/ + middleware/)
-│   └── app/                      # Browser product app
+│   └── app/                      # Browser app
 │
 ├── terraform/modules/            # GCP infrastructure
 │   └── {cloud-sql,storage,cloud-run,pubsub,firestore,budget,iam,networking}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ QA Gate: Post-MVP     ███████████████████�
 M5   Curation         ██████████████████████████████  5/5  ✓
 M6   Intelligence     ██████████████████████████████  7/7  ✓
 M7   API+Workers      ██████████████████████████████ 11/11 ✓
-M7.5 Product App      █████░░░░░░░░░░░░░░░░░░░░░░░░░  1/6
+M7.5 App              █████░░░░░░░░░░░░░░░░░░░░░░░░░  1/6
 M8   Operations       ██████████████████████████████  6/6  ✓
 M9   Multi-Format     ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0/13
 M10  Provenance       ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0/9
@@ -196,7 +196,7 @@ Everything beyond `project` and `ontology` has sensible defaults. See [`mulder.c
 
 Mulder's **CLI/backend track is complete through M8 Operations**: the v1.0 search pipeline is operational, the v2.0 intelligence layer is in place, and the production-safety tooling now covers evals, cost gates, budget alerts, selective reprocessing, dead-letter retry, and devlog conventions.
 
-The browser product app lives in [`apps/app`](./apps/app) and is guided by the [product app design strategy](./docs/product-app-design-strategy.md), [API integration notes](./docs/product-app-api-integration.md), and [deployment runbook](./docs/product-app-deployment.md). The [functional spec](./docs/functional-spec.md), [implementation roadmap](./docs/roadmap.md), and [config schema](./mulder.config.example.yaml) are finalized.
+The browser app lives in [`apps/app`](./apps/app) and is guided by the [app design strategy](./docs/app-design-strategy.md), [API integration notes](./docs/app-api-integration.md), and [deployment runbook](./docs/app-deployment.md). The [functional spec](./docs/functional-spec.md), [implementation roadmap](./docs/roadmap.md), and [config schema](./mulder.config.example.yaml) are finalized.
 
 See the [roadmap](./docs/roadmap.md) for all 14 milestones from foundation to autonomous research agent.
 

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -1,8 +1,8 @@
 # Mulder App
 
-Product browser app for the cleaner, technical Mulder research workbench direction.
+Browser app for the cleaner, technical Mulder research workbench direction.
 
-`apps/app` is the only active browser product app. Product API integration decisions are captured in [`../../docs/product-app-api-integration.md`](../../docs/product-app-api-integration.md).
+`apps/app` is the only active browser app. API integration decisions are captured in [`../../docs/app-api-integration.md`](../../docs/app-api-integration.md).
 
 ## Commands
 
@@ -16,7 +16,7 @@ pnpm --filter @mulder/app preview
 
 ## API And Auth
 
-The product app uses Mulder's cookie-backed browser auth. It never embeds an operator API key.
+The app uses Mulder's cookie-backed browser auth. It never embeds an operator API key.
 
 ```bash
 cp apps/app/.env.example apps/app/.env.local
@@ -40,7 +40,7 @@ Build output is `apps/app/dist`. Production only needs `VITE_API_BASE_URL=<api-o
 
 ## Design Tokens
 
-The product app look is controlled from `src/styles.css`.
+The app's look is controlled from `src/styles.css`.
 
 - Surface tokens: `--canvas`, `--panel`, `--panel-raised`, `--field`
 - Text tokens: `--text`, `--text-muted`, `--text-subtle`, `--text-inverse`
@@ -49,10 +49,10 @@ The product app look is controlled from `src/styles.css`.
 - Status tokens: `--success`, `--warning`, `--danger`, `--info`
 - Density tokens: `--sidebar-width`, `--topbar-height`, `--radius-*`
 
-The app intentionally avoids the v1 editorial serif language. It is sans-first, light-first, research-focused, and optimized for dense analysis screens without becoming a developer-only console.
+The app intentionally avoids editorial serif language. It is sans-first, light-first, research-focused, and optimized for dense analysis screens without becoming a developer-only console.
 
-Primary product references:
+Primary app references:
 
-- [`../../docs/product-app-design-strategy.md`](../../docs/product-app-design-strategy.md)
-- [`../../docs/product-app-api-integration.md`](../../docs/product-app-api-integration.md)
-- [`../../docs/product-app-deployment.md`](../../docs/product-app-deployment.md)
+- [`../../docs/app-design-strategy.md`](../../docs/app-design-strategy.md)
+- [`../../docs/app-api-integration.md`](../../docs/app-api-integration.md)
+- [`../../docs/app-deployment.md`](../../docs/app-deployment.md)

--- a/apps/app/src/components/AuthFrame.tsx
+++ b/apps/app/src/components/AuthFrame.tsx
@@ -20,7 +20,7 @@ export function AuthFrame({
 						</div>
 						<div>
 							<p className="text-sm font-semibold text-text">Mulder</p>
-							<p className="font-mono text-[11px] text-text-subtle">product app</p>
+							<p className="font-mono text-[11px] text-text-subtle">app</p>
 						</div>
 					</div>
 

--- a/apps/app/src/components/Sidebar.tsx
+++ b/apps/app/src/components/Sidebar.tsx
@@ -89,7 +89,7 @@ export function Sidebar({ onClose, mobile = false }: { onClose?: () => void; mob
 					className="flex w-full items-center justify-between rounded-md border border-border bg-field px-3 py-2 text-left text-sm text-text transition-colors hover:bg-field-hover"
 					type="button"
 				>
-					<span>Product App</span>
+					<span>App</span>
 					<span className="rounded-sm bg-panel px-1.5 py-0.5 font-mono text-[11px] text-accent">API</span>
 				</button>
 			</div>

--- a/docs/app-api-integration.md
+++ b/docs/app-api-integration.md
@@ -1,9 +1,9 @@
-# Mulder Product App API Integration Notes
+# Mulder App API Integration Notes
 
 **Status:** Active implementation reference for `apps/app`
-**Related:** [`product-app-design-strategy.md`](./product-app-design-strategy.md), [`product-app-deployment.md`](./product-app-deployment.md), [`api-architecture.md`](./api-architecture.md)
+**Related:** [`app-design-strategy.md`](./app-design-strategy.md), [`app-deployment.md`](./app-deployment.md), [`api-architecture.md`](./api-architecture.md)
 
-This document is the active API integration reference for the Mulder product app. It is not a visual or interaction-design reference. The product app must continue to follow the cleaner, research-first direction in `docs/product-app-design-strategy.md`.
+This document is the active API integration reference for the Mulder app. It is not a visual or interaction-design reference. The app must continue to follow the cleaner, research-first direction in `docs/app-design-strategy.md`.
 
 ## Integration Posture
 
@@ -16,9 +16,9 @@ The app should use:
 - `credentials: 'include'` for all authenticated API calls.
 - Cookie-backed browser sessions, not bundled bearer tokens.
 - Explicit loading, empty, unavailable, and error states.
-- No showcase IDs or checked-in product-screen fixtures in `apps/app`.
+- No checked-in static IDs or product-screen fixtures in `apps/app`.
 
-The product app API client should keep these properties:
+The app API client should keep these properties:
 
 - `ApiError` carries `status`, `code`, `message`, and optional `details`.
 - Error responses are parsed from `{ error: { code, message, details } }` when available.
@@ -34,11 +34,11 @@ React Query should use conservative defaults:
 - Limited retry for transient network/server failures.
 - Session expiry should be observable through a shared `auth:expired` event or equivalent app-level handling.
 
-The product app should expose:
+The app should expose:
 
 - `/login` for email/password authentication.
 - `/auth/invitations/:token` for invite acceptance, matching the API-generated invitation link shape.
-- Protected product routes behind `GET /api/auth/session`.
+- Protected app routes behind `GET /api/auth/session`.
 - Logout through `POST /api/auth/logout` and query-cache clearing.
 
 ## Usable HTTP Surface
@@ -48,7 +48,7 @@ These endpoints are the first candidates for `apps/app` because they already rep
 | Area | Endpoint | Notes |
 | --- | --- | --- |
 | Health | `GET /api/health` | Public service health. Useful for deployment smoke checks. |
-| Auth | `GET /api/auth/session` | Session bootstrap for protected product routes. |
+| Auth | `GET /api/auth/session` | Session bootstrap for protected app routes. |
 | Auth | `POST /api/auth/login` | Email/password login. |
 | Auth | `POST /api/auth/logout` | Ends the browser session. |
 | Auth | `POST /api/auth/invitations/accept` | Invite acceptance flow. |
@@ -81,9 +81,9 @@ These endpoints are the first candidates for `apps/app` because they already rep
 
 ## Hook Mapping
 
-This mapping captures the product app's hook-per-contract shape.
+This mapping captures the app's hook-per-contract shape.
 
-| Legacy hook | API contract | Product-app use |
+| Legacy hook | API contract | App use |
 | --- | --- | --- |
 | `useSession` | `GET /api/auth/session` | AuthGate/session bootstrap. |
 | `useLogin` | `POST /api/auth/login` | Login screen. |
@@ -107,17 +107,17 @@ This mapping captures the product app's hook-per-contract shape.
 | `useEvidenceReliabilitySources` | `GET /api/evidence/reliability/sources` | Trust/source panels. |
 | `useEvidenceChains` | `GET /api/evidence/chains` | Future evidence-chain drilldown. |
 | `useEvidenceClusters` | `GET /api/evidence/clusters` | Future spatial/temporal review. |
-| `useDocumentUpload` | upload initiate -> transport -> complete -> job polling | Future document ingest flow after product gates are satisfied. |
+| `useDocumentUpload` | upload initiate -> transport -> complete -> job polling | Future document ingest flow after release gates are satisfied. |
 
-## Known Product-App API Gaps
+## Known App API Gaps
 
 These gaps should be visible in the app capability registry instead of hidden behind fake data.
 
 | Capability | Current issue |
 | --- | --- |
-| Analysis run facade | Jobs exist, but product-shaped run summaries, artifacts, step timings, and retry affordances are still partial. |
-| Evidence claims | Summary and contradictions exist, but first-class claim records, review decisions, and assertion history need a product contract. |
-| Provenance and trust gate | M10 provenance, document quality, sensitivity/RBAC, custody, rollback, and source credibility are product gates for real archive ingest. |
+| Analysis run facade | Jobs exist, but app-shaped run summaries, artifacts, step timings, and retry affordances are still partial. |
+| Evidence claims | Summary and contradictions exist, but first-class claim records, review decisions, and assertion history need an app contract. |
+| Provenance and trust gate | M10 provenance, document quality, sensitivity/RBAC, custody, rollback, and source credibility are release gates for real archive ingest. |
 | Graph aggregate | Entity-local edges exist, but product graph views need an aggregate or batched graph read model. |
 | Activity feed | No cross-system event stream exists yet. |
 | Usage/cost surface | Status exposes budget pieces, but product usage views need a broader read model. |
@@ -135,20 +135,20 @@ These gaps should be visible in the app capability registry instead of hidden be
 
 ## What Not To Reuse
 
-- Old editorial visual language: serif typography, cinematic hero moments, dark dossier mood, or investor-showcase pacing.
+- Old editorial visual language: serif typography, cinematic hero moments, dark dossier mood, or investor-style pacing.
 - Old top-nav route structure: Desk, Archive, Board, Ask as the default product IA.
 - Fake hero interactions or fixture-backed product claims.
-- Showcase-specific copy, seeded users, fixed showcase IDs, or local-only data assumptions.
+- Static sample copy, seeded users, fixed local IDs, or local-only data assumptions.
 - Pipeline-first navigation that makes jobs feel like the main product object for non-technical researchers.
 
 ## First API Slice
 
-After the cleanup, the first product-app API implementation should stay narrow:
+After the cleanup, the first app API implementation should stay narrow:
 
 1. Add the API client, local API types, React Query provider, and capability registry to `apps/app`.
 2. Bind existing routes only: `/`, `/runs`, and `/evidence`.
 3. Use real loading/empty/error states.
-4. Do not use checked-in fixture data in product screens.
+4. Do not use checked-in fixture data in app screens.
 5. Do not add new product modules until the API foundation is green.
 
-If Mulder needs a public, stable showcase later, build it as a separate, explicitly labeled surface with fixed showcase data. That surface must not be the product app and must not point at a private production project.
+If Mulder needs a public example later, build it as a separate, explicitly labeled surface that does not point at a private production project and does not shape the production app.

--- a/docs/app-deployment.md
+++ b/docs/app-deployment.md
@@ -1,6 +1,6 @@
-# Mulder Product App Deployment and Infrastructure Runbook
+# Mulder App Deployment and Infrastructure Runbook
 
-This runbook describes what must be in place before the product app is exposed to real users. It is intentionally configuration-neutral: do not commit private domains, GCP project IDs, sender addresses, customer names, private corpus choices, API keys, service-account keys, or production config files to this open-source repository.
+This runbook describes what must be in place before the app is exposed to real users. It is intentionally configuration-neutral: do not commit private domains, GCP project IDs, sender addresses, customer names, private corpus choices, API keys, service-account keys, or production config files to this open-source repository.
 
 Use placeholders in repo-tracked documentation and code:
 
@@ -14,15 +14,15 @@ Store real values in Cloudflare settings, GitHub Actions secrets or variables, G
 
 ## Scope
 
-The target product UI is `apps/app`. Product API integration rules are preserved in [`docs/product-app-api-integration.md`](./product-app-api-integration.md).
+The target browser UI is `apps/app`. API integration rules are preserved in [`docs/app-api-integration.md`](./app-api-integration.md).
 
-The product app must be populated through the product pipeline only:
+The app must be populated through the Mulder pipeline only:
 
 - no SQL fixture seeding in production
 - no checked-in production corpus configuration
-- no showcase UUID families
+- no checked-in static UUID families
 - no `*.e2e@mulder.local` users
-- no showcase metadata in production data
+- no static sample metadata in production data
 
 ## Target Architecture
 
@@ -48,9 +48,9 @@ Already present:
 - Resend-backed invite delivery plumbing
 - owner invite helper: `pnpm invite:owner`
 - live smoke helper: `pnpm smoke:live`
-- one-command local product-app dev entrypoint: `pnpm dev`
+- one-command local app dev entrypoint: `pnpm dev`
 - API-backed `apps/app` shell with browser auth, loading, empty, and error states
-- product-app API integration notes in `docs/product-app-api-integration.md`
+- app API integration notes in `docs/app-api-integration.md`
 - `wrangler.json` points Cloudflare assets at `apps/app/dist`
 
 Still required before live:
@@ -68,7 +68,7 @@ Still required before live:
 
 Do not go live until all of these are true:
 
-- `apps/app` does not depend on checked-in fixture data for product screens.
+- `apps/app` does not depend on checked-in fixture data for app screens.
 - Cloudflare production has `VITE_API_BASE_URL=<api-origin>`.
 - The API health check at `<api-origin>/api/health` returns 200.
 - Production database migrations have completed successfully.
@@ -112,16 +112,16 @@ VITE_API_BASE_URL=<api-origin>
 
 Do not add operator API keys, preview auth bypasses, mock data toggles, or fixture fallbacks to the browser bundle.
 
-### 4. Verify product app API integration before production
+### 4. Verify app API integration before production
 
-Before assigning the production domain to `apps/app`, verify that the current API-backed product shell still has:
+Before assigning the production domain to `apps/app`, verify that the current API-backed app shell still has:
 
 - API client support for `VITE_API_BASE_URL`
 - session bootstrap against `GET /api/auth/session`
 - login, logout, and invite acceptance screens
 - no operator API keys in the browser bundle
 - API-backed loading, empty, success, and error states
-- no checked-in fixture fallback for product screens
+- no checked-in fixture fallback for app screens
 - visible production API errors rather than masked fallback data
 - a green repo-root `pnpm --filter @mulder/app build`
 
@@ -144,7 +144,7 @@ For each route, verify:
 - no overlapping UI
 - professional empty states for a fresh database
 - loading states do not shift the layout badly
-- API failures show product-appropriate errors
+- API failures show appropriate errors
 - no preview or mock data appears in production
 
 ## Backend Work Order: GCP API and Worker
@@ -253,7 +253,7 @@ For open-source safety, prefer GitHub Workload Identity Federation over long-liv
 
 ## Backend Deploy
 
-Use the manual GitHub Actions workflow `Deploy Product App`.
+Use the manual GitHub Actions workflow `Deploy App`.
 
 Required GitHub configuration:
 
@@ -331,11 +331,11 @@ pnpm invite:owner
 
 The API sends the invite email in production. In local/dev with log delivery enabled, it logs the acceptance URL server-side.
 
-After the first owner accepts the invitation, all future users should be invited from the product admin flow.
+After the first owner accepts the invitation, all future users should be invited from the admin flow.
 
-## Product App Data
+## App Data
 
-Do not insert product corpus rows directly into Cloud SQL.
+Do not insert corpus rows directly into Cloud SQL.
 
 Populate the live corpus through the product:
 
@@ -344,7 +344,7 @@ Populate the live corpus through the product:
 3. Let API and worker processing complete.
 4. Verify the documents, stories, entities, retrieval, and analysis views from the frontend.
 
-The checked-in PDFs in `fixtures/raw/` can be used for technical smoke only if they are acceptable for the product trial. Any curated real pilot corpus choice belongs in private operator notes, not in this repo.
+The checked-in PDFs in `fixtures/raw/` can be used for technical smoke only if they are acceptable for the trial. Any curated real pilot corpus choice belongs in private operator notes, not in this repo.
 
 After processing, audit production for:
 
@@ -354,7 +354,7 @@ SELECT * FROM api_users WHERE email LIKE '%.e2e@mulder.local';
 SELECT * FROM sources WHERE id::text LIKE '11111111-%' OR id::text LIKE '22222222-%' OR id::text LIKE '33333333-%';
 ```
 
-Also check metadata and tags for retired showcase labels.
+Also check metadata and tags for retired static sample labels.
 
 ## No-Deploy Local Smoke
 
@@ -376,7 +376,7 @@ MULDER_SMOKE_PASSWORD=<password> \
 pnpm smoke:live
 ```
 
-Browser smoke against the local product app:
+Browser smoke against the local app:
 
 - unauthenticated `/` redirects to `/login`
 - login succeeds with the local owner account
@@ -417,7 +417,7 @@ Minimum pass criteria:
 - recipient receives the invite email
 - PDF upload creates a source
 - worker advances queued jobs
-- processed documents appear in the product app
+- processed documents appear in the app
 
 ## Infrastructure Checklist Before Go-Live
 
@@ -444,7 +444,7 @@ Engineering-owned:
 
 - `apps/app` API integration completed
 - `apps/app` production build path configured
-- no mock or fixture fallback in production product screens
+- no mock or fixture fallback in production app screens
 - Cloud Run API deployed
 - Cloud Run worker deployed
 - production migrations run
@@ -456,7 +456,7 @@ Engineering-owned:
 ## Recommended Follow-Up PRs
 
 1. `apps/app` production readiness
-   - Keep `apps/app` as the monorepo workspace package for the product UI.
+   - Keep `apps/app` as the monorepo workspace package for the browser UI.
 
 2. Production migration job
    - Add a Cloud Run Job or GitHub Actions step that runs `db migrate` with production config.

--- a/docs/app-design-strategy.md
+++ b/docs/app-design-strategy.md
@@ -1,7 +1,7 @@
-# Mulder Product App Design Strategy
+# Mulder App Design Strategy
 
 **Date:** 2026-04-30
-**Status:** Direction-setting document for `apps/app`, the Mulder product web app
+**Status:** Direction-setting document for `apps/app`, the Mulder web app
 **Audience:** Product, design, and engineering contributors extending the Mulder web app
 
 ---
@@ -10,9 +10,9 @@
 
 `apps/app` is the only active product direction for Mulder's browser experience.
 
-Mulder is a powerful research and analysis system. The interface should therefore feel like a precise technical workbench, not like an editorial presentation layer. API integration decisions are captured in [`docs/product-app-api-integration.md`](./product-app-api-integration.md).
+Mulder is a powerful research and analysis system. The interface should therefore feel like a precise technical workbench, not like an editorial presentation layer. API integration decisions are captured in [`docs/app-api-integration.md`](./app-api-integration.md).
 
-The key decision is not simply "make v1 cleaner." The better path is to continue the product app as an API-contract-first, capability-aware product shell:
+The key decision is not simply "make the earlier interface cleaner." The better path is to continue the app as an API-contract-first, capability-aware shell:
 
 - Build the UI around real workflows: documents, runs, evidence, entities, search, graph, review.
 - Bind real API data as early as possible.
@@ -25,23 +25,23 @@ This avoids the trap of building a beautiful static frontend that later has to b
 
 ---
 
-## 2. Why The Product App Exists
+## 2. Why The App Exists
 
-The v1 design was visually polished, but its concept was not fully aligned with the product's purpose. It leaned into an investigative, literary, archival tone: serif headlines, large atmospheric surfaces, cinematic pacing, and a narrated "hero moment" structure.
+The earlier visual direction was polished, but its concept was not fully aligned with the product's purpose. It leaned into an investigative, literary, archival tone: serif headlines, large atmospheric surfaces, cinematic pacing, and a narrated "hero moment" structure.
 
-That direction can work for a fundable showcase, but it is less convincing as the daily interface for a serious analysis tool. It makes the app feel like it is presenting insight rather than helping the user operate a complex system.
+That direction can work for a fundable presentation, but it is less convincing as the daily interface for a serious analysis tool. It makes the app feel like it is presenting insight rather than helping the user operate a complex system.
 
-The product app exists to shift the product posture:
+The app exists to shift the product posture:
 
-| v1 tendency | product app correction |
+| Earlier tendency | app correction |
 | --- | --- |
 | Editorial, cinematic, narrated | Technical, operational, direct |
 | Large hero surfaces | Dense work surfaces |
 | Serif/display emphasis | Sans-first UI typography |
 | Mood-led visual identity | Data-led visual identity |
-| Top-nav prototype structure | Sidebar-first product IA |
+| Top-nav-only structure | Sidebar-first product IA |
 | Screens as chapters | Screens as tools |
-| Static showcase risk | API-contract-backed workbench |
+| Static screen risk | API-contract-backed workbench |
 
 The product should communicate that it can handle difficult research work: messy sources, long-running jobs, contradictory claims, entity resolution, graph traversal, and auditability. The UI should make that power feel controllable.
 
@@ -79,7 +79,7 @@ Not:
 
 ## 4. Product Posture
 
-The product app should feel:
+The app should feel:
 
 - **Clean:** restrained palette, low decoration, clear layout rhythm.
 - **Productive:** users can scan, compare, filter, inspect, and act quickly.
@@ -140,9 +140,9 @@ Recommended sidebar grouping:
 | Research | Search | Hybrid retrieval, citations, trace disclosure | Mounted API; trace depth is partial |
 | Knowledge | Entities | Entity search, profiles, aliases, merges | Mounted API |
 | Knowledge | Graph | Relationship exploration and graph-backed review | Mounted partial; aggregate graph endpoint or batch edge query needed |
-| Operations | Analysis Runs | Queue, jobs, artifacts, failures, retries | Jobs mounted; product-shaped run facade needed |
+| Operations | Analysis Runs | Queue, jobs, artifacts, failures, retries | Jobs mounted; app-shaped run facade needed |
 | Operations | Activity | Cross-system event stream | Missing aggregate |
-| Operations | Usage | Cost, budget, worker, and capacity signals | CLI/package-only plus mounted status pieces; product API partial |
+| Operations | Usage | Cost, budget, worker, and capacity signals | CLI/package-only plus mounted status pieces; app API partial |
 | Admin | Settings | Workspace, users, API/auth, config, policy | Future milestone |
 
 `Analysis Runs` can stay active early because it is the fastest way to validate API binding and operational states. In the real product navigation, it should sit under Operations so pipeline machinery does not look like the core research object.
@@ -158,17 +158,17 @@ Use precise contract states in planning:
 | Future milestone | Depends on upcoming milestone work before product use |
 | Missing | Needed by the product direction but not yet planned clearly |
 
-Disabled or "soon" items are acceptable in the prototype only if they are visually honest and non-interactive. As APIs become real, these sections should graduate from disabled to functional.
+Disabled or "soon" items are acceptable only if they are visually honest and non-interactive. As APIs become real, these sections should graduate from disabled to functional.
 
 ---
 
 ## 6. Visual System
 
-The product app visual system lives in `apps/app/src/styles.css`. That file should remain the main adjustment surface.
+The app visual system lives in `apps/app/src/styles.css`. That file should remain the main adjustment surface.
 
 ### Typography
 
-Use sans-first typography for all product UI. Avoid v1's editorial display-serif language in the product app.
+Use sans-first typography for all app UI. Avoid editorial display-serif language in the app.
 
 Recommended usage:
 
@@ -237,7 +237,7 @@ Do not make Mulder feel powerful only by making everything smaller. The interfac
 
 ## 7. Usability Strategy
 
-The product app should optimize for repeated analytical work, not just first impression.
+The app should optimize for repeated analytical work, not just first impression.
 
 ### Research First, Pipeline Second
 
@@ -312,7 +312,7 @@ Until those backend contracts exist, the app can support development ingest and 
 If an action has no API, do not render it as a working primary action. Use one of these patterns instead:
 
 - Hide the action until available.
-- Render a disabled control with "API pending" or similar internal-facing language in prototype mode.
+- Render a disabled control with "API pending" or similar internal-facing language in internal planning mode.
 - Show a capability-aware empty state.
 
 This is especially important for evidence review actions, graph aggregation, taxonomy management, exports, and cost controls.
@@ -339,18 +339,18 @@ This does not mean the backend should become UI-driven. Mulder's durable archite
 - Long-running operations are produced as jobs.
 - The worker executes domain pipeline steps.
 - Read-only browser views consume stable HTTP read models.
-- Product facades are acceptable when they compose existing domain data for the UI.
-- Product facades are not acceptable when they duplicate pipeline logic or become a second implementation of domain behavior.
+- App facades are acceptable when they compose existing domain data for the UI.
+- App facades are not acceptable when they duplicate pipeline logic or become a second implementation of domain behavior.
 
 Recommended architecture:
 
 1. A typed API client layer.
 2. React Query hooks per backend capability.
 3. A capability registry describing the real contract state of each feature.
-4. No checked-in fixture data in product screens.
+4. No checked-in fixture data in app screens.
 5. UI states for loading, error, empty, partial, and unavailable.
 
-The initial prototype used static fixtures to establish the visual direction. The product app should now behave like the real application: API data when available, honest empty/error/unavailable states when it is not. If a public fixed-data showcase is needed later, it should live beside the product app as an explicit showcase surface.
+The initial static shell used fixtures to establish the visual direction. The app should now behave like the real application: API data when available, honest empty/error/unavailable states when it is not. Public examples, if needed later, must be separate from the production app direction.
 
 ### Contract States
 
@@ -366,7 +366,7 @@ type CapabilityState =
 	| 'missing';
 ```
 
-For `mounted-api` and `mounted-partial`, the default path must be real API data. For `documented-target`, `future-milestone`, and `missing` capabilities, the product app should show unavailable or planned states rather than silently substituting fixed data.
+For `mounted-api` and `mounted-partial`, the default path must be real API data. For `documented-target`, `future-milestone`, and `missing` capabilities, the app should show unavailable or planned states rather than silently substituting checked-in static data.
 
 ### Mounted API Coverage
 
@@ -405,13 +405,13 @@ These can be bound immediately or with minimal UI adaptation:
 
 ### Missing or Weak API Shapes
 
-These are important for the product workbench:
+These are important for the app workbench:
 
 | Need | Contract state | Recommendation |
 | --- | --- | --- |
-| Analysis run list/detail | Mounted partial: jobs exist, product-shaped runs do not | Add `/api/analysis-runs` facade or enrich `/api/jobs` with stable run grouping, progress, artifacts, parameters, and source status |
+| Analysis run list/detail | Mounted partial: jobs exist, app-shaped runs do not | Add `/api/analysis-runs` facade or enrich `/api/jobs` with stable run grouping, progress, artifacts, parameters, and source status |
 | Run artifacts and params | Mounted partial: payload exists but is not normalized for UI | Expose a stable artifact/parameter read model rather than parsing job payloads in components |
-| Evidence claims | Missing/product facade needed: contradictions exist, claims are not first-class | Add `/api/evidence/claims` with claim text, source support, confidence, contradiction state, and review state |
+| Evidence claims | Missing app facade needed: contradictions exist, claims are not first-class | Add `/api/evidence/claims` with claim text, source support, confidence, contradiction state, and review state |
 | Evidence review actions | Missing | Add confirm, dismiss, watch, resolve, and annotate actions with optimistic-safe contracts |
 | Graph aggregate | Mounted partial: per-entity edges only | Add `/api/graph` or `/api/entities/edges?entity_ids=...` for graph surfaces beyond one entity |
 | Global stories | Mounted partial: document-scoped stories exist | Add `/api/stories` and `/api/stories/:id` or keep story access intentionally document-scoped |
@@ -431,7 +431,7 @@ The UI should be designed with these needs in mind, but it should not fabricate 
 
 ### Phase 1: Bind Real API Data
 
-Replace static prototype data with real API hooks for:
+Replace static shell data with real API hooks for:
 
 - Overview metrics.
 - Jobs/runs table.
@@ -440,9 +440,9 @@ Replace static prototype data with real API hooks for:
 - Source reliability.
 - Search status where useful.
 
-Do not keep fixed-data fallbacks in product screens. Use empty, unavailable, or planned states when an API contract is not ready.
+Do not keep checked-in static-data fallbacks in app screens. Use empty, unavailable, or planned states when an API contract is not ready.
 
-### Phase 2: Add Capability-Aware Product States
+### Phase 2: Add Capability-Aware App States
 
 Introduce a small capability map:
 
@@ -462,7 +462,7 @@ Use it to control:
 - Missing actions.
 - Empty states.
 - Tooltips.
-- "API pending" prototype notes.
+- "API pending" internal notes.
 
 ### Phase 3: Close Backend Gaps in Product Order
 
@@ -494,9 +494,9 @@ Once the API shape exists, expand:
 
 ## 10. Non-Goals
 
-The product app should not attempt to:
+The app should not attempt to:
 
-- Recreate v1's cinematic document reveal language.
+- Recreate cinematic document reveal language.
 - Ship a complete fake workbench before API coverage exists.
 - Add complex visual effects before core workflows are usable.
 - Optimize for a marketing landing page.
@@ -505,17 +505,17 @@ The product app should not attempt to:
 - Move pipeline or domain logic into frontend-shaped API routes.
 - Productize real archive ingest before the provenance/trust gate is resolved or explicitly waived.
 
-The goal is a durable product shell that can absorb backend capability as it lands.
+The goal is a durable app shell that can absorb backend capability as it lands.
 
 ---
 
 ## 11. Success Criteria
 
-The product app is succeeding if:
+The app is succeeding if:
 
-- It feels immediately more credible as a powerful analysis product than v1.
+- It feels immediately credible as a powerful analysis product.
 - Users can understand system state without reading explanatory prose.
-- Real API data replaces static prototype data without redesigning screens.
+- Real API data replaces static shell data without redesigning screens.
 - Missing capabilities are visible but not fake.
 - Sidebar IA scales as new milestones land while keeping research modules visually primary.
 - Tables, inspectors, filters, and status surfaces become the dominant interaction model.
@@ -531,4 +531,4 @@ The product should feel like it was built by people who trust the user with comp
 
 Mulder does not need to make research look magical. It needs to make difficult research controllable, inspectable, and reliable.
 
-That is the core design strategy for the Mulder product app.
+That is the core design strategy for the Mulder app.

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -2247,7 +2247,7 @@ mulder/
 │   ├── specs/                      # Spec-driven development
 │   └── functional-spec.md          # This document
 │
-└── apps/app/                       # Browser product app
+└── apps/app/                       # Browser app
 ```
 
 ### Package Dependencies

--- a/docs/reviews/m1-review.md
+++ b/docs/reviews/m1-review.md
@@ -182,7 +182,7 @@ No divergences found. Implementation matches spec:
 - **Severity:** NOTE
 - **Spec says:** §13 lists a browser UI surface.
 - **Code does:** current browser product work lives in `apps/app`.
-- **Evidence:** This is consistent with the current product-app layout. Not a divergence.
+- **Evidence:** This is consistent with the current app layout. Not a divergence.
 
 No divergences found. All directories listed in §13 exist:
 - packages/core, packages/pipeline, packages/retrieval, packages/taxonomy, packages/worker, packages/evidence
@@ -261,4 +261,4 @@ None.
 3. [DIV-006]: v2.0 migration files (009-011) will be created in M6
 4. [DIV-008]: `cost-estimator.ts` is M8-I2 scope
 5. [DIV-011]: `shared/types.ts` can be created when shared types are needed beyond service interfaces
-6. [DIV-013]: Not a real divergence — the browser product app lives in `apps/app`
+6. [DIV-013]: Not a real divergence — the browser app lives in `apps/app`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,27 +193,27 @@ Move from CLI to HTTP. Job queue, async workers, a full REST API over the pipeli
 | 🟢 | H8 | Entity API routes (sync) | §10.6 |
 | 🟢 | H9 | Evidence API routes (sync) | §10.6 |
 | 🟢 | H10 | Document retrieval routes — list/pdf/markdown sync routes | §10.6 |
-| 🟢 | H11 | Browser product shell consuming H10 routes | §13, consumes H10 |
+| 🟢 | H11 | Browser app shell consuming H10 routes | §13, consumes H10 |
 
 **Also read for all M7 steps:** [`docs/api-architecture.md`](./api-architecture.md) (framework choice, route structure, middleware stack, OpenAPI strategy, key trade-offs), §10 (full job queue section — especially §10.3 transaction discipline), §14 (design decisions — PostgreSQL queue, auto-commit dequeue, per-step job slicing)
 
 **Verification guidance for M7:** use package-local builds plus step- or milestone-scoped spec tests while iterating (`pnpm test:scope -- step M7-Hx` / `pnpm test:scope -- milestone M7`). For HTTP work, use `pnpm test:api:e2e` as the API-focused end-to-end lane for M7-H3 through M7-H10. Do not default to the full CI-equivalent suite for routine API milestone work.
 
-**Testable:** HTTP API for everything. Workers process jobs asynchronously. Deployable to Cloud Run. First browser product shell consuming the real API.
+**Testable:** HTTP API for everything. Workers process jobs asynchronously. Deployable to Cloud Run. First browser app shell consuming the real API.
 
-**Note on H11 (Document Viewer):** Current browser product work lives in `apps/app` and should follow the product-app documents. An earlier off-roadmap attempt was reverted in commit 90bee3a (issue #127 closed) because the clean path requires a real HTTP API to sit on, not a dev-only Vite filesystem plugin that would have bypassed the service abstraction.
+**Note on H11 (Document Viewer):** Current browser app work lives in `apps/app` and should follow the app documents. An earlier off-roadmap attempt was reverted in commit 90bee3a (issue #127 closed) because the clean path requires a real HTTP API to sit on, not a dev-only Vite filesystem plugin that would have bypassed the service abstraction.
 
 ---
 
-## M7.5: Retired Browser Prototype Track
+## M7.5: Browser App Track
 
-This track is retired. Current browser product work is governed by `apps/app`, [`docs/product-app-design-strategy.md`](./product-app-design-strategy.md), [`docs/product-app-api-integration.md`](./product-app-api-integration.md), and [`docs/product-app-deployment.md`](./product-app-deployment.md).
+Current browser app work is governed by `apps/app`, [`docs/app-design-strategy.md`](./app-design-strategy.md), [`docs/app-api-integration.md`](./app-api-integration.md), and [`docs/app-deployment.md`](./app-deployment.md).
 
-Do not start new implementation from retired prototype routes, visual language, or fixed showcase data. If a public fixed-data showcase is needed later, build it as a separate, explicitly labeled surface that does not point at a private production project.
+Do not start new implementation from old visual language or checked-in static data. Public examples, if needed later, must be separate from the production app and must not point at a private production project.
 
-**Current product-app verification:** `pnpm --filter @mulder/app dev`, `pnpm --filter @mulder/app build`, and browser checks against `apps/app`.
+**Current app verification:** `pnpm --filter @mulder/app dev`, `pnpm --filter @mulder/app build`, and browser checks against `apps/app`.
 
-**Current target:** Product-app acceptance is governed by the product-app strategy, API integration notes, and deployment runbook.
+**Current target:** App acceptance is governed by the app strategy, API integration notes, and deployment runbook.
 
 ---
 
@@ -389,7 +389,7 @@ M1 Foundation
                      ├→ M5 Curation
                      ├→ M6 Intelligence (v2.0)
                      ├→ M7 API+Workers
-                    │   └→ Product App Track ← API-backed browser work
+                    │   └→ App Track ← API-backed browser work
                      ├→ M8 Operations
                      ├→ M9 Multi-Format Ingestion
                      └→ M10 Provenance & Quality ← BEFORE FIRST REAL ARCHIVE INGEST

--- a/docs/specs/48_layout_to_markdown.spec.md
+++ b/docs/specs/48_layout_to_markdown.spec.md
@@ -1,7 +1,7 @@
 ---
 spec: 48
 title: Layout-to-Markdown Converter
-roadmap_step: "off-roadmap (demoability)"
+roadmap_step: "off-roadmap (inspection tooling)"
 functional_spec: "§2.2 (extract step), §4.5 (service abstraction)"
 scope: single
 issue: https://github.com/mulkatz/mulder/issues/125
@@ -26,7 +26,7 @@ This is the first feature that makes the pipeline's output directly consumable b
 
 - New pure function `layoutToMarkdown(layout: LayoutDocument): string` in `packages/pipeline/src/extract/layout-to-markdown.ts`. Pure means: no I/O, no logger, no services, no mutation of input, no date-dependent output — same input always produces byte-identical output.
 - Extract step writes `layout.md` alongside `layout.json` to `services.storage` on every successful run (both real GCP and dev-mode fixtures). The Markdown write is additive — it does not replace `layout.json`, and failures in the Markdown write must not fail the overall Extract result.
-- CLI flag `mulder extract <source-id> --markdown-to <local-path>` that downloads the `layout.md` produced by that run and writes it to a local file path. Useful for demos and quick inspection.
+- CLI flag `mulder extract <source-id> --markdown-to <local-path>` that downloads the `layout.md` produced by that run and writes it to a local file path. Useful for quick inspection and review.
 - Running header/footer filtering via heuristic: blocks tagged `type: 'header'` or `type: 'footer'` are excluded from the Markdown output. (Cross-page repetition detection is handled by the Document AI parser, not this converter — see §2 Out of scope.)
 - Heading rendering: blocks tagged `type: 'heading'` become `#` headings. For a first pass, all headings are level 1 (`#`). Rendering hierarchy from relative font size is a V2 concern.
 - Table rendering: blocks tagged `type: 'table'` are parsed from their pipe-delimited `text` content into GitHub-Flavored Markdown tables (first row = header, `|---|` separator injected, rows padded). Tables that fail to parse fall back to a verbatim code block so no information is lost.
@@ -45,7 +45,7 @@ This is the first feature that makes the pipeline's output directly consumable b
 - **Image placement** — page images exist in storage at `extracted/{doc}/pages/page-NNN.png` but are NOT referenced from the Markdown. Image embedding is a future spec.
 - **Modifications to the Segment step** — Segment continues to produce per-story Markdown independently. This spec's whole-document Markdown is a separate artifact.
 - **`layoutToMarkdown` as a configurable function** — no config options, no feature flags. It is a pure function with one input and one output.
-- **A one-shot `mulder preview <pdf>` command that ingests + extracts in memory without DB** — deferred. For now, users run `mulder ingest foo.pdf && mulder extract <id> --markdown-to foo.md`. Two commands, each fast, acceptable for demos.
+- **A one-shot `mulder preview <pdf>` command that ingests + extracts in memory without DB** — deferred. For now, users run `mulder ingest foo.pdf && mulder extract <id> --markdown-to foo.md`. Two commands, each fast, acceptable for quick inspection.
 
 ### Interfaces affected
 
@@ -71,7 +71,7 @@ This is the first feature that makes the pipeline's output directly consumable b
 
 ### Required by (consumers)
 
-- Future **Viewer UI** spec (next in the demoability sequence). Depends on `layout.md` being a stable, deterministic artifact in storage.
+- Future **Viewer UI** spec (next in the inspection sequence). Depends on `layout.md` being a stable, deterministic artifact in storage.
 - Future **Document AI parser enrichment** spec — will enhance the inputs to this converter (richer block types for real GCP runs). Not a hard dependency in either direction; this spec ships first.
 
 ## 4. Blueprint

--- a/docs/specs/49_mulder_show_command.spec.md
+++ b/docs/specs/49_mulder_show_command.spec.md
@@ -1,7 +1,7 @@
 ---
 spec: 49
 title: "`mulder show` command — terminal preview of layout.md"
-roadmap_step: "off-roadmap (demoability)"
+roadmap_step: "off-roadmap (inspection tooling)"
 functional_spec: "§1 (CLI surface), §2.2 (extract step), §4.5 (service abstraction)"
 scope: single
 issue: https://github.com/mulkatz/mulder/issues/128
@@ -12,7 +12,7 @@ created: 2026-04-09
 
 ## 1. Objective
 
-Add a `mulder show <source-id>` CLI command that reads the `layout.md` artifact produced by the Extract step (spec 48) and prints it to stdout with lightweight ANSI formatting. Makes the derived Markdown immediately consumable in the terminal without opening a file in an editor — the cheapest possible demoability win for the Extract pipeline stage while the real document viewer waits for M7-H11.
+Add a `mulder show <source-id>` CLI command that reads the `layout.md` artifact produced by the Extract step (spec 48) and prints it to stdout with lightweight ANSI formatting. Makes the derived Markdown immediately consumable in the terminal without opening a file in an editor, which is the cheapest possible inspection win for the Extract pipeline stage while the real document viewer waits for M7-H11.
 
 This is a focused stop-gap: a single-file CLI command (~200 lines) that uses the existing service abstraction, adds zero new dependencies, and will be naturally superseded once the M7 HTTP API + React viewer lands. It does not create architectural debt — it uses the same `loadConfig() → createServiceRegistry() → services.storage.download()` pattern as every other CLI command, and its formatter is a pure function of the input string.
 

--- a/docs/specs/69_hono_server_scaffold.spec.md
+++ b/docs/specs/69_hono_server_scaffold.spec.md
@@ -19,7 +19,7 @@ Introduce Mulder's first real HTTP runtime in `apps/api` so M7 can build on a co
 - **Roadmap Step:** `M7-H3` — Hono server scaffold — app, node-server, health endpoint
 - **Target:** `apps/api/package.json`, `apps/api/src/app.ts`, `apps/api/src/index.ts`, `apps/api/src/routes/health.ts`, `tests/specs/69_hono_server_scaffold.test.ts`
 - **In scope:** Hono runtime dependencies for `@mulder/api`; a reusable app factory that mounts `/api/health`; a Node entrypoint that starts the Hono app with `@hono/node-server`; minimal request logging through Mulder's existing logger; and black-box coverage proving the scaffold boots and serves the health route
-- **Out of scope:** auth, rate limiting, request context, structured error middleware (`M7-H4`); pipeline, jobs, search, entity, evidence, or document routes (`M7-H5` through `M7-H10`); OpenAPI/Scalar setup; config schema additions for API settings; and any browser product app work (`M7-H11`)
+- **Out of scope:** auth, rate limiting, request context, structured error middleware (`M7-H4`); pipeline, jobs, search, entity, evidence, or document routes (`M7-H5` through `M7-H10`); OpenAPI/Scalar setup; config schema additions for API settings; and any browser app work (`M7-H11`)
 - **Constraints:** preserve the CLI-first package boundaries from `CLAUDE.md`; keep business logic out of the HTTP layer; keep the initial server bootstrap small and dependency-light; avoid inventing a broad API config surface before the middleware/routes specs land; and ensure the health endpoint can be called without authentication for Cloud Run-style liveness checks
 
 ## 3. Dependencies

--- a/docs/specs/77_browser_safe_email_password_auth.spec.md
+++ b/docs/specs/77_browser_safe_email_password_auth.spec.md
@@ -1,6 +1,6 @@
 ---
 spec: "77"
-title: "Browser-Safe Email/Password Session Auth For The Product App"
+title: "Browser-Safe Email/Password Session Auth For The App"
 roadmap_step: ""
 functional_spec: ["§10.6", "§13"]
 scope: phased
@@ -8,26 +8,26 @@ issue: "https://github.com/mulkatz/mulder/issues/195"
 created: 2026-04-18
 ---
 
-# Spec 77: Browser-Safe Email/Password Session Auth For The Product App
+# Spec 77: Browser-Safe Email/Password Session Auth For The App
 
 ## 1. Objective
 
-Deliver browser-safe, cookie-backed session auth for the product app. This spec closes the browser auth gap by defining the auth/session routes, cookie behavior, role-gated invite flow, and browser-compatible middleware path needed for `apps/app` to consume the real API without embedding bearer keys in the web bundle.
+Deliver browser-safe, cookie-backed session auth for the app. This spec closes the browser auth gap by defining the auth/session routes, cookie behavior, role-gated invite flow, and browser-compatible middleware path needed for `apps/app` to consume the real API without embedding bearer keys in the web bundle.
 
-The functional-spec authority here is partial: `§10.6` governs the API boundary and `§13` governs the source layout. The active product-app implementation reference is `docs/product-app-api-integration.md`.
+The functional-spec authority here is partial: `§10.6` governs the API boundary and `§13` governs the source layout. The active app implementation reference is `docs/app-api-integration.md`.
 
 ## 2. Boundaries
 
 - **Roadmap Step:** N/A — M7/M7.5 remediation follow-up restoring the browser auth prerequisite
 - **Target:** `packages/core/src/config/schema.ts`, `packages/core/src/config/types.ts`, `packages/core/src/config/defaults.ts`, `mulder.config.example.yaml`, `apps/api/src/app.ts`, `apps/api/src/middleware/auth.ts`, `apps/api/src/routes/auth.schemas.ts`, `apps/api/src/routes/auth.ts`, `apps/api/src/lib/auth.ts`, `apps/app/vite.config.ts`, `apps/app/src/lib/api-client.ts`, `apps/app/src/features/auth/useSession.ts`, `apps/app/src/features/auth/useLogin.ts`, `apps/app/src/features/auth/useLogout.ts`, `apps/app/src/features/auth/useAcceptInvitation.ts`, `apps/app/src/app/AuthGate.tsx`, `tests/specs/77_browser_safe_email_password_auth.test.ts`
-- **In scope:** cookie-backed browser login/logout/session routes; invitation acceptance and admin-gated invitation issuance; explicit role handling for `owner`, `admin`, and `member`; middleware support for session-authenticated browser requests alongside existing operator/API-key flows; dev-mode same-origin proxy alignment for the product app; and black-box verification that the product app can authenticate and then call protected API routes without embedding bearer tokens
+- **In scope:** cookie-backed browser login/logout/session routes; invitation acceptance and admin-gated invitation issuance; explicit role handling for `owner`, `admin`, and `member`; middleware support for session-authenticated browser requests alongside existing operator/API-key flows; dev-mode same-origin proxy alignment for the app; and black-box verification that the app can authenticate and then call protected API routes without embedding bearer tokens
 - **Out of scope:** OAuth/OIDC/SSO, password-reset flows, admin invitation management UI beyond create-invite, full ACL/RBAC beyond role gating, non-browser SDK auth, and unrelated OpenAPI/Scalar work
 - **Constraints:** the browser bundle must never carry a static API key; session cookies must be `HttpOnly`; auth failures on login must remain generic; protected read routes must accept valid session auth from the browser; and the implementation must not regress CLI/server-side bearer-key access where that path is still intentionally used
 
 ## 3. Dependencies
 
-- **Requires:** Spec 69 (`M7-H3`) Hono server scaffold, Spec 70 (`M7-H4`) middleware stack, Spec 76 (`M7-H10`) document retrieval routes, and the current product app auth hooks/pages under `apps/app/src/features/auth/*` and `apps/app/src/pages/*`
-- **Blocks:** a fully clean browser product app integration story, because the current web app assumes this auth model for all protected API access
+- **Requires:** Spec 69 (`M7-H3`) Hono server scaffold, Spec 70 (`M7-H4`) middleware stack, Spec 76 (`M7-H10`) document retrieval routes, and the current app auth hooks/pages under `apps/app/src/features/auth/*` and `apps/app/src/pages/*`
+- **Blocks:** a fully clean browser app integration story, because the current web app assumes this auth model for all protected API access
 
 ## 4. Blueprint
 
@@ -37,7 +37,7 @@ The functional-spec authority here is partial: `§10.6` governs the API boundary
 2. **`apps/api/src/routes/auth.schemas.ts`** — define Zod-backed request/response contracts for login, logout, session, invitation acceptance, and invitation creation
 3. **`apps/api/src/lib/auth.ts`** — implement session creation/validation/clearing plus invitation acceptance/issuance helpers behind one route-facing library boundary
 4. **`apps/api/src/routes/auth.ts`** — mount `POST /api/auth/login`, `POST /api/auth/logout`, `GET /api/auth/session`, `POST /api/auth/invitations/accept`, and `POST /api/auth/invitations`
-5. **`apps/api/src/middleware/auth.ts`** and **`apps/api/src/app.ts`** — extend protected-route auth so browser session cookies can authorize the same read surfaces the product app uses, while preserving explicit public-path behavior and intentional operator-key support where documented
+5. **`apps/api/src/middleware/auth.ts`** and **`apps/api/src/app.ts`** — extend protected-route auth so browser session cookies can authorize the same read surfaces the app uses, while preserving explicit public-path behavior and intentional operator-key support where documented
 6. **`apps/app/vite.config.ts`** and **`apps/app/src/lib/api-client.ts`** — keep the browser fetch path same-origin in dev and credential-aware in all environments
 7. **`apps/app/src/features/auth/*`** and **`apps/app/src/app/AuthGate.tsx`** — align the existing auth hooks/gate with the real API contract rather than preview-only fallbacks
 8. **`tests/specs/77_browser_safe_email_password_auth.test.ts`** — add black-box verification for the API auth/session flow and the browser-facing contract
@@ -70,12 +70,12 @@ The browser-facing auth contract is:
 - Browser sessions are cookie-based and `HttpOnly`
 - The browser uses `credentials: 'include'`; it does not send a bearer key
 - CLI/server-side flows may continue to use bearer keys where those surfaces are intentionally operator-only
-- Protected read routes used by the product app (`/api/documents*`, `/api/search`, `/api/entities*`, `/api/evidence*`) must accept a valid browser session
+- Protected read routes used by the app (`/api/documents*`, `/api/search`, `/api/entities*`, `/api/evidence*`) must accept a valid browser session
 
 ### 4.4 Integration Points
 
 - The existing `apps/app` auth hooks should remain real clients of the API rather than preview-mode placeholders
-- The middleware contract must stop treating browser auth as out of scope for product app paths
+- The middleware contract must stop treating browser auth as out of scope for app paths
 - The invite flow in the UI and the admin-gated invite API must agree on roles, expiration semantics, and generic failure copy
 - Dev mode must use the Vite proxy path so cookies behave same-origin during local work
 - Production invite links use `MULDER_APP_BASE_URL` and delivery is selected by `MULDER_INVITE_DELIVERY` (`log` or `resend`)
@@ -92,7 +92,7 @@ The browser-facing auth contract is:
 - preserve operator-key behavior where documented
 - wire the auth route family into the app
 
-**Phase 3: product-app alignment + QA**
+**Phase 3: app alignment + QA**
 - align `apps/app` auth hooks and proxy behavior with the real backend
 - verify protected document/search/entity/evidence routes work through session auth
 - close preview-only assumptions that mask missing backend auth

--- a/packages/core/src/database/migrations/020_browser_auth.sql
+++ b/packages/core/src/database/migrations/020_browser_auth.sql
@@ -1,4 +1,4 @@
--- Browser-safe session auth for the API and product app.
+-- Browser-safe session auth for the API and app.
 -- Password hashes use application-level scrypt. Session and invitation tokens
 -- are stored as irreversible hashes; raw tokens are never persisted.
 

--- a/tests/specs/77_browser_safe_email_password_auth.test.ts
+++ b/tests/specs/77_browser_safe_email_password_auth.test.ts
@@ -262,7 +262,7 @@ describe('Spec 77: Browser-safe email/password auth', () => {
 		}
 	});
 
-	it('QA-06: the product app bundle source does not reference VITE_MULDER_API_KEY', () => {
+	it('QA-06: the app bundle source does not reference VITE_MULDER_API_KEY', () => {
 		const apiClient = readFileSync(resolve(ROOT, 'apps/app/src/lib/api-client.ts'), 'utf8');
 		const authGate = readFileSync(resolve(ROOT, 'apps/app/src/app/AuthGate.tsx'), 'utf8');
 		expect(apiClient).not.toContain('VITE_MULDER_API_KEY');


### PR DESCRIPTION
## Summary
- rename active app docs and deployment workflow away from product-app naming
- remove stale demo/showcase/fixed-data wording from active docs and specs
- normalize the browser app references across README, docs, workflow, and app chrome

## Verification
- pnpm lint
- pnpm --filter @mulder/app build
- pnpm build
- node --check scripts/smoke-live-api.mjs
- targeted searches for demo/product-app/showcase/fixed-data references