### PR TITLE
feat(pipeline): skip segment step for pre-structured source types (M9-J2)

### DIFF
--- a/devlog/2026-05-03-m9-j2-pipeline-step-skipping.md
+++ b/devlog/2026-05-03-m9-j2-pipeline-step-skipping.md
@@ -1,0 +1,16 @@
+---
+date: 2026-05-03
+type: implementation
+title: "M9-J2: Pipeline orchestrator supports pre-structured format skip"
+tags: [pipeline, multi-format, orchestrator, m9]
+---
+
+The pipeline orchestrator now knows that some source types don't need Gemini segmentation. `text`, `docx`, `spreadsheet`, `email`, and `url` sources produce discrete stories at extract time, so there is no story-boundary detection work to do — the segment step is a no-op that would run pointlessly.
+
+M9-J2 wires this up by adding `isPreStructuredType()` as a pure utility, updating `shouldRun()` with an optional fifth `sourceType` parameter, and extending the `enumerateSources()` resume logic to treat `extracted` as a valid pickup status when the first step is `enrich`. The dry-run estimate path mirrors the same change.
+
+The critical constraint was ordering: the segment-skip guard fires before the `--force` check inside `shouldRun()`, so a user cannot accidentally force-run segment for a format that has no segment implementation. The function stays pure — no I/O, no database access — which kept the change surgical and easy to unit-test.
+
+The status machine now has two valid paths to `enriched`: the PDF path (`segmented → enriched`) and the pre-structured path (`extracted → enriched`). The `segmented` status is never touched for pre-structured sources; they simply skip past it. All seven QA conditions pass as pure-function assertions — no database or GCP infrastructure required.
+
+J3–J10 format handlers can now be implemented knowing the orchestrator will route their sources correctly. The only downstream concern noted in review: extract handlers must persist at least one story before returning, or the enrich step silently no-ops with no error (correct per spec, but worth verifying per format).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,7 +243,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | Status | Step | What | Spec |
 |--------|------|------|------|
 | 🟢 | J1 | Source type discriminator — `source_type` column, JSONB `format_metadata`, magic-byte detection | §4.3 (sources table), §2.1 |
-| 🟡 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
+| 🟢 | J2 | Pipeline step skipping — orchestrator supports `skip_to` so pre-structured formats bypass segment | §3.1, §3.2 |
 | ⚪ | J3 | Image ingestion — JPG, PNG, TIFF via Document AI / Gemini Vision | §2.1, §2.2 |
 | ⚪ | J4 | Plain text ingestion — .txt, .md pass-through (no OCR, no segment) | §2.1 |
 | ⚪ | J5 | DOCX ingestion — Office document extraction via `mammoth` / `docx-parser` | §2.1 |

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -98,7 +98,7 @@ export type {
 	SourceDetectionConfidence,
 	SourceDetectionResult,
 } from './ingest/index.js';
