### PR TITLE
fix(app): harden API unavailable and auth expiry states

### DIFF
--- a/apps/app/src/app/Providers.tsx
+++ b/apps/app/src/app/Providers.tsx
@@ -1,12 +1,25 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MotionConfig } from 'framer-motion';
 import { type ReactNode, useEffect, useState } from 'react';
 import { appTransition } from '@/app/motion';
 import { PreferencesProvider } from '@/app/preferences';
 import { ApiError } from '@/lib/api-client';
 
+function emitAuthExpired(error: unknown) {
+	if (error instanceof ApiError && error.status === 401) {
+		if (typeof window === 'undefined') return;
+		window.dispatchEvent(new Event('auth:expired'));
+	}
+}
+
 function createQueryClient() {
 	return new QueryClient({
+		queryCache: new QueryCache({
+			onError: emitAuthExpired,
+		}),
+		mutationCache: new MutationCache({
+			onError: emitAuthExpired,
+		}),
 		defaultOptions: {
 			queries: {
 				staleTime: 30_000,
@@ -18,13 +31,6 @@ function createQueryClient() {
 					return count < 2;
 				},
 				refetchOnWindowFocus: false,
-			},
-			mutations: {
-				onError: (error) => {
-					if (error instanceof ApiError && error.status === 401) {
-						window.dispatchEvent(new Event('auth:expired'));
-					}
-				},
 			},
 		},
 	});

--- a/apps/app/src/lib/api-client.ts
+++ b/apps/app/src/lib/api-client.ts
@@ -22,6 +22,15 @@ export class ApiError extends Error {
 	}
 }
 
+function toNetworkError(error: unknown) {
+	return new ApiError(
+		0,
+		'NETWORK_ERROR',
+		error instanceof Error ? error.message : 'The API could not be reached.',
+		error instanceof Error ? { name: error.name } : undefined,
+	);
+}
+
 async function parseErrorBody(response: Response): Promise<ApiErrorBody> {
 	try {
 		return (await response.json()) as ApiErrorBody;
@@ -38,12 +47,20 @@ function buildJsonHeaders(init?: RequestInit) {
 	return headers;
 }
 
+async function fetchApi(path: string, init?: RequestInit) {
+	try {
+		return await fetch(buildApiUrl(path), {
+			credentials: 'include',
+			...init,
+			headers: buildJsonHeaders(init),
+		});
+	} catch (error) {
+		throw toNetworkError(error);
+	}
+}
+
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-	const response = await fetch(buildApiUrl(path), {
-		credentials: 'include',
-		...init,
-		headers: buildJsonHeaders(init),
-	});
+	const response = await fetchApi(path, init);
 
 	if (!response.ok) {
 		const body = await parseErrorBody(response);
@@ -76,11 +93,16 @@ export async function apiFetchText(path: string, init?: RequestInit): Promise<st
 		headers.set('Accept', 'text/markdown, text/plain');
 	}
 
-	const response = await fetch(buildApiUrl(path), {
-		credentials: 'include',
-		...init,
-		headers,
-	});
+	let response: Response;
+	try {
+		response = await fetch(buildApiUrl(path), {
+			credentials: 'include',
+			...init,
+			headers,
+		});
+	} catch (error) {
+		throw toNetworkError(error);
+	}
 
 	if (!response.ok) {
 		const body = await parseErrorBody(response);

--- a/apps/app/src/lib/query-state.ts
+++ b/apps/app/src/lib/query-state.ts
@@ -2,6 +2,7 @@ import { ApiError } from '@/lib/api-client';
 
 export function getErrorMessage(error: unknown, fallback = 'The API request failed.') {
 	if (error instanceof ApiError) {
+		if (error.status === 0) return fallback;
 		return `${error.status} ${error.message}`;
 	}
 	if (error instanceof Error) {

--- a/docs/app-api-integration.md
+++ b/docs/app-api-integration.md
@@ -22,6 +22,7 @@ The app API client should keep these properties:
 
 - `ApiError` carries `status`, `code`, `message`, and optional `details`.
 - Error responses are parsed from `{ error: { code, message, details } }` when available.
+- Network, CORS, and unreachable-origin failures are normalized to structured API-unavailable errors.
 - JSON helpers set `Content-Type: application/json`.
 - Text helpers use `Accept: text/markdown, text/plain`.
 - `buildApiUrl(path)` passes through absolute URLs and prefixes relative API paths with `VITE_API_BASE_URL`.
@@ -32,7 +33,8 @@ React Query should use conservative defaults:
 - No refetch on window focus by default.
 - No retry for `401`, `403`, or `404`.
 - Limited retry for transient network/server failures.
-- Session expiry should be observable through a shared `auth:expired` event or equivalent app-level handling.
+- Session expiry is observable through shared app-level handling for both queries and mutations.
+- API-unavailable states must remain visible product states and must not be treated as logout.
 
 The app should expose:
 
@@ -40,6 +42,7 @@ The app should expose:
 - `/auth/invitations/:token` for invite acceptance, matching the API-generated invitation link shape.
 - Protected app routes behind `GET /api/auth/session`.
 - Logout through `POST /api/auth/logout` and query-cache clearing.
+- Any `401` from a protected app query or mutation should invalidate auth state and force the session gate to re-check.
 
 ## Usable HTTP Surface
 
@@ -148,7 +151,8 @@ After the cleanup, the first app API implementation should stay narrow:
 1. Add the API client, local API types, React Query provider, and capability registry to `apps/app`.
 2. Bind existing routes only: `/`, `/runs`, and `/evidence`.
 3. Use real loading/empty/error states.
-4. Do not use checked-in fixture data in app screens.
-5. Do not add new product modules until the API foundation is green.
+4. Keep auth/session behavior honest: `401` means unauthenticated, while network/CORS/5xx states remain unavailable/error UI.
+5. Do not use checked-in fixture data in app screens.
+6. Do not add new product modules until the API foundation is green.
 
 If Mulder needs a public example later, build it as a separate, explicitly labeled surface that does not point at a private production project and does not shape the production app.


### PR DESCRIPTION
## Summary
- normalize network/CORS/unreachable API failures into structured API-unavailable errors
- keep unavailable API states from rendering as logout or raw browser fetch errors
- route 401s from both protected queries and mutations through the shared auth-expired handling
- update app API integration notes with the now-enforced auth/error behavior

## Verification
- pnpm lint
- pnpm --filter @mulder/app build
- pnpm build

## Notes
- No new product surfaces or fixtures were added.
- Existing Vite chunk-size warning remains a future code-splitting follow-up.