-export { detectSourceType, execute as executeIngest, resolvePdfFiles } from './ingest/index.js';
+export { detectSourceType, execute as executeIngest, isPreStructuredType, resolvePdfFiles } from './ingest/index.js';
 export type {
 	PipelineGlobalAnalysisOutcome,
 	PipelineRunInput,

--- a/packages/pipeline/src/ingest/index.ts
+++ b/packages/pipeline/src/ingest/index.ts
@@ -29,7 +29,7 @@ import { detectSourceType } from './source-type.js';
 import type { IngestFileResult, IngestInput, IngestResult } from './types.js';
 
 export type { SourceDetectionConfidence, SourceDetectionResult } from './source-type.js';
-export { detectSourceType } from './source-type.js';
+export { detectSourceType, isPreStructuredType } from './source-type.js';
 export type { IngestFileResult, IngestInput, IngestResult } from './types.js';
 
 const STEP_NAME = 'ingest';

--- a/packages/pipeline/src/ingest/source-type.ts
+++ b/packages/pipeline/src/ingest/source-type.ts
@@ -93,6 +93,21 @@ function hasRfc822HeaderShape(buffer: Buffer): boolean {
 	return /^From:\s.+$/im.test(sample) && /^Date:\s.+$/im.test(sample) && /^Subject:\s.+$/im.test(sample);
 }
 
+/**
+ * Returns true for source types that produce stories directly at extract time
+ * and therefore skip the segment step in the pipeline orchestrator.
+ * PDF and image go through the normal segment step.
+ */
+export function isPreStructuredType(sourceType: SourceType): boolean {
+	return (
+		sourceType === 'text' ||
+		sourceType === 'docx' ||
+		sourceType === 'spreadsheet' ||
+		sourceType === 'email' ||
+		sourceType === 'url'
+	);
+}
+
 export function detectSourceType(
 	buffer: Buffer | null | undefined,
 	filenameOrInput: string,

--- a/packages/pipeline/src/pipeline/index.ts
+++ b/packages/pipeline/src/pipeline/index.ts
@@ -18,7 +18,17 @@
  */
 
 import { performance } from 'node:perf_hooks';
-import type { Logger, MulderConfig, Services, Source, SourceStatus, StepError, Story, StoryStatus } from '@mulder/core';
+import type {
+	Logger,
+	MulderConfig,
+	Services,
+	Source,
+	SourceStatus,
+	SourceType,
+	StepError,
+	Story,
+	StoryStatus,
+} from '@mulder/core';
 import {
 	completedStepsFromProgress,
 	createChildLogger,
@@ -42,7 +52,7 @@ import { execute as executeEmbed } from '../embed/index.js';
 import { execute as executeEnrich } from '../enrich/index.js';
 import { execute as executeExtract } from '../extract/index.js';
 import { execute as executeGraph } from '../graph/index.js';
-import { execute as executeIngest, resolvePdfFiles } from '../ingest/index.js';
+import { execute as executeIngest, isPreStructuredType, resolvePdfFiles } from '../ingest/index.js';
 import { execute as executeSegment } from '../segment/index.js';
 import type {
 	PipelineGlobalAnalysisOutcome,
@@ -182,10 +192,17 @@ export function shouldRun(
 	sourceStatus: SourceStatus,
 	storyStatuses: StoryStatus[],
 	options: PipelineRunOptions,
+	sourceType?: SourceType,
 ): boolean {
 	if (step === 'ingest') {
 		// Ingest is handled outside the per-source loop. Should never be
 		// asked of `shouldRun`, but defensively return false.
+		return false;
+	}
+
+	// Pre-structured types never have a segment step — skip unconditionally,
+	// even with `--force` (there is no segment implementation to retry).
+	if (step === 'segment' && sourceType !== undefined && isPreStructuredType(sourceType)) {
 		return false;
 	}
 
@@ -219,6 +236,8 @@ export function shouldRun(
 
 	if (step === 'enrich') {
 		if (sourceStatus === 'segmented') return true;
+		// Pre-structured types skip segment, so they enter enrich at `extracted`.
+		if (sourceType !== undefined && isPreStructuredType(sourceType) && sourceStatus === 'extracted') return true;
 		return storyStatuses.some((s) => storyStatusIndex(s) < targetStoryIdx);
 	}
 	if (step === 'embed') {
@@ -395,7 +414,8 @@ async function enumerateSources(
 			eligibleStatuses.push('extracted');
 			break;
 		case 'enrich':
-			eligibleStatuses.push('segmented');
+			// 'extracted' covers pre-structured types that skip segment.
+			eligibleStatuses.push('segmented', 'extracted');
 			break;
 		case 'embed':
 			eligibleStatuses.push('enriched', 'segmented');
@@ -472,7 +492,7 @@ async function processSource(source: Source, ctx: ProcessSourceContext): Promise
 		const stories = await findStoriesBySourceId(ctx.pool, currentSource.id);
 		const storyStatuses = stories.map((s) => s.status);
 
-		if (!shouldRun(step, currentSource.status, storyStatuses, ctx.options)) {
+		if (!shouldRun(step, currentSource.status, storyStatuses, ctx.options, currentSource.sourceType)) {
 			sourceLog.debug({ step, sourceStatus: currentSource.status }, 'pipeline.source.step.skipped');
 			continue;
 		}
@@ -624,7 +644,8 @@ export async function execute(
 					eligibleStatuses.push('extracted');
 					break;
 				case 'enrich':
-					eligibleStatuses.push('segmented');
+					// 'extracted' covers pre-structured types that skip segment.
+					eligibleStatuses.push('segmented', 'extracted');
 					break;
 				case 'embed':
 					eligibleStatuses.push('enriched', 'segmented');

--- a/tests/specs/86_pipeline_step_skipping.test.ts
+++ b/tests/specs/86_pipeline_step_skipping.test.ts
@@ -1,0 +1,87 @@
+import { isPreStructuredType, shouldRun } from '@mulder/pipeline';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Black-box QA tests for Spec 86: Pipeline Step Skipping — Pre-Structured Format Support
+ *
+ * Each `it()` maps to one QA condition from Section 5 of the spec.
+ * Tests interact through system boundaries only: imports from `@mulder/pipeline` (public API).
+ * Never imports from packages/ or src/ or apps/ internal paths.
+ *
+ * No database or GCP infrastructure is required — these are pure function tests.
+ */
+
+describe('Spec 86 — Pipeline Step Skipping', () => {
+	// ─── QA-01: isPreStructuredType classifies correctly ───
+
+	it('QA-01: isPreStructuredType returns true for pre-structured types and false for normal types', () => {
+		// Pre-structured types → true
+		expect(isPreStructuredType('text')).toBe(true);
+		expect(isPreStructuredType('docx')).toBe(true);
+		expect(isPreStructuredType('spreadsheet')).toBe(true);
+		expect(isPreStructuredType('email')).toBe(true);
+		expect(isPreStructuredType('url')).toBe(true);
+
+		// Normal-pipeline types → false
+		expect(isPreStructuredType('pdf')).toBe(false);
+		expect(isPreStructuredType('image')).toBe(false);
+	});
+
+	// ─── QA-02: shouldRun skips segment for pre-structured types ───
+
+	it('QA-02: shouldRun("segment") returns false for pre-structured types, true for pdf', () => {
+		expect(shouldRun('segment', 'extracted', [], {}, 'text')).toBe(false);
+		expect(shouldRun('segment', 'extracted', [], {}, 'docx')).toBe(false);
+		expect(shouldRun('segment', 'extracted', [], {}, 'email')).toBe(false);
+
+		// PDF at extracted should still run segment (normal pipeline)
+		expect(shouldRun('segment', 'extracted', [], {}, 'pdf')).toBe(true);
+	});
+
+	// ─── QA-03: shouldRun skips segment even with force=true ───
+
+	it('QA-03: shouldRun("segment") returns false for pre-structured types even when force=true', () => {
+		expect(shouldRun('segment', 'extracted', [], { force: true }, 'text')).toBe(false);
+
+		// force=true on PDF still runs segment
+		expect(shouldRun('segment', 'extracted', [], { force: true }, 'pdf')).toBe(true);
+	});
+
+	// ─── QA-04: shouldRun allows enrich from extracted for pre-structured types ───
+
+	it('QA-04: shouldRun("enrich") returns true for pre-structured types at extracted status', () => {
+		expect(shouldRun('enrich', 'extracted', [], {}, 'text')).toBe(true);
+		expect(shouldRun('enrich', 'extracted', [], {}, 'docx')).toBe(true);
+
+		// PDF at extracted must NOT enrich (still needs segment first)
+		expect(shouldRun('enrich', 'extracted', [], {}, 'pdf')).toBe(false);
+	});
+
+	// ─── QA-05: shouldRun allows enrich from segmented (unchanged PDF path) ───
+
+	it('QA-05: shouldRun("enrich") returns true for segmented status regardless of sourceType', () => {
+		expect(shouldRun('enrich', 'segmented', [], {}, 'pdf')).toBe(true);
+		expect(shouldRun('enrich', 'segmented', [], {}, undefined)).toBe(true);
+	});
+
+	// ─── QA-06: shouldRun with no sourceType is backward-compatible ───
+
+	it('QA-06: shouldRun without 5th argument preserves pre-J2 behaviour', () => {
+		// No sourceType → segment still runs from extracted (original behaviour)
+		expect(shouldRun('segment', 'extracted', [], {})).toBe(true);
+
+		// No sourceType → enrich does NOT run from extracted (original behaviour)
+		expect(shouldRun('enrich', 'extracted', [], {})).toBe(false);
+	});
+
+	// ─── QA-07: isPreStructuredType is exported from the pipeline package ───
+
+	it('QA-07: isPreStructuredType is importable from @mulder/pipeline and callable', () => {
+		// Import resolved at the top of this file. If it were missing, vitest would
+		// fail to load the module and none of these tests would execute. Additionally,
+		// verify the function is callable and returns a boolean.
+		expect(typeof isPreStructuredType).toBe('function');
+		const result = isPreStructuredType('pdf');
+		expect(typeof result).toBe('boolean');
+	});
+});


### PR DESCRIPTION
## Summary

- Add `isPreStructuredType()` utility that classifies text/docx/spreadsheet/email/url as pre-structured
- Update `shouldRun()` to skip segment (even with force) and allow enrich from extracted status for pre-structured types
- Update `processSource()` to pass `sourceType` to `shouldRun()`
- Update resume path in `enumerateSources()` to pick up pre-structured sources at `extracted` status when first step is `enrich`

Closes #239

## Test plan
- [ ] QA-01 through QA-07 verified via `tests/specs/86_pipeline_step_skipping.test.ts`
- [ ] Full test suite passes
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)