### PR TITLE
[Pipeline] URL lifecycle and re-fetch support — M9-J10

### DIFF
--- a/apps/cli/src/commands/url.ts
+++ b/apps/cli/src/commands/url.ts
@@ -1,0 +1,158 @@
+/**
+ * CLI command: `mulder url status | refetch`.
+ *
+ * Thin URL lifecycle surface over the pipeline URL lifecycle module.
+ *
+ * @see docs/specs/94_url_lifecycle_refetch.spec.md
+ */
+
+import { closeAllPools, createLogger, createServiceRegistry, getWorkerPool, loadConfig } from '@mulder/core';
+import { getUrlLifecycleStatus, refetchUrlSource } from '@mulder/pipeline';
+import type { Command } from 'commander';
+import { withErrorHandler } from '../lib/errors.js';
+import { printError, printJson, printSuccess } from '../lib/output.js';
+
+interface UrlStatusOptions {
+	json?: boolean;
+}
+
+interface UrlRefetchOptions {
+	dryRun?: boolean;
+	force?: boolean;
+	json?: boolean;
+}
+
+function formatDate(value: Date | null | undefined): string {
+	return value ? value.toISOString() : '-';
+}
+
+function writeStatus(result: Awaited<ReturnType<typeof getUrlLifecycleStatus>>): void {
+	const { source, lifecycle, host } = result;
+	const rows = [
+		['Source ID', source.id],
+		['Original URL', lifecycle.originalUrl],
+		['Final URL', lifecycle.finalUrl],
+		['Host', lifecycle.host],
+		['HTTP status', lifecycle.lastHttpStatus?.toString() ?? '-'],
+		['ETag', lifecycle.etag ?? '-'],
+		['Last-Modified', lifecycle.lastModified ?? '-'],
+		['Last fetched', formatDate(lifecycle.lastFetchedAt)],
+		['Last checked', formatDate(lifecycle.lastCheckedAt)],
+		['Next fetch after', formatDate(lifecycle.nextFetchAfter)],
+		['Robots allowed', lifecycle.robotsAllowed ? 'yes' : 'no'],
+		['Robots URL', lifecycle.robotsUrl ?? '-'],
+		['Matched robots rule', lifecycle.robotsMatchedRule ?? '-'],
+		['Fetch count', lifecycle.fetchCount.toString()],
+		['Unchanged count', lifecycle.unchangedCount.toString()],
+		['Changed count', lifecycle.changedCount.toString()],
+		['Content hash', lifecycle.lastContentHash],
+		['Storage path', lifecycle.lastSnapshotStoragePath],
+		['Rendering', lifecycle.renderingMethod ?? '-'],
+		['Host next allowed', formatDate(host?.nextAllowedAt)],
+	];
+
+	for (const [label, value] of rows) {
+		process.stdout.write(`${label.padEnd(22)} ${value}\n`);
+	}
+}
+
+function writeRefetch(result: Awaited<ReturnType<typeof refetchUrlSource>>): void {
+	const mode = result.dryRun ? 'dry-run ' : '';
+	process.stdout.write(`Source ID             ${result.sourceId}\n`);
+	process.stdout.write(`Result                ${mode}${result.status}\n`);
+	process.stdout.write(`HTTP status           ${result.httpStatus}\n`);
+	process.stdout.write(`Original URL          ${result.originalUrl}\n`);
+	process.stdout.write(`Final URL             ${result.finalUrl}\n`);
+	process.stdout.write(`Not modified          ${result.notModified ? 'yes' : 'no'}\n`);
+	process.stdout.write(`Previous hash         ${result.previousHash}\n`);
+	process.stdout.write(`Current hash          ${result.currentHash}\n`);
+	process.stdout.write(`Storage path          ${result.storagePath}\n`);
+	process.stdout.write(`Rendering             ${result.renderingMethod ?? '-'}\n`);
+	process.stdout.write(`Checked at            ${result.checkedAt}\n`);
+}
+
+function requireWorkerPoolContext(commandName: string): ReturnType<typeof getWorkerPool> {
+	const config = loadConfig();
+	if (!config.gcp && !config.dev_mode) {
+		printError(`GCP configuration is required for ${commandName} (or enable dev_mode)`);
+		process.exit(1);
+	}
+	if (!config.gcp) {
+		printError(`GCP configuration with cloud_sql is required for ${commandName}`);
+		process.exit(1);
+	}
+	return getWorkerPool(config.gcp.cloud_sql);
+}
+
+export function registerUrlCommands(program: Command): void {
+	const url = program.command('url').description('Inspect and refresh URL source lifecycle state');
+
+	url
+		.command('status')
+		.description('Show lifecycle state for one URL source')
+		.argument('<source-id>', 'UUID of the URL source')
+		.option('--json', 'print machine-readable JSON')
+		.action(
+			withErrorHandler(async (sourceId: string, options: UrlStatusOptions) => {
+				const pool = requireWorkerPoolContext('url status');
+				try {
+					const result = await getUrlLifecycleStatus(pool, sourceId);
+					if (options.json) {
+						printJson(result);
+						return;
+					}
+					writeStatus(result);
+				} finally {
+					await closeAllPools();
+				}
+			}),
+		);
+
+	url
+		.command('refetch')
+		.description('Re-fetch one existing URL source')
+		.argument('<source-id>', 'UUID of the URL source')
+		.option('--dry-run', 'check freshness without writing database or storage changes')
+		.option('--force', 'skip conditional request headers while still respecting safety and robots')
+		.option('--json', 'print machine-readable JSON')
+		.action(
+			withErrorHandler(async (sourceId: string, options: UrlRefetchOptions) => {
+				const config = loadConfig();
+				if (!config.gcp && !config.dev_mode) {
+					printError('GCP configuration is required for url refetch (or enable dev_mode)');
+					process.exit(1);
+					return;
+				}
+				if (!config.gcp) {
+					printError('GCP configuration with cloud_sql is required for url refetch');
+					process.exit(1);
+					return;
+				}
+
+				const logger = createLogger();
+				const services = createServiceRegistry(config, logger);
+				const pool = getWorkerPool(config.gcp.cloud_sql);
+				try {
+					const result = await refetchUrlSource(
+						{
+							sourceId,
+							dryRun: options.dryRun ?? false,
+							force: options.force ?? false,
+						},
+						config,
+						services,
+						pool,
+						logger,
+					);
+					if (options.json) {
+						printJson(result);
+						return;
+					}
+					writeRefetch(result);
+					printSuccess(`URL re-fetch ${result.status}${result.dryRun ? ' (dry-run)' : ''}`);
+				} finally {
+					await closeAllPools();
+				}
+			}),
+		);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -35,6 +35,7 @@ import { registerSegmentCommands } from './commands/segment.js';
 import { registerShowCommands } from './commands/show.js';
 import { registerStatusCommand } from './commands/status.js';
 import { registerTaxonomyCommands } from './commands/taxonomy.js';
+import { registerUrlCommands } from './commands/url.js';
 import { registerWorkerCommands } from './commands/worker.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -85,5 +86,6 @@ registerShowCommands(program);
 registerStatusCommand(program);
 registerWorkerCommands(program);
 registerTaxonomyCommands(program);
+registerUrlCommands(program);
 
 program.parse();

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -260,7 +260,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J7 | Email ingestion — .eml/.msg parsing, header metadata → entities (sender, recipient, date, thread) | §2.1 |
 | 🟢 | J8 | URL ingestion — fetch + snapshot to GCS, Readability extraction → Markdown | §2.1 |
 | 🟢 | J9 | URL rendering — Playwright fallback for JS-rendered pages | §2.1 |
-| ⚪ | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
+| 🟡 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
 | ⚪ | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | ⚪ | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
 | ⚪ | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -260,7 +260,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J7 | Email ingestion — .eml/.msg parsing, header metadata → entities (sender, recipient, date, thread) | §2.1 |
 | 🟢 | J8 | URL ingestion — fetch + snapshot to GCS, Readability extraction → Markdown | §2.1 |
 | 🟢 | J9 | URL rendering — Playwright fallback for JS-rendered pages | §2.1 |
-| 🟡 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
+| 🟢 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
 | ⚪ | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | ⚪ | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
 | ⚪ | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |

--- a/docs/specs/94_url_lifecycle_refetch.spec.md
+++ b/docs/specs/94_url_lifecycle_refetch.spec.md
@@ -1,0 +1,164 @@
+---
+spec: "94"
+title: "URL Lifecycle and Re-fetch Support"
+roadmap_step: M9-J10
+functional_spec: ["§2", "§2.1", "§3", "§4.5"]
+scope: phased
+issue: "https://github.com/mulkatz/mulder/issues/252"
+created: 2026-05-04
+---
+
+# Spec 94: URL Lifecycle and Re-fetch Support
+
+## 1. Objective
+
+Complete the M9 URL ingestion thread by adding durable lifecycle support for first-class `url` sources. A URL source should no longer be only a one-time snapshot: Mulder must record fetch freshness metadata, remember robots and per-host politeness state, and expose an explicit re-fetch path that can check or refresh an existing URL source without creating a duplicate source.
+
+This spec builds on Spec 92 static URL ingestion and Spec 93 Playwright rendering fallback. It should preserve their safety and extraction behavior while adding the lifecycle layer those specs intentionally left out.
+
+## 2. Boundaries
+
+**Roadmap step:** M9-J10 - URL lifecycle: `robots.txt` respect, rate limiting, freshness tracking, re-fetch support.
+
+**Base branch:** `milestone/9`. This spec is delivered to the M9 integration branch, not directly to `main`.
+
+**Target branch:** `feat/252-url-lifecycle-refetch`.
+
+**Target files:**
+
+- `packages/core/src/database/migrations/023_url_lifecycle.sql`
+- `packages/core/src/database/repositories/url-lifecycle.repository.ts`
+- `packages/core/src/database/repositories/source.repository.ts`
+- `packages/core/src/shared/services.ts`
+- `packages/core/src/shared/services.dev.ts`
+- `packages/core/src/shared/url-fetcher.ts`
+- `packages/core/src/shared/url-lifecycle.ts`
+- `packages/core/src/index.ts`
+- `packages/pipeline/src/ingest/index.ts`
+- `packages/pipeline/src/url-lifecycle/index.ts`
+- `packages/pipeline/src/index.ts`
+- `apps/cli/src/commands/url.ts`
+- `apps/cli/src/index.ts`
+- `tests/specs/94_url_lifecycle_refetch.test.ts`
+- Existing URL regression tests for Specs 92 and 93 as needed
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Persist URL lifecycle rows for `source_type = 'url'` sources.
+- Persist per-host URL politeness state so rate-limit decisions survive process restarts.
+- Continue enforcing URL safety and `robots.txt` before source creation and before re-fetch writes.
+- Record robots decision metadata, including whether fetch was allowed, the robots URL used, check time, matched rule when available, and fetch errors when blocked.
+- Record freshness metadata, including `etag`, `last_modified`, `last_fetched_at`, `last_checked_at`, `last_http_status`, `last_content_hash`, fetch counters, unchanged counters, changed counters, and `next_fetch_after`.
+- Add conditional fetch support using `If-None-Match` and `If-Modified-Since` when previous `etag` or `last_modified` values exist.
+- Add an explicit CLI lifecycle surface:
+  - `mulder url status <source-id>` shows lifecycle state for one URL source.
+  - `mulder url refetch <source-id>` checks the current URL and updates the source when content changed.
+  - `mulder url refetch <source-id> --dry-run` reports the decision without writing source or lifecycle mutations, except no dry-run writes at all.
+  - `mulder url refetch <source-id> --force` bypasses conditional request headers but still respects safety, robots, and rate limits.
+- Handle `304 Not Modified` as an unchanged result that updates lifecycle freshness state without changing source hash, raw storage, extraction output, or pipeline step state.
+- Handle changed HTML by updating the existing source's canonical raw snapshot, content hash, URL metadata, lifecycle counters, and extraction readiness so the next pipeline run re-processes the refreshed content.
+- Support both static and rendered URL snapshots. If the refreshed static HTML still needs Playwright fallback, reuse the Spec 93 rendering path and persist the same rendering metadata keys.
+- Fail clearly for missing sources, non-URL sources, blocked robots decisions, unsafe redirects, unsupported content types, and fetch/render failures.
+- Keep tests hermetic by using local HTTP fixtures and injected/mock services where browser or network behavior would otherwise be flaky.
+
+**Out of scope:**
+
+- Crawling, link following, sitemap ingestion, RSS ingestion, or batch URL-list files.
+- Background schedulers, cron workers, queue-driven refresh, or automatic refresh of stale URLs without an explicit command.
+- Multi-version source history, diff views, or retaining every historical HTML snapshot.
+- GCP-specific lifecycle services. Pipeline code must continue to use the service abstraction from §4.5.
+- LLM, embedding, graph, taxonomy, or enrichment behavior changes beyond invalidating downstream work after an explicit changed re-fetch.
+
+## 3. Data Model
+
+Add a migration for two durable tables.
+
+`url_lifecycle`
+
+- One row per URL source, keyed by `source_id`.
+- Stores original/final URL, host, robots decision fields, freshness fields, conditional request validators, counters, last content hash, last snapshot storage path, last error fields, and timestamps.
+- Deleting a source deletes its lifecycle row.
+
+`url_host_lifecycle`
+
+- One row per normalized host.
+- Stores the host's last request time, next allowed request time, minimum delay in milliseconds, last robots check time, and last error fields.
+- Used by ingest and refetch to make per-host politeness durable.
+
+The source table remains authoritative for source identity, current snapshot storage path, current content hash, source status, and format metadata. Lifecycle rows are operational metadata for URL behavior and should not become a second source record.
+
+## 4. Behavior
+
+### 4.1 Ingest
+
+When a new URL source is ingested:
+
+1. Normalize and safety-check the URL using the existing URL safety path.
+2. Consult durable per-host politeness state before performing outbound HTTP work.
+3. Fetch static HTML with robots enforcement.
+4. Use Playwright fallback only when Spec 93 conditions require it.
+5. Create the source as Specs 92 and 93 already define.
+6. Upsert `url_lifecycle` and `url_host_lifecycle` with fetch, robots, validator, hash, rendering, and freshness data.
+
+Duplicate URL snapshots should keep existing source de-duplication semantics. If ingest returns an existing source because the snapshot hash already exists, lifecycle state for that existing URL source should still be updated.
+
+### 4.2 Status
+
+`mulder url status <source-id>` must:
+
+- Require an existing `url` source.
+- Read the source and lifecycle row from PostgreSQL.
+- Print source id, original/final URL, host, last fetch/check times, HTTP status, validators, hash, robots decision, next allowed fetch time, and counters.
+- Exit non-zero for missing sources, non-URL sources, or missing lifecycle rows.
+
+### 4.3 Re-fetch
+
+`mulder url refetch <source-id>` must:
+
+1. Require an existing `url` source.
+2. Load lifecycle metadata and compute conditional request headers unless `--force` is used.
+3. Respect durable host politeness state before making outbound HTTP work.
+4. Re-run URL safety and robots checks.
+5. Treat `304 Not Modified` or same content hash as unchanged.
+6. For unchanged content, update lifecycle freshness fields and counters only.
+7. For changed content, write the refreshed HTML snapshot to the source's canonical storage path, update source hash and URL metadata, mark the source ready for extraction, reset downstream pipeline progress as needed, and update lifecycle counters.
+8. In dry-run mode, report what would happen and perform no database or storage mutations.
+
+Changed re-fetch must be explicit and observable. It may mutate the current source snapshot because the user invoked a re-fetch command, but it must not silently create a second source or leave stale downstream pipeline state marked green.
+
+## 5. Acceptance Criteria
+
+1. URL ingest creates or updates a lifecycle row containing final URL, host, robots decision, validators, current content hash, last fetch/check timestamps, and counters.
+2. Per-host politeness state is persisted and consulted by both URL ingest and re-fetch.
+3. A re-fetch with `304 Not Modified` leaves source hash, storage, extraction output, and pipeline step state unchanged while updating freshness metadata.
+4. A re-fetch with changed HTML updates the existing source snapshot/hash and invalidates downstream extraction work so the refreshed content is processed on the next pipeline run.
+5. `--dry-run` reports unchanged/changed/blocked decisions without writing database rows or storage objects.
+6. `--force` skips conditional request headers but does not bypass safety, robots, or rate limiting.
+7. Robots-blocked and unsafe URL cases fail before writing source or lifecycle changes.
+8. Non-URL sources are rejected by URL lifecycle commands with clear errors.
+9. Spec 92 and Spec 93 URL behavior remains green.
+
+## 6. Test Plan
+
+- `tests/specs/94_url_lifecycle_refetch.test.ts`
+  - ingest persists lifecycle and host state for a static URL source.
+  - status command prints lifecycle fields for a URL source.
+  - unchanged re-fetch using `etag`/`last_modified` and `304` updates lifecycle only.
+  - changed re-fetch updates source hash/snapshot metadata and resets extraction readiness.
+  - dry-run changed re-fetch performs no writes.
+  - force re-fetch omits conditional headers.
+  - robots-disallowed re-fetch fails without mutations.
+  - non-URL source is rejected.
+- Regression:
+  - `tests/specs/92_url_ingestion_prestructured_path.test.ts`
+  - `tests/specs/93_url_rendering_playwright_fallback.test.ts`
+
+## 7. Review Checklist
+
+- The implementation stays on the first-class URL source path and does not introduce crawling.
+- Lifecycle state is durable in PostgreSQL; Firestore remains observability-only if touched at all.
+- Pipeline steps use service abstractions, not direct GCP clients.
+- Re-fetch has no LLM, embedding, or graph cost by itself.
+- Changed re-fetch cannot leave stale extracted stories marked current.
+- Tests do not rely on live internet, wall-clock sleep, or a real browser unless explicitly mocked/skipped.

--- a/packages/core/src/database/migrations/023_url_lifecycle.sql
+++ b/packages/core/src/database/migrations/023_url_lifecycle.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS url_host_lifecycle (
+  host TEXT PRIMARY KEY,
+  minimum_delay_ms INTEGER NOT NULL DEFAULT 1000 CHECK (minimum_delay_ms >= 0),
+  last_request_at TIMESTAMPTZ,
+  next_allowed_at TIMESTAMPTZ,
+  last_robots_checked_at TIMESTAMPTZ,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS url_lifecycle (
+  source_id UUID PRIMARY KEY REFERENCES sources(id) ON DELETE CASCADE,
+  original_url TEXT NOT NULL,
+  normalized_url TEXT NOT NULL,
+  final_url TEXT NOT NULL,
+  host TEXT NOT NULL,
+  etag TEXT,
+  last_modified TEXT,
+  last_fetched_at TIMESTAMPTZ NOT NULL,
+  last_checked_at TIMESTAMPTZ NOT NULL,
+  next_fetch_after TIMESTAMPTZ,
+  last_http_status INTEGER,
+  robots_allowed BOOLEAN NOT NULL DEFAULT true,
+  robots_url TEXT,
+  robots_checked_at TIMESTAMPTZ,
+  robots_matched_user_agent TEXT,
+  robots_matched_rule TEXT,
+  redirect_count INTEGER NOT NULL DEFAULT 0 CHECK (redirect_count >= 0),
+  content_type TEXT,
+  rendering_method TEXT,
+  snapshot_encoding TEXT,
+  last_content_hash TEXT NOT NULL,
+  last_snapshot_storage_path TEXT NOT NULL,
+  fetch_count INTEGER NOT NULL DEFAULT 0 CHECK (fetch_count >= 0),
+  unchanged_count INTEGER NOT NULL DEFAULT 0 CHECK (unchanged_count >= 0),
+  changed_count INTEGER NOT NULL DEFAULT 0 CHECK (changed_count >= 0),
+  last_change_at TIMESTAMPTZ,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_url_lifecycle_host ON url_lifecycle(host);
+CREATE INDEX IF NOT EXISTS idx_url_lifecycle_next_fetch_after ON url_lifecycle(next_fetch_after);
+CREATE INDEX IF NOT EXISTS idx_url_host_lifecycle_next_allowed_at ON url_host_lifecycle(next_allowed_at);

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -284,3 +284,16 @@ export type {
 	TaxonomySimilarityMatch,
 	UpdateTaxonomyEntryInput,
 } from './taxonomy.types.js';
+export type {
+	RecordUrlHostLifecycleInput,
+	RecordUrlLifecycleFetchInput,
+	UrlHostLifecycle,
+	UrlLifecycle,
+	UrlLifecycleChangeKind,
+} from './url-lifecycle.repository.js';
+export {
+	findUrlHostLifecycleByHost,
+	findUrlLifecycleBySourceId,
+	recordUrlHostLifecycle,
+	recordUrlLifecycleFetch,
+} from './url-lifecycle.repository.js';

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -399,6 +399,7 @@ export async function updateSource(pool: pg.Pool, id: string, input: UpdateSourc
 	const fieldMap: Array<[keyof UpdateSourceInput, string]> = [
 		['filename', 'filename'],
 		['storagePath', 'storage_path'],
+		['fileHash', 'file_hash'],
 		['parentSourceId', 'parent_source_id'],
 		['sourceType', 'source_type'],
 		['pageCount', 'page_count'],

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -68,6 +68,7 @@ export interface CreateSourceInput {
 export interface UpdateSourceInput {
 	filename?: string;
 	storagePath?: string;
+	fileHash?: string;
 	parentSourceId?: string | null;
 	sourceType?: SourceType;
 	formatMetadata?: SourceFormatMetadata;

--- a/packages/core/src/database/repositories/url-lifecycle.repository.ts
+++ b/packages/core/src/database/repositories/url-lifecycle.repository.ts
@@ -1,0 +1,377 @@
+/**
+ * Repository functions for durable URL lifecycle and host politeness state.
+ *
+ * PostgreSQL remains the source of truth for URL freshness metadata. The
+ * pipeline records one row per URL source and one row per normalized host.
+ *
+ * @see docs/specs/94_url_lifecycle_refetch.spec.md
+ */
+
+import type pg from 'pg';
+import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
+
+type Queryable = pg.Pool | pg.PoolClient;
+
+export type UrlLifecycleChangeKind = 'initial' | 'changed' | 'unchanged';
+
+export interface UrlLifecycle {
+	sourceId: string;
+	originalUrl: string;
+	normalizedUrl: string;
+	finalUrl: string;
+	host: string;
+	etag: string | null;
+	lastModified: string | null;
+	lastFetchedAt: Date;
+	lastCheckedAt: Date;
+	nextFetchAfter: Date | null;
+	lastHttpStatus: number | null;
+	robotsAllowed: boolean;
+	robotsUrl: string | null;
+	robotsCheckedAt: Date | null;
+	robotsMatchedUserAgent: string | null;
+	robotsMatchedRule: string | null;
+	redirectCount: number;
+	contentType: string | null;
+	renderingMethod: string | null;
+	snapshotEncoding: string | null;
+	lastContentHash: string;
+	lastSnapshotStoragePath: string;
+	fetchCount: number;
+	unchangedCount: number;
+	changedCount: number;
+	lastChangeAt: Date | null;
+	lastErrorCode: string | null;
+	lastErrorMessage: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export interface UrlHostLifecycle {
+	host: string;
+	minimumDelayMs: number;
+	lastRequestAt: Date | null;
+	nextAllowedAt: Date | null;
+	lastRobotsCheckedAt: Date | null;
+	lastErrorCode: string | null;
+	lastErrorMessage: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export interface RecordUrlHostLifecycleInput {
+	host: string;
+	minimumDelayMs: number;
+	requestedAt: Date;
+	lastRobotsCheckedAt?: Date | null;
+	lastErrorCode?: string | null;
+	lastErrorMessage?: string | null;
+}
+
+export interface RecordUrlLifecycleFetchInput {
+	sourceId: string;
+	originalUrl: string;
+	normalizedUrl: string;
+	finalUrl: string;
+	host: string;
+	etag?: string | null;
+	lastModified?: string | null;
+	lastFetchedAt: Date;
+	lastCheckedAt: Date;
+	nextFetchAfter?: Date | null;
+	lastHttpStatus?: number | null;
+	robotsAllowed: boolean;
+	robotsUrl?: string | null;
+	robotsCheckedAt?: Date | null;
+	robotsMatchedUserAgent?: string | null;
+	robotsMatchedRule?: string | null;
+	redirectCount?: number;
+	contentType?: string | null;
+	renderingMethod?: string | null;
+	snapshotEncoding?: string | null;
+	lastContentHash: string;
+	lastSnapshotStoragePath: string;
+	changeKind: UrlLifecycleChangeKind;
+}
+
+interface UrlLifecycleRow {
+	source_id: string;
+	original_url: string;
+	normalized_url: string;
+	final_url: string;
+	host: string;
+	etag: string | null;
+	last_modified: string | null;
+	last_fetched_at: Date;
+	last_checked_at: Date;
+	next_fetch_after: Date | null;
+	last_http_status: number | null;
+	robots_allowed: boolean;
+	robots_url: string | null;
+	robots_checked_at: Date | null;
+	robots_matched_user_agent: string | null;
+	robots_matched_rule: string | null;
+	redirect_count: number;
+	content_type: string | null;
+	rendering_method: string | null;
+	snapshot_encoding: string | null;
+	last_content_hash: string;
+	last_snapshot_storage_path: string;
+	fetch_count: number;
+	unchanged_count: number;
+	changed_count: number;
+	last_change_at: Date | null;
+	last_error_code: string | null;
+	last_error_message: string | null;
+	created_at: Date;
+	updated_at: Date;
+}
+
+interface UrlHostLifecycleRow {
+	host: string;
+	minimum_delay_ms: number;
+	last_request_at: Date | null;
+	next_allowed_at: Date | null;
+	last_robots_checked_at: Date | null;
+	last_error_code: string | null;
+	last_error_message: string | null;
+	created_at: Date;
+	updated_at: Date;
+}
+
+function mapUrlLifecycleRow(row: UrlLifecycleRow): UrlLifecycle {
+	return {
+		sourceId: row.source_id,
+		originalUrl: row.original_url,
+		normalizedUrl: row.normalized_url,
+		finalUrl: row.final_url,
+		host: row.host,
+		etag: row.etag,
+		lastModified: row.last_modified,
+		lastFetchedAt: row.last_fetched_at,
+		lastCheckedAt: row.last_checked_at,
+		nextFetchAfter: row.next_fetch_after,
+		lastHttpStatus: row.last_http_status,
+		robotsAllowed: row.robots_allowed,
+		robotsUrl: row.robots_url,
+		robotsCheckedAt: row.robots_checked_at,
+		robotsMatchedUserAgent: row.robots_matched_user_agent,
+		robotsMatchedRule: row.robots_matched_rule,
+		redirectCount: row.redirect_count,
+		contentType: row.content_type,
+		renderingMethod: row.rendering_method,
+		snapshotEncoding: row.snapshot_encoding,
+		lastContentHash: row.last_content_hash,
+		lastSnapshotStoragePath: row.last_snapshot_storage_path,
+		fetchCount: row.fetch_count,
+		unchangedCount: row.unchanged_count,
+		changedCount: row.changed_count,
+		lastChangeAt: row.last_change_at,
+		lastErrorCode: row.last_error_code,
+		lastErrorMessage: row.last_error_message,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+function mapUrlHostLifecycleRow(row: UrlHostLifecycleRow): UrlHostLifecycle {
+	return {
+		host: row.host,
+		minimumDelayMs: row.minimum_delay_ms,
+		lastRequestAt: row.last_request_at,
+		nextAllowedAt: row.next_allowed_at,
+		lastRobotsCheckedAt: row.last_robots_checked_at,
+		lastErrorCode: row.last_error_code,
+		lastErrorMessage: row.last_error_message,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function findUrlLifecycleBySourceId(pool: Queryable, sourceId: string): Promise<UrlLifecycle | null> {
+	const sql = 'SELECT * FROM url_lifecycle WHERE source_id = $1';
+
+	try {
+		const result = await pool.query<UrlLifecycleRow>(sql, [sourceId]);
+		const row = result.rows[0];
+		return row ? mapUrlLifecycleRow(row) : null;
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to find URL lifecycle row', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { sourceId },
+		});
+	}
+}
+
+export async function findUrlHostLifecycleByHost(pool: Queryable, host: string): Promise<UrlHostLifecycle | null> {
+	const sql = 'SELECT * FROM url_host_lifecycle WHERE host = $1';
+
+	try {
+		const result = await pool.query<UrlHostLifecycleRow>(sql, [host]);
+		const row = result.rows[0];
+		return row ? mapUrlHostLifecycleRow(row) : null;
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to find URL host lifecycle row', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { host },
+		});
+	}
+}
+
+export async function recordUrlHostLifecycle(
+	pool: Queryable,
+	input: RecordUrlHostLifecycleInput,
+): Promise<UrlHostLifecycle> {
+	const nextAllowedAt = new Date(input.requestedAt.getTime() + input.minimumDelayMs);
+	const sql = `
+    INSERT INTO url_host_lifecycle (
+      host,
+      minimum_delay_ms,
+      last_request_at,
+      next_allowed_at,
+      last_robots_checked_at,
+      last_error_code,
+      last_error_message
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    ON CONFLICT (host) DO UPDATE SET
+      minimum_delay_ms = EXCLUDED.minimum_delay_ms,
+      last_request_at = EXCLUDED.last_request_at,
+      next_allowed_at = EXCLUDED.next_allowed_at,
+      last_robots_checked_at = EXCLUDED.last_robots_checked_at,
+      last_error_code = EXCLUDED.last_error_code,
+      last_error_message = EXCLUDED.last_error_message,
+      updated_at = now()
+    RETURNING *
+  `;
+
+	try {
+		const result = await pool.query<UrlHostLifecycleRow>(sql, [
+			input.host,
+			input.minimumDelayMs,
+			input.requestedAt,
+			nextAllowedAt,
+			input.lastRobotsCheckedAt ?? null,
+			input.lastErrorCode ?? null,
+			input.lastErrorMessage ?? null,
+		]);
+		return mapUrlHostLifecycleRow(result.rows[0]);
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to record URL host lifecycle row', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { host: input.host },
+		});
+	}
+}
+
+export async function recordUrlLifecycleFetch(
+	pool: Queryable,
+	input: RecordUrlLifecycleFetchInput,
+): Promise<UrlLifecycle> {
+	const unchangedIncrement = input.changeKind === 'unchanged' ? 1 : 0;
+	const changedIncrement = input.changeKind === 'changed' ? 1 : 0;
+	const lastChangeAt = input.changeKind === 'unchanged' ? null : input.lastFetchedAt;
+	const sql = `
+    INSERT INTO url_lifecycle (
+      source_id,
+      original_url,
+      normalized_url,
+      final_url,
+      host,
+      etag,
+      last_modified,
+      last_fetched_at,
+      last_checked_at,
+      next_fetch_after,
+      last_http_status,
+      robots_allowed,
+      robots_url,
+      robots_checked_at,
+      robots_matched_user_agent,
+      robots_matched_rule,
+      redirect_count,
+      content_type,
+      rendering_method,
+      snapshot_encoding,
+      last_content_hash,
+      last_snapshot_storage_path,
+      fetch_count,
+      unchanged_count,
+      changed_count,
+      last_change_at,
+      last_error_code,
+      last_error_message
+    )
+    VALUES (
+      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+      $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+      $21, $22, 1, $23, $24, $25, NULL, NULL
+    )
+    ON CONFLICT (source_id) DO UPDATE SET
+      original_url = EXCLUDED.original_url,
+      normalized_url = EXCLUDED.normalized_url,
+      final_url = EXCLUDED.final_url,
+      host = EXCLUDED.host,
+      etag = EXCLUDED.etag,
+      last_modified = EXCLUDED.last_modified,
+      last_fetched_at = EXCLUDED.last_fetched_at,
+      last_checked_at = EXCLUDED.last_checked_at,
+      next_fetch_after = EXCLUDED.next_fetch_after,
+      last_http_status = EXCLUDED.last_http_status,
+      robots_allowed = EXCLUDED.robots_allowed,
+      robots_url = EXCLUDED.robots_url,
+      robots_checked_at = EXCLUDED.robots_checked_at,
+      robots_matched_user_agent = EXCLUDED.robots_matched_user_agent,
+      robots_matched_rule = EXCLUDED.robots_matched_rule,
+      redirect_count = EXCLUDED.redirect_count,
+      content_type = EXCLUDED.content_type,
+      rendering_method = EXCLUDED.rendering_method,
+      snapshot_encoding = EXCLUDED.snapshot_encoding,
+      last_content_hash = EXCLUDED.last_content_hash,
+      last_snapshot_storage_path = EXCLUDED.last_snapshot_storage_path,
+      fetch_count = url_lifecycle.fetch_count + 1,
+      unchanged_count = url_lifecycle.unchanged_count + EXCLUDED.unchanged_count,
+      changed_count = url_lifecycle.changed_count + EXCLUDED.changed_count,
+      last_change_at = COALESCE(EXCLUDED.last_change_at, url_lifecycle.last_change_at),
+      last_error_code = NULL,
+      last_error_message = NULL,
+      updated_at = now()
+    RETURNING *
+  `;
+
+	try {
+		const result = await pool.query<UrlLifecycleRow>(sql, [
+			input.sourceId,
+			input.originalUrl,
+			input.normalizedUrl,
+			input.finalUrl,
+			input.host,
+			input.etag ?? null,
+			input.lastModified ?? null,
+			input.lastFetchedAt,
+			input.lastCheckedAt,
+			input.nextFetchAfter ?? null,
+			input.lastHttpStatus ?? null,
+			input.robotsAllowed,
+			input.robotsUrl ?? null,
+			input.robotsCheckedAt ?? null,
+			input.robotsMatchedUserAgent ?? null,
+			input.robotsMatchedRule ?? null,
+			input.redirectCount ?? 0,
+			input.contentType ?? null,
+			input.renderingMethod ?? null,
+			input.snapshotEncoding ?? null,
+			input.lastContentHash,
+			input.lastSnapshotStoragePath,
+			unchangedIncrement,
+			changedIncrement,
+			lastChangeAt,
+		]);
+		return mapUrlLifecycleRow(result.rows[0]);
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to record URL lifecycle fetch', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { sourceId: input.sourceId, changeKind: input.changeKind },
+		});
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,9 @@ export type {
 	UpsertEntityGroundingInput,
 	UpsertPipelineRunSourceInput,
 	UpsertSourceStepInput,
+	UrlHostLifecycle,
+	UrlLifecycle,
+	UrlLifecycleChangeKind,
 	VectorSearchResult,
 } from './database/index.js';
 // ── Database ─────────────────────────────────────────────────
@@ -235,6 +238,8 @@ export {
 	findStoryById,
 	findTaxonomyEntryById,
 	findTaxonomyEntryByName,
+	findUrlHostLifecycleByHost,
+	findUrlLifecycleBySourceId,
 	gcOrphanedEntities,
 	getEntityCorroborationStats,
 	getMigrationStatus,
@@ -249,6 +254,8 @@ export {
 	mergeJobPayload,
 	persistEntityGroundingResult,
 	reapRunningJobs,
+	recordUrlHostLifecycle,
+	recordUrlLifecycleFetch,
 	replaceSpatioTemporalClustersSnapshot,
 	resetDeadLetterJobs,
 	resetPipelineStep,
@@ -450,6 +457,13 @@ export type {
 export type { StepError } from './shared/types.js';
 export { createUrlExtractorService } from './shared/url-extractor.js';
 export { createUrlFetcherService } from './shared/url-fetcher.js';
+export {
+	computeUrlLifecycleNextAllowedAt,
+	headerValue as urlLifecycleHeaderValue,
+	normalizeUrlLifecycleHost,
+	resolveUrlPolitenessDelayMs,
+	sleepForUrlPoliteness,
+} from './shared/url-lifecycle.js';
 export { createUrlRendererService } from './shared/url-renderer.js';
 // ── Vertex AI wrapper ────────────────────────────────────────
 export type { VertexClient, VertexClientOptions } from './vertex.js';

--- a/packages/core/src/shared/services.ts
+++ b/packages/core/src/shared/services.ts
@@ -231,6 +231,7 @@ export interface UrlFetchResult {
 	httpStatus: number;
 	headers: Record<string, string>;
 	html: Buffer;
+	notModified: boolean;
 	contentType: string;
 	redirectCount: number;
 	fetchedAt: string;
@@ -242,6 +243,8 @@ export interface UrlFetchOptions {
 	maxBytes: number;
 	timeoutMs?: number;
 	redirectLimit?: number;
+	ifNoneMatch?: string | null;
+	ifModifiedSince?: string | null;
 }
 
 export interface UrlFetcherService {

--- a/packages/core/src/shared/url-fetcher.ts
+++ b/packages/core/src/shared/url-fetcher.ts
@@ -61,19 +61,29 @@ async function readBoundedResponse(response: NodeFetchResponse, maxBytes: number
 	return Buffer.concat(chunks);
 }
 
-async function fetchOnce(target: VettedTarget, options: { timeoutMs: number }): Promise<NodeFetchResponse> {
+async function fetchOnce(
+	target: VettedTarget,
+	options: { timeoutMs: number; ifNoneMatch?: string | null; ifModifiedSince?: string | null },
+): Promise<NodeFetchResponse> {
 	const { url } = target;
+	const headers: Record<string, string> = {
+		Host: url.host,
+		'User-Agent': URL_USER_AGENT,
+		Accept: 'text/html, application/xhtml+xml;q=0.9',
+	};
+	if (options.ifNoneMatch) {
+		headers['If-None-Match'] = options.ifNoneMatch;
+	}
+	if (options.ifModifiedSince) {
+		headers['If-Modified-Since'] = options.ifModifiedSince;
+	}
 	const requestOptions: HttpsRequestOptions = {
 		protocol: url.protocol,
 		hostname: connectionHostname(url.hostname),
 		port: url.port || undefined,
 		method: 'GET',
 		path: `${url.pathname}${url.search}`,
-		headers: {
-			Host: url.host,
-			'User-Agent': URL_USER_AGENT,
-			Accept: 'text/html, application/xhtml+xml;q=0.9',
-		},
+		headers,
 		lookup: target.lookup,
 		agent: false,
 	};
@@ -301,8 +311,15 @@ class LocalUrlFetcherService implements UrlFetcherService {
 
 		let redirectCount = 0;
 		let response: NodeFetchResponse;
+		let conditionalHeaders: Pick<UrlFetchOptions, 'ifNoneMatch' | 'ifModifiedSince'> = {
+			ifNoneMatch: options.ifNoneMatch,
+			ifModifiedSince: options.ifModifiedSince,
+		};
 		while (true) {
-			response = await fetchOnce(currentTarget, { timeoutMs });
+			response = await fetchOnce(currentTarget, {
+				timeoutMs,
+				...conditionalHeaders,
+			});
 			if (!isRedirectStatus(response.status)) {
 				break;
 			}
@@ -320,8 +337,12 @@ class LocalUrlFetcherService implements UrlFetcherService {
 				});
 			}
 			discardResponse(response);
+			const previousOrigin = currentUrl.origin;
 			currentUrl = new URL(location, currentUrl);
 			currentUrl.hash = '';
+			if (currentUrl.origin !== previousOrigin) {
+				conditionalHeaders = {};
+			}
 			currentTarget = await validatePublicHttpTarget(currentUrl);
 			robots = await fetchRobots(currentUrl, { timeoutMs, maxBytes: options.maxBytes, redirectLimit });
 			if (!robots.allowed) {
@@ -330,6 +351,25 @@ class LocalUrlFetcherService implements UrlFetcherService {
 				});
 			}
 			redirectCount++;
+		}
+
+		const rawContentType = responseHeader(response, 'content-type');
+		if (response.status === 304) {
+			discardResponse(response);
+			return {
+				originalUrl: inputUrl,
+				normalizedUrl,
+				finalUrl: currentUrl.toString(),
+				httpStatus: response.status,
+				headers: headersToRecord(response.headers),
+				html: Buffer.alloc(0),
+				notModified: true,
+				contentType: rawContentType ?? '',
+				redirectCount,
+				fetchedAt: new Date().toISOString(),
+				robots,
+				snapshotEncoding: null,
+			};
 		}
 
 		if (!response.ok) {
@@ -345,7 +385,6 @@ class LocalUrlFetcherService implements UrlFetcherService {
 				context: { maxBytes: options.maxBytes, contentLength },
 			});
 		}
-		const rawContentType = responseHeader(response, 'content-type');
 		const contentType = parseContentType(rawContentType);
 		if (!HTML_CONTENT_TYPES.has(contentType.mediaType)) {
 			discardResponse(response);
@@ -361,6 +400,7 @@ class LocalUrlFetcherService implements UrlFetcherService {
 			httpStatus: response.status,
 			headers: headersToRecord(response.headers),
 			html,
+			notModified: false,
 			contentType: rawContentType ?? contentType.mediaType,
 			redirectCount,
 			fetchedAt: new Date().toISOString(),

--- a/packages/core/src/shared/url-lifecycle.ts
+++ b/packages/core/src/shared/url-lifecycle.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared helpers for URL lifecycle freshness and host politeness.
+ *
+ * The persistence lives in the database repository; these helpers keep the
+ * normalization and environment parsing identical for ingest and re-fetch.
+ *
+ * @see docs/specs/94_url_lifecycle_refetch.spec.md
+ */
+
+const DEFAULT_URL_POLITENESS_DELAY_MS = 1000;
+const MAX_URL_POLITENESS_DELAY_MS = 60_000;
+
+export function normalizeUrlLifecycleHost(url: string): string {
+	return new URL(url).host.toLowerCase();
+}
+
+export function headerValue(headers: Record<string, string>, name: string): string | null {
+	return headers[name.toLowerCase()] ?? null;
+}
+
+export function computeUrlLifecycleNextAllowedAt(requestedAt: Date, minimumDelayMs: number): Date {
+	return new Date(requestedAt.getTime() + Math.max(0, minimumDelayMs));
+}
+
+export function resolveUrlPolitenessDelayMs(env: NodeJS.ProcessEnv = process.env): number {
+	const raw = env.MULDER_URL_POLITENESS_DELAY_MS;
+	if (raw === undefined || raw.trim() === '') {
+		return DEFAULT_URL_POLITENESS_DELAY_MS;
+	}
+
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_URL_POLITENESS_DELAY_MS;
+	}
+
+	return Math.min(Math.max(parsed, 0), MAX_URL_POLITENESS_DELAY_MS);
+}
+
+export async function sleepForUrlPoliteness(ms: number): Promise<void> {
+	if (ms <= 0) {
+		return;
+	}
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -179,3 +179,5 @@ export type {
 export { executeReprocess, planReprocess } from './reprocess/index.js';
 export type { SegmentationData, SegmentedStory, SegmentInput, SegmentResult } from './segment/index.js';
 export { execute as executeSegment } from './segment/index.js';
+export type { UrlLifecycleStatusResult, UrlRefetchInput, UrlRefetchResult } from './url-lifecycle/index.js';
+export { getUrlLifecycleStatus, refetchUrlSource } from './url-lifecycle/index.js';

--- a/packages/pipeline/src/ingest/index.ts
+++ b/packages/pipeline/src/ingest/index.ts
@@ -18,23 +18,28 @@ import type {
 	MulderConfig,
 	PdfMetadata,
 	Services,
+	Source,
 	SourceFormatMetadata,
 	SourceType,
 	StepError,
-	UrlExtractionResult,
-	UrlFetchResult,
-	UrlRenderResult,
 } from '@mulder/core';
 import {
+	computeUrlLifecycleNextAllowedAt,
 	createChildLogger,
 	createSource,
 	detectNativeText,
 	extractPdfMetadata,
 	findSourceByHash,
+	findUrlHostLifecycleByHost,
 	INGEST_ERROR_CODES,
 	IngestError,
-	MulderError,
+	normalizeUrlLifecycleHost,
+	recordUrlHostLifecycle,
+	recordUrlLifecycleFetch,
+	resolveUrlPolitenessDelayMs,
+	sleepForUrlPoliteness,
 	upsertSourceStep,
+	urlLifecycleHeaderValue,
 } from '@mulder/core';
 import type pg from 'pg';
 import {
@@ -43,7 +48,6 @@ import {
 	buildImageFormatMetadata,
 	buildSpreadsheetFormatMetadata,
 	buildTextFormatMetadata,
-	buildUrlFormatMetadata,
 	CSV_MEDIA_TYPE,
 	detectSourceType,
 	getStorageExtensionForDetection,
@@ -59,6 +63,7 @@ import {
 	URL_SNAPSHOT_MEDIA_TYPE,
 } from './source-type.js';
 import type { IngestFileResult, IngestInput, IngestResult } from './types.js';
+import { filenameForUrlSnapshot, prepareUrlSnapshot } from './url-snapshot.js';
 
 export type {
 	ImageDimensions,
@@ -225,141 +230,83 @@ function isIngestibleSourceType(sourceType: SourceType): sourceType is Ingestibl
 	);
 }
 
-function htmlTitle(html: Buffer): string | null {
-	const match = html.toString('utf-8').match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-	const title = match?.[1]
-		?.replace(/<[^>]+>/g, ' ')
-		.replace(/\s+/g, ' ')
-		.trim();
-	return title && title.length > 0 ? title : null;
+function stringMetadataValue(metadata: SourceFormatMetadata, key: string): string | null {
+	const value = metadata[key];
+	return typeof value === 'string' ? value : null;
 }
 
-function slugifyFilenamePart(value: string): string {
-	return (
-		value
-			.toLowerCase()
-			.replace(/[^a-z0-9]+/g, '-')
-			.replace(/^-+|-+$/g, '')
-			.slice(0, 80) || 'page'
-	);
-}
-
-function filenameForUrlSnapshot(html: Buffer, finalUrl: string, extractedTitle?: string): string {
-	const title = extractedTitle ?? htmlTitle(html);
-	const final = new URL(finalUrl);
-	const pathPart = final.pathname === '/' ? final.hostname : `${final.hostname}${final.pathname}`;
-	const basis = title ? `${title}-${final.hostname}` : pathPart;
-	return `${slugifyFilenamePart(basis)}.html`;
-}
-
-interface PreparedUrlSnapshot {
-	html: Buffer;
-	finalUrl: string;
-	title: string | null;
-	formatMetadata: SourceFormatMetadata;
-	renderingMethod: 'static' | 'playwright';
-}
-
-function errorCode(error: unknown): string {
-	return error instanceof MulderError ? error.code : error instanceof Error ? error.name : 'UNKNOWN';
-}
-
-function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
-}
-
-async function probeUrlSnapshot(input: {
-	services: Services;
-	html: Buffer;
-	sourceId: string;
-	fetchMetadata: SourceFormatMetadata;
-}): Promise<UrlExtractionResult> {
-	return await input.services.urlExtractors.extractUrl(input.html, input.sourceId, input.fetchMetadata);
-}
-
-async function prepareUrlSnapshot(
-	fetchResult: UrlFetchResult,
-	ctx: ProcessFileContext,
-	displayUrl: string,
-	log: Logger,
-): Promise<PreparedUrlSnapshot> {
-	const staticTitle = htmlTitle(fetchResult.html);
-	const staticMetadata = buildUrlFormatMetadata(fetchResult, staticTitle ?? undefined);
-	try {
-		const staticProbe = await probeUrlSnapshot({
-			services: ctx.services,
-			html: fetchResult.html,
-			sourceId: 'url-static-readability-probe',
-			fetchMetadata: staticMetadata,
-		});
-		return {
-			html: fetchResult.html,
-			finalUrl: fetchResult.finalUrl,
-			title: staticProbe.title || staticTitle,
-			formatMetadata: buildUrlFormatMetadata(fetchResult, staticProbe.title || staticTitle || undefined),
-			renderingMethod: 'static',
-		};
-	} catch (staticError: unknown) {
-		const staticReadabilityError = errorCode(staticError);
-		log.info({ staticReadabilityError }, 'Static URL snapshot unreadable, attempting render fallback');
-		let renderResult: UrlRenderResult;
-		try {
-			renderResult = await ctx.services.urlRenderers.renderUrl(fetchResult.finalUrl, {
-				maxBytes: ctx.config.ingestion.max_file_size_mb * 1024 * 1024,
-			});
-		} catch (cause: unknown) {
-			throw new IngestError(
-				`URL render fallback failed for ${displayUrl}`,
-				INGEST_ERROR_CODES.INGEST_URL_RENDER_FAILED,
-				{
-					cause,
-					context: { url: displayUrl, staticReadabilityError },
-				},
-			);
-		}
-		const renderingMetadata = {
-			result: renderResult,
-			fallbackReason: 'static_unreadable',
-			staticReadabilityError,
-			renderedFromUrl: fetchResult.finalUrl,
-		};
-		const renderedTitle = htmlTitle(renderResult.html);
-		const renderedMetadata = buildUrlFormatMetadata(fetchResult, renderedTitle ?? undefined, renderingMetadata);
-		let renderedProbe: UrlExtractionResult;
-		try {
-			renderedProbe = await probeUrlSnapshot({
-				services: ctx.services,
-				html: renderResult.html,
-				sourceId: 'url-rendered-readability-probe',
-				fetchMetadata: renderedMetadata,
-			});
-		} catch (cause: unknown) {
-			throw new IngestError(
-				`Rendered URL snapshot was not readable for ${displayUrl}`,
-				INGEST_ERROR_CODES.INGEST_URL_RENDER_FAILED,
-				{
-					cause,
-					context: {
-						url: displayUrl,
-						staticReadabilityError,
-						renderedReadabilityError: errorCode(cause),
-						renderedErrorMessage: errorMessage(cause),
-					},
-				},
-			);
-		}
-		return {
-			html: renderResult.html,
-			finalUrl: renderResult.finalUrl,
-			title: renderedProbe.title || renderedTitle,
-			formatMetadata: buildUrlFormatMetadata(
-				fetchResult,
-				renderedProbe.title || renderedTitle || undefined,
-				renderingMetadata,
-			),
-			renderingMethod: 'playwright',
-		};
+async function waitForUrlHostPoliteness(ctx: ProcessFileContext, normalizedUrl: string): Promise<void> {
+	if (!ctx.pool) {
+		return;
 	}
+
+	const host = normalizeUrlLifecycleHost(normalizedUrl);
+	const state = await findUrlHostLifecycleByHost(ctx.pool, host);
+	if (!state?.nextAllowedAt) {
+		return;
+	}
+
+	const waitMs = state.nextAllowedAt.getTime() - Date.now();
+	if (waitMs > 0) {
+		await sleepForUrlPoliteness(waitMs);
+	}
+}
+
+async function recordUrlLifecycleForFetch(input: {
+	ctx: ProcessFileContext;
+	source: Source;
+	fetchResult: Awaited<ReturnType<Services['urls']['fetchUrl']>>;
+	formatMetadata: SourceFormatMetadata;
+	fileHash: string;
+	storagePath: string;
+	changeKind: 'initial' | 'changed' | 'unchanged';
+}): Promise<void> {
+	if (!input.ctx.pool || input.ctx.dryRun || input.source.sourceType !== 'url') {
+		return;
+	}
+
+	const fetchedAt = new Date(input.fetchResult.fetchedAt);
+	const minimumDelayMs = resolveUrlPolitenessDelayMs();
+	const finalUrl = stringMetadataValue(input.formatMetadata, 'final_url') ?? input.fetchResult.finalUrl;
+	const host = normalizeUrlLifecycleHost(finalUrl);
+	const initialHost = normalizeUrlLifecycleHost(input.fetchResult.normalizedUrl);
+	const nextFetchAfter = computeUrlLifecycleNextAllowedAt(fetchedAt, minimumDelayMs);
+
+	for (const hostToRecord of new Set([initialHost, host])) {
+		await recordUrlHostLifecycle(input.ctx.pool, {
+			host: hostToRecord,
+			minimumDelayMs,
+			requestedAt: fetchedAt,
+			lastRobotsCheckedAt: fetchedAt,
+		});
+	}
+
+	await recordUrlLifecycleFetch(input.ctx.pool, {
+		sourceId: input.source.id,
+		originalUrl: input.fetchResult.originalUrl,
+		normalizedUrl: input.fetchResult.normalizedUrl,
+		finalUrl,
+		host,
+		etag: urlLifecycleHeaderValue(input.fetchResult.headers, 'etag'),
+		lastModified: urlLifecycleHeaderValue(input.fetchResult.headers, 'last-modified'),
+		lastFetchedAt: fetchedAt,
+		lastCheckedAt: fetchedAt,
+		nextFetchAfter,
+		lastHttpStatus: input.fetchResult.httpStatus,
+		robotsAllowed: input.fetchResult.robots.allowed,
+		robotsUrl: input.fetchResult.robots.robotsUrl,
+		robotsCheckedAt: fetchedAt,
+		robotsMatchedUserAgent: input.fetchResult.robots.matchedUserAgent,
+		robotsMatchedRule: input.fetchResult.robots.matchedRule,
+		redirectCount: input.fetchResult.redirectCount,
+		contentType: input.fetchResult.contentType,
+		renderingMethod: stringMetadataValue(input.formatMetadata, 'rendering_method'),
+		snapshotEncoding:
+			input.fetchResult.snapshotEncoding ?? stringMetadataValue(input.formatMetadata, 'snapshot_encoding'),
+		lastContentHash: input.fileHash,
+		lastSnapshotStoragePath: input.storagePath,
+		changeKind: input.changeKind,
+	});
 }
 
 async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<IngestFileResult> {
@@ -374,6 +321,7 @@ async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<In
 	const log = createChildLogger(ctx.logger, { step: STEP_NAME, url: displayUrl });
 	let fetchResult: Awaited<ReturnType<Services['urls']['fetchUrl']>>;
 	try {
+		await waitForUrlHostPoliteness(ctx, normalizedUrl);
 		fetchResult = await ctx.services.urls.fetchUrl(inputUrl, {
 			maxBytes: ctx.config.ingestion.max_file_size_mb * 1024 * 1024,
 		});
@@ -384,7 +332,12 @@ async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<In
 		});
 	}
 
-	const prepared = await prepareUrlSnapshot(fetchResult, ctx, displayUrl, log);
+	const prepared = await prepareUrlSnapshot(fetchResult, {
+		config: ctx.config,
+		services: ctx.services,
+		displayUrl,
+		logger: log,
+	});
 	const filename = filenameForUrlSnapshot(prepared.html, prepared.finalUrl, prepared.title ?? undefined);
 	const fileHash = computeFileHash(prepared.html);
 	const formatMetadata = prepared.formatMetadata;
@@ -393,6 +346,15 @@ async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<In
 		const existing = await findSourceByHash(ctx.pool, fileHash);
 		if (existing) {
 			log.info({ sourceId: existing.id, fileHash }, 'Duplicate URL snapshot detected, skipping upload');
+			await recordUrlLifecycleForFetch({
+				ctx,
+				source: existing,
+				fetchResult,
+				formatMetadata,
+				fileHash,
+				storagePath: existing.storagePath,
+				changeKind: 'unchanged',
+			});
 			return {
 				sourceId: existing.id,
 				filename,
@@ -464,6 +426,15 @@ async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<In
 
 	if (source.id !== sourceId) {
 		await ctx.services.storage.delete(storagePath).catch(() => undefined);
+		await recordUrlLifecycleForFetch({
+			ctx,
+			source,
+			fetchResult,
+			formatMetadata,
+			fileHash,
+			storagePath: source.storagePath,
+			changeKind: 'unchanged',
+		});
 		return {
 			sourceId: source.id,
 			filename,
@@ -477,6 +448,16 @@ async function processUrl(inputUrl: string, ctx: ProcessFileContext): Promise<In
 			duplicate: true,
 		};
 	}
+
+	await recordUrlLifecycleForFetch({
+		ctx,
+		source,
+		fetchResult,
+		formatMetadata,
+		fileHash,
+		storagePath: source.storagePath,
+		changeKind: 'initial',
+	});
 
 	await upsertSourceStep(ctx.pool, {
 		sourceId: source.id,

--- a/packages/pipeline/src/ingest/url-snapshot.ts
+++ b/packages/pipeline/src/ingest/url-snapshot.ts
@@ -1,0 +1,153 @@
+import type {
+	Logger,
+	MulderConfig,
+	Services,
+	SourceFormatMetadata,
+	UrlExtractionResult,
+	UrlFetchResult,
+	UrlRenderResult,
+} from '@mulder/core';
+import { INGEST_ERROR_CODES, IngestError, MulderError } from '@mulder/core';
+import { buildUrlFormatMetadata } from './source-type.js';
+
+export interface PreparedUrlSnapshot {
+	html: Buffer;
+	finalUrl: string;
+	title: string | null;
+	formatMetadata: SourceFormatMetadata;
+	renderingMethod: 'static' | 'playwright';
+}
+
+export interface PrepareUrlSnapshotContext {
+	config: MulderConfig;
+	services: Services;
+	displayUrl: string;
+	logger: Logger;
+}
+
+function htmlTitle(html: Buffer): string | null {
+	const match = html.toString('utf-8').match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+	const title = match?.[1]
+		?.replace(/<[^>]+>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+	return title && title.length > 0 ? title : null;
+}
+
+function slugifyFilenamePart(value: string): string {
+	return (
+		value
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+			.slice(0, 80) || 'page'
+	);
+}
+
+export function filenameForUrlSnapshot(html: Buffer, finalUrl: string, extractedTitle?: string): string {
+	const title = extractedTitle ?? htmlTitle(html);
+	const final = new URL(finalUrl);
+	const pathPart = final.pathname === '/' ? final.hostname : `${final.hostname}${final.pathname}`;
+	const basis = title ? `${title}-${final.hostname}` : pathPart;
+	return `${slugifyFilenamePart(basis)}.html`;
+}
+
+function errorCode(error: unknown): string {
+	return error instanceof MulderError ? error.code : error instanceof Error ? error.name : 'UNKNOWN';
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+async function probeUrlSnapshot(input: {
+	services: Services;
+	html: Buffer;
+	sourceId: string;
+	fetchMetadata: SourceFormatMetadata;
+}): Promise<UrlExtractionResult> {
+	return await input.services.urlExtractors.extractUrl(input.html, input.sourceId, input.fetchMetadata);
+}
+
+export async function prepareUrlSnapshot(
+	fetchResult: UrlFetchResult,
+	ctx: PrepareUrlSnapshotContext,
+): Promise<PreparedUrlSnapshot> {
+	const staticTitle = htmlTitle(fetchResult.html);
+	const staticMetadata = buildUrlFormatMetadata(fetchResult, staticTitle ?? undefined);
+	try {
+		const staticProbe = await probeUrlSnapshot({
+			services: ctx.services,
+			html: fetchResult.html,
+			sourceId: 'url-static-readability-probe',
+			fetchMetadata: staticMetadata,
+		});
+		return {
+			html: fetchResult.html,
+			finalUrl: fetchResult.finalUrl,
+			title: staticProbe.title || staticTitle,
+			formatMetadata: buildUrlFormatMetadata(fetchResult, staticProbe.title || staticTitle || undefined),
+			renderingMethod: 'static',
+		};
+	} catch (staticError: unknown) {
+		const staticReadabilityError = errorCode(staticError);
+		ctx.logger.info({ staticReadabilityError }, 'Static URL snapshot unreadable, attempting render fallback');
+		let renderResult: UrlRenderResult;
+		try {
+			renderResult = await ctx.services.urlRenderers.renderUrl(fetchResult.finalUrl, {
+				maxBytes: ctx.config.ingestion.max_file_size_mb * 1024 * 1024,
+			});
+		} catch (cause: unknown) {
+			throw new IngestError(
+				`URL render fallback failed for ${ctx.displayUrl}`,
+				INGEST_ERROR_CODES.INGEST_URL_RENDER_FAILED,
+				{
+					cause,
+					context: { url: ctx.displayUrl, staticReadabilityError },
+				},
+			);
+		}
+		const renderingMetadata = {
+			result: renderResult,
+			fallbackReason: 'static_unreadable',
+			staticReadabilityError,
+			renderedFromUrl: fetchResult.finalUrl,
+		};
+		const renderedTitle = htmlTitle(renderResult.html);
+		const renderedMetadata = buildUrlFormatMetadata(fetchResult, renderedTitle ?? undefined, renderingMetadata);
+		let renderedProbe: UrlExtractionResult;
+		try {
+			renderedProbe = await probeUrlSnapshot({
+				services: ctx.services,
+				html: renderResult.html,
+				sourceId: 'url-rendered-readability-probe',
+				fetchMetadata: renderedMetadata,
+			});
+		} catch (cause: unknown) {
+			throw new IngestError(
+				`Rendered URL snapshot was not readable for ${ctx.displayUrl}`,
+				INGEST_ERROR_CODES.INGEST_URL_RENDER_FAILED,
+				{
+					cause,
+					context: {
+						url: ctx.displayUrl,
+						staticReadabilityError,
+						renderedReadabilityError: errorCode(cause),
+						renderedErrorMessage: errorMessage(cause),
+					},
+				},
+			);
+		}
+		return {
+			html: renderResult.html,
+			finalUrl: renderResult.finalUrl,
+			title: renderedProbe.title || renderedTitle,
+			formatMetadata: buildUrlFormatMetadata(
+				fetchResult,
+				renderedProbe.title || renderedTitle || undefined,
+				renderingMetadata,
+			),
+			renderingMethod: 'playwright',
+		};
+	}
+}

--- a/packages/pipeline/src/url-lifecycle/index.ts
+++ b/packages/pipeline/src/url-lifecycle/index.ts
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+import type {
+	Logger,
+	MulderConfig,
+	Services,
+	Source,
+	SourceFormatMetadata,
+	UrlHostLifecycle,
+	UrlLifecycle,
+} from '@mulder/core';
+import {
+	computeUrlLifecycleNextAllowedAt,
+	createChildLogger,
+	findSourceByHash,
+	findSourceById,
+	findUrlHostLifecycleByHost,
+	findUrlLifecycleBySourceId,
+	MulderError,
+	normalizeUrlLifecycleHost,
+	recordUrlHostLifecycle,
+	recordUrlLifecycleFetch,
+	resetPipelineStep,
+	resolveUrlPolitenessDelayMs,
+	sleepForUrlPoliteness,
+	updateSource,
+	upsertSourceStep,
+	urlLifecycleHeaderValue,
+} from '@mulder/core';
+import type pg from 'pg';
+import { URL_SNAPSHOT_MEDIA_TYPE } from '../ingest/source-type.js';
+import { filenameForUrlSnapshot, prepareUrlSnapshot } from '../ingest/url-snapshot.js';
+
+const STEP_NAME = 'url-lifecycle';
+
+export interface UrlLifecycleStatusResult {
+	source: Source;
+	lifecycle: UrlLifecycle;
+	host: UrlHostLifecycle | null;
+}
+
+export interface UrlRefetchInput {
+	sourceId: string;
+	dryRun?: boolean;
+	force?: boolean;
+}
+
+export interface UrlRefetchResult {
+	sourceId: string;
+	status: 'changed' | 'unchanged';
+	dryRun: boolean;
+	notModified: boolean;
+	httpStatus: number;
+	originalUrl: string;
+	finalUrl: string;
+	previousHash: string;
+	currentHash: string;
+	storagePath: string;
+	renderingMethod: string | null;
+	checkedAt: string;
+}
+
+function computeHash(buffer: Buffer): string {
+	return createHash('sha256').update(buffer).digest('hex');
+}
+
+function stringMetadataValue(metadata: SourceFormatMetadata, key: string): string | null {
+	const value = metadata[key];
+	return typeof value === 'string' ? value : null;
+}
+
+function lifecycleError(
+	message: string,
+	code: string,
+	context?: Record<string, unknown>,
+	cause?: unknown,
+): MulderError {
+	return new MulderError(message, code, { context, cause });
+}
+
+async function loadUrlSource(pool: pg.Pool, sourceId: string): Promise<{ source: Source; lifecycle: UrlLifecycle }> {
+	const source = await findSourceById(pool, sourceId);
+	if (!source) {
+		throw lifecycleError(`Source not found: ${sourceId}`, 'URL_SOURCE_NOT_FOUND', { sourceId });
+	}
+	if (source.sourceType !== 'url') {
+		throw lifecycleError(`Source is not a URL source: ${sourceId}`, 'URL_SOURCE_REQUIRED', {
+			sourceId,
+			sourceType: source.sourceType,
+		});
+	}
+
+	const lifecycle = await findUrlLifecycleBySourceId(pool, sourceId);
+	if (!lifecycle) {
+		throw lifecycleError(`URL lifecycle metadata not found for source: ${sourceId}`, 'URL_LIFECYCLE_NOT_FOUND', {
+			sourceId,
+		});
+	}
+
+	return { source, lifecycle };
+}
+
+async function waitForHostPoliteness(pool: pg.Pool, host: string): Promise<void> {
+	const state = await findUrlHostLifecycleByHost(pool, host);
+	if (!state?.nextAllowedAt) {
+		return;
+	}
+	const waitMs = state.nextAllowedAt.getTime() - Date.now();
+	if (waitMs > 0) {
+		await sleepForUrlPoliteness(waitMs);
+	}
+}
+
+async function recordSuccessfulLifecycle(input: {
+	pool: pg.Pool;
+	source: Source;
+	lifecycle: UrlLifecycle;
+	fetchResult: Awaited<ReturnType<Services['urls']['fetchUrl']>>;
+	formatMetadata: SourceFormatMetadata;
+	fileHash: string;
+	storagePath: string;
+	changeKind: 'changed' | 'unchanged';
+}): Promise<void> {
+	const fetchedAt = new Date(input.fetchResult.fetchedAt);
+	const minimumDelayMs = resolveUrlPolitenessDelayMs();
+	const finalUrl = stringMetadataValue(input.formatMetadata, 'final_url') ?? input.fetchResult.finalUrl;
+	const host = normalizeUrlLifecycleHost(finalUrl);
+	const initialHost = normalizeUrlLifecycleHost(input.fetchResult.normalizedUrl);
+	const nextFetchAfter = computeUrlLifecycleNextAllowedAt(fetchedAt, minimumDelayMs);
+
+	for (const hostToRecord of new Set([initialHost, host])) {
+		await recordUrlHostLifecycle(input.pool, {
+			host: hostToRecord,
+			minimumDelayMs,
+			requestedAt: fetchedAt,
+			lastRobotsCheckedAt: fetchedAt,
+		});
+	}
+
+	await recordUrlLifecycleFetch(input.pool, {
+		sourceId: input.source.id,
+		originalUrl: input.fetchResult.originalUrl,
+		normalizedUrl: input.fetchResult.normalizedUrl,
+		finalUrl,
+		host,
+		etag: urlLifecycleHeaderValue(input.fetchResult.headers, 'etag') ?? input.lifecycle.etag,
+		lastModified: urlLifecycleHeaderValue(input.fetchResult.headers, 'last-modified') ?? input.lifecycle.lastModified,
+		lastFetchedAt: fetchedAt,
+		lastCheckedAt: fetchedAt,
+		nextFetchAfter,
+		lastHttpStatus: input.fetchResult.httpStatus,
+		robotsAllowed: input.fetchResult.robots.allowed,
+		robotsUrl: input.fetchResult.robots.robotsUrl,
+		robotsCheckedAt: fetchedAt,
+		robotsMatchedUserAgent: input.fetchResult.robots.matchedUserAgent,
+		robotsMatchedRule: input.fetchResult.robots.matchedRule,
+		redirectCount: input.fetchResult.redirectCount,
+		contentType: input.fetchResult.contentType || input.lifecycle.contentType,
+		renderingMethod: stringMetadataValue(input.formatMetadata, 'rendering_method') ?? input.lifecycle.renderingMethod,
+		snapshotEncoding:
+			input.fetchResult.snapshotEncoding ??
+			stringMetadataValue(input.formatMetadata, 'snapshot_encoding') ??
+			input.lifecycle.snapshotEncoding,
+		lastContentHash: input.fileHash,
+		lastSnapshotStoragePath: input.storagePath,
+		changeKind: input.changeKind,
+	});
+}
+
+export async function getUrlLifecycleStatus(pool: pg.Pool, sourceId: string): Promise<UrlLifecycleStatusResult> {
+	const { source, lifecycle } = await loadUrlSource(pool, sourceId);
+	const host = await findUrlHostLifecycleByHost(pool, lifecycle.host);
+	return { source, lifecycle, host };
+}
+
+export async function refetchUrlSource(
+	input: UrlRefetchInput,
+	config: MulderConfig,
+	services: Services,
+	pool: pg.Pool,
+	logger: Logger,
+): Promise<UrlRefetchResult> {
+	const { source, lifecycle } = await loadUrlSource(pool, input.sourceId);
+	const dryRun = input.dryRun ?? false;
+	const force = input.force ?? false;
+	const log = createChildLogger(logger, { step: STEP_NAME, sourceId: source.id });
+	const refetchUrl =
+		lifecycle.normalizedUrl || stringMetadataValue(source.formatMetadata, 'normalized_url') || lifecycle.originalUrl;
+	const initialHost = normalizeUrlLifecycleHost(refetchUrl);
+
+	await waitForHostPoliteness(pool, initialHost);
+
+	let fetchResult: Awaited<ReturnType<Services['urls']['fetchUrl']>>;
+	try {
+		fetchResult = await services.urls.fetchUrl(refetchUrl, {
+			maxBytes: config.ingestion.max_file_size_mb * 1024 * 1024,
+			ifNoneMatch: force ? null : lifecycle.etag,
+			ifModifiedSince: force ? null : lifecycle.lastModified,
+		});
+	} catch (cause: unknown) {
+		const detail = cause instanceof Error ? `: ${cause.message}` : '';
+		throw lifecycleError(
+			`URL re-fetch failed for source ${source.id}${detail}`,
+			'URL_REFETCH_FAILED',
+			{
+				sourceId: source.id,
+				url: refetchUrl,
+			},
+			cause,
+		);
+	}
+
+	if (fetchResult.notModified) {
+		if (!dryRun) {
+			await recordSuccessfulLifecycle({
+				pool,
+				source,
+				lifecycle,
+				fetchResult,
+				formatMetadata: source.formatMetadata,
+				fileHash: source.fileHash,
+				storagePath: source.storagePath,
+				changeKind: 'unchanged',
+			});
+		}
+		return {
+			sourceId: source.id,
+			status: 'unchanged',
+			dryRun,
+			notModified: true,
+			httpStatus: fetchResult.httpStatus,
+			originalUrl: fetchResult.originalUrl,
+			finalUrl: fetchResult.finalUrl,
+			previousHash: source.fileHash,
+			currentHash: source.fileHash,
+			storagePath: source.storagePath,
+			renderingMethod: lifecycle.renderingMethod,
+			checkedAt: fetchResult.fetchedAt,
+		};
+	}
+
+	const prepared = await prepareUrlSnapshot(fetchResult, {
+		config,
+		services,
+		displayUrl: refetchUrl,
+		logger: log,
+	});
+	const fileHash = computeHash(prepared.html);
+	const unchanged = fileHash === source.fileHash;
+
+	if (unchanged) {
+		if (!dryRun) {
+			await recordSuccessfulLifecycle({
+				pool,
+				source,
+				lifecycle,
+				fetchResult,
+				formatMetadata: prepared.formatMetadata,
+				fileHash: source.fileHash,
+				storagePath: source.storagePath,
+				changeKind: 'unchanged',
+			});
+		}
+		return {
+			sourceId: source.id,
+			status: 'unchanged',
+			dryRun,
+			notModified: false,
+			httpStatus: fetchResult.httpStatus,
+			originalUrl: fetchResult.originalUrl,
+			finalUrl: prepared.finalUrl,
+			previousHash: source.fileHash,
+			currentHash: source.fileHash,
+			storagePath: source.storagePath,
+			renderingMethod: prepared.renderingMethod,
+			checkedAt: fetchResult.fetchedAt,
+		};
+	}
+
+	const filename = filenameForUrlSnapshot(prepared.html, prepared.finalUrl, prepared.title ?? undefined);
+	if (!dryRun) {
+		const duplicate = await findSourceByHash(pool, fileHash);
+		if (duplicate && duplicate.id !== source.id) {
+			throw lifecycleError(
+				'URL re-fetch produced content that already belongs to another source',
+				'URL_REFETCH_DUPLICATE_HASH',
+				{
+					sourceId: source.id,
+					duplicateSourceId: duplicate.id,
+					fileHash,
+				},
+			);
+		}
+		await services.storage.upload(source.storagePath, prepared.html, URL_SNAPSHOT_MEDIA_TYPE);
+		await updateSource(pool, source.id, {
+			filename,
+			fileHash,
+			formatMetadata: prepared.formatMetadata,
+			metadata: prepared.formatMetadata,
+			status: 'ingested',
+		});
+		await resetPipelineStep(pool, source.id, 'extract');
+		await upsertSourceStep(pool, {
+			sourceId: source.id,
+			stepName: 'ingest',
+			status: 'completed',
+		});
+		await recordSuccessfulLifecycle({
+			pool,
+			source,
+			lifecycle,
+			fetchResult,
+			formatMetadata: prepared.formatMetadata,
+			fileHash,
+			storagePath: source.storagePath,
+			changeKind: 'changed',
+		});
+	}
+
+	return {
+		sourceId: source.id,
+		status: 'changed',
+		dryRun,
+		notModified: false,
+		httpStatus: fetchResult.httpStatus,
+		originalUrl: fetchResult.originalUrl,
+		finalUrl: prepared.finalUrl,
+		previousHash: source.fileHash,
+		currentHash: fileHash,
+		storagePath: source.storagePath,
+		renderingMethod: prepared.renderingMethod,
+		checkedAt: fetchResult.fetchedAt,
+	};
+}

--- a/tests/lib/schema.ts
+++ b/tests/lib/schema.ts
@@ -39,6 +39,8 @@ export const MULDER_TEST_TABLES = [
 	'pipeline_run_sources',
 	'pipeline_runs',
 	'jobs',
+	'url_lifecycle',
+	'url_host_lifecycle',
 	'source_steps',
 	'sources',
 ] as const;

--- a/tests/specs/07_database_client_migration_runner.test.ts
+++ b/tests/specs/07_database_client_migration_runner.test.ts
@@ -112,6 +112,8 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 		'DROP TABLE IF EXISTS evidence_chains CASCADE',
 		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+		'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/08_core_schema_migrations.test.ts
+++ b/tests/specs/08_core_schema_migrations.test.ts
@@ -74,6 +74,8 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 		'DROP TABLE IF EXISTS evidence_chains CASCADE',
 		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+		'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/09_job_queue_pipeline_tracking_migrations.test.ts
+++ b/tests/specs/09_job_queue_pipeline_tracking_migrations.test.ts
@@ -82,6 +82,8 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 		'DROP TABLE IF EXISTS evidence_chains CASCADE',
 		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+		'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/14_source_repository.test.ts
+++ b/tests/specs/14_source_repository.test.ts
@@ -97,6 +97,8 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 		'DROP TABLE IF EXISTS evidence_chains CASCADE',
 		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+		'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/54_v2_schema_migrations.test.ts
+++ b/tests/specs/54_v2_schema_migrations.test.ts
@@ -73,6 +73,8 @@ function resetDatabase(): void {
 		'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 		'DROP TABLE IF EXISTS evidence_chains CASCADE',
 		'DROP TABLE IF EXISTS entity_grounding CASCADE',
+		'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+		'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 		'DROP TABLE IF EXISTS source_steps CASCADE',
 		'DROP TABLE IF EXISTS sources CASCADE',
 		'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -55,6 +55,8 @@ function resetSchemaToMissing(): void {
 			'DROP TABLE IF EXISTS spatio_temporal_clusters CASCADE',
 			'DROP TABLE IF EXISTS evidence_chains CASCADE',
 			'DROP TABLE IF EXISTS entity_grounding CASCADE',
+			'DROP TABLE IF EXISTS url_lifecycle CASCADE',
+			'DROP TABLE IF EXISTS url_host_lifecycle CASCADE',
 			'DROP TABLE IF EXISTS source_steps CASCADE',
 			'DROP TABLE IF EXISTS sources CASCADE',
 			'DROP TABLE IF EXISTS mulder_migrations CASCADE',

--- a/tests/specs/73_search_api_routes.test.ts
+++ b/tests/specs/73_search_api_routes.test.ts
@@ -146,6 +146,7 @@ function buildMockServices(): Services {
 				httpStatus: 200,
 				headers: {},
 				html: Buffer.from('<html><body></body></html>'),
+				notModified: false,
 				contentType: 'text/html',
 				redirectCount: 0,
 				fetchedAt: new Date(0).toISOString(),

--- a/tests/specs/92_url_ingestion_prestructured_path.test.ts
+++ b/tests/specs/92_url_ingestion_prestructured_path.test.ts
@@ -98,6 +98,7 @@ async function runCli(
 		MULDER_CONFIG: EXAMPLE_CONFIG,
 		MULDER_LOG_LEVEL: 'silent',
 		MULDER_URL_RENDERER_FIXTURE_FILE: RENDER_FIXTURE_FILE,
+		MULDER_URL_POLITENESS_DELAY_MS: '0',
 		NODE_ENV: 'test',
 		PGPASSWORD: db.TEST_PG_PASSWORD,
 	};
@@ -139,6 +140,8 @@ function cleanState(): void {
 			'DELETE FROM jobs',
 			'DELETE FROM pipeline_run_sources',
 			'DELETE FROM pipeline_runs',
+			'DELETE FROM url_lifecycle',
+			'DELETE FROM url_host_lifecycle',
 			'DELETE FROM source_steps',
 			'DELETE FROM chunks',
 			'DELETE FROM story_entities',

--- a/tests/specs/93_url_rendering_playwright_fallback.test.ts
+++ b/tests/specs/93_url_rendering_playwright_fallback.test.ts
@@ -120,6 +120,7 @@ async function runCli(args: string[], options: { timeout?: number; allowUnsafeUr
 		MULDER_CONFIG: EXAMPLE_CONFIG,
 		MULDER_LOG_LEVEL: 'silent',
 		MULDER_URL_RENDERER_FIXTURE_FILE: RENDER_FIXTURE_FILE,
+		MULDER_URL_POLITENESS_DELAY_MS: '0',
 		NODE_ENV: 'test',
 		PGPASSWORD: db.TEST_PG_PASSWORD,
 	};
@@ -161,6 +162,8 @@ function cleanState(): void {
 			'DELETE FROM jobs',
 			'DELETE FROM pipeline_run_sources',
 			'DELETE FROM pipeline_runs',
+			'DELETE FROM url_lifecycle',
+			'DELETE FROM url_host_lifecycle',
 			'DELETE FROM source_steps',
 			'DELETE FROM chunks',
 			'DELETE FROM story_entities',

--- a/tests/specs/94_url_lifecycle_refetch.test.ts
+++ b/tests/specs/94_url_lifecycle_refetch.test.ts
@@ -1,0 +1,351 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const EXTRACTED_STORAGE_DIR = resolve(STORAGE_DIR, 'extracted');
+const SEGMENTS_STORAGE_DIR = resolve(STORAGE_DIR, 'segments');
+const SOURCE_ID_TEXT = '00000000-0000-0000-0000-000000009410';
+
+let server: Server;
+let baseUrl = '';
+let pgAvailable = false;
+let rawSnapshot: StorageSnapshot | null = null;
+let extractedSnapshot: StorageSnapshot | null = null;
+let segmentsSnapshot: StorageSnapshot | null = null;
+let articleBody = 'Initial lifecycle article body for Spec 94 URL freshness tracking.';
+let articleEtag = '"spec-94-v1"';
+let articleLastModified = 'Mon, 04 May 2026 08:00:00 GMT';
+let robotsDisallowArticle = false;
+let lastIfNoneMatch: string | null = null;
+let lastIfModifiedSince: string | null = null;
+
+function articleHtml(body: string): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <title>Spec 94 Lifecycle Article</title>
+  <meta name="author" content="Uma URL Lifecycle">
+</head>
+<body>
+  <article>
+    <h1>Spec 94 Lifecycle Article</h1>
+    <p>${body}</p>
+    <p>This deterministic page has enough readable text for Readability extraction and stable URL lifecycle assertions.</p>
+    <p>The page mentions freshness, robots decisions, conditional requests, and explicit source re-fetch behavior.</p>
+  </article>
+</body>
+</html>`;
+}
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+async function runCli(args: string[], options: { timeout?: number } = {}) {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		MULDER_CONFIG: EXAMPLE_CONFIG,
+		MULDER_LOG_LEVEL: 'silent',
+		MULDER_ALLOW_UNSAFE_URLS_FOR_TESTS: 'true',
+		MULDER_URL_POLITENESS_DELAY_MS: '0',
+		NODE_ENV: 'test',
+		PGPASSWORD: db.TEST_PG_PASSWORD,
+	};
+	return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolveCli) => {
+		const child = spawn('node', [CLI_DIST, ...args], {
+			cwd: ROOT,
+			stdio: ['ignore', 'pipe', 'pipe'],
+			env,
+		});
+		let stdout = '';
+		let stderr = '';
+		const timeout = setTimeout(() => {
+			child.kill('SIGTERM');
+		}, options.timeout ?? 180_000);
+		child.stdout.setEncoding('utf-8');
+		child.stderr.setEncoding('utf-8');
+		child.stdout.on('data', (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr.on('data', (chunk: string) => {
+			stderr += chunk;
+		});
+		child.on('close', (code) => {
+			clearTimeout(timeout);
+			resolveCli({ stdout, stderr, exitCode: code ?? 1 });
+		});
+	});
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM monthly_budget_reservations',
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM url_lifecycle',
+			'DELETE FROM url_host_lifecycle',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function resetStorage(): void {
+	for (const snapshot of [rawSnapshot, extractedSnapshot, segmentsSnapshot]) {
+		if (snapshot) {
+			cleanStorageDirSince(snapshot);
+		}
+	}
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sourceIdForArticle(): string {
+	return db.runSql(
+		`SELECT id FROM sources WHERE format_metadata->>'original_url' = ${sqlLiteral(`${baseUrl}/article`)} LIMIT 1;`,
+	);
+}
+
+function rawHtmlForSource(sourceId: string): string {
+	return readFileSync(resolve(STORAGE_DIR, `raw/${sourceId}/original.html`), 'utf-8');
+}
+
+async function ingestArticle(): Promise<string> {
+	const ingest = await runCli(['ingest', `${baseUrl}/article`]);
+	expect(ingest.exitCode, `${ingest.stdout}\n${ingest.stderr}`).toBe(0);
+	return sourceIdForArticle();
+}
+
+beforeAll(async () => {
+	server = createServer((request, response) => {
+		const url = request.url ?? '/';
+		if (url === '/robots.txt') {
+			response.writeHead(200, { 'content-type': 'text/plain' });
+			response.end(robotsDisallowArticle ? 'User-agent: *\nDisallow: /article' : 'User-agent: *\nAllow: /');
+			return;
+		}
+		if (url === '/article') {
+			lastIfNoneMatch = Array.isArray(request.headers['if-none-match'])
+				? (request.headers['if-none-match'][0] ?? null)
+				: (request.headers['if-none-match'] ?? null);
+			lastIfModifiedSince = Array.isArray(request.headers['if-modified-since'])
+				? (request.headers['if-modified-since'][0] ?? null)
+				: (request.headers['if-modified-since'] ?? null);
+			const validatorsMatch = lastIfNoneMatch === articleEtag || lastIfModifiedSince === articleLastModified;
+			if (validatorsMatch) {
+				response.writeHead(304, { etag: articleEtag, 'last-modified': articleLastModified });
+				response.end();
+				return;
+			}
+			response.writeHead(200, {
+				'content-type': 'text/html; charset=utf-8',
+				etag: articleEtag,
+				'last-modified': articleLastModified,
+			});
+			response.end(articleHtml(articleBody));
+			return;
+		}
+		response.writeHead(404, { 'content-type': 'text/plain' });
+		response.end('not found');
+	});
+	await new Promise<void>((resolveServer) => {
+		server.listen(0, '127.0.0.1', resolveServer);
+	});
+	const address = server.address();
+	if (typeof address === 'object' && address) {
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	}
+
+	rawSnapshot = snapshotStorageDir(RAW_STORAGE_DIR);
+	extractedSnapshot = snapshotStorageDir(EXTRACTED_STORAGE_DIR);
+	segmentsSnapshot = snapshotStorageDir(SEGMENTS_STORAGE_DIR);
+
+	buildPackage(CORE_DIR);
+	buildPackage(PIPELINE_DIR);
+	buildPackage(CLI_DIR);
+
+	pgAvailable = db.isPgAvailable();
+	if (pgAvailable) {
+		const migrate = await runCli(['db', 'migrate', EXAMPLE_CONFIG]);
+		expect(migrate.exitCode, `${migrate.stdout}\n${migrate.stderr}`).toBe(0);
+	}
+}, 600_000);
+
+beforeEach(() => {
+	articleBody = 'Initial lifecycle article body for Spec 94 URL freshness tracking.';
+	articleEtag = '"spec-94-v1"';
+	articleLastModified = 'Mon, 04 May 2026 08:00:00 GMT';
+	robotsDisallowArticle = false;
+	lastIfNoneMatch = null;
+	lastIfModifiedSince = null;
+	if (!pgAvailable) return;
+	cleanState();
+	resetStorage();
+});
+
+afterAll(async () => {
+	try {
+		if (pgAvailable) {
+			cleanState();
+			resetStorage();
+		}
+	} catch {
+		// Ignore cleanup failures.
+	}
+	await new Promise<void>((resolveServer) => {
+		server.close(() => resolveServer());
+	});
+});
+
+describe('Spec 94 - URL lifecycle and re-fetch support', () => {
+	it('QA-01/02: ingest persists lifecycle and host state, and status prints it', async () => {
+		if (!pgAvailable) return;
+		const sourceId = await ingestArticle();
+		const host = new URL(baseUrl).host;
+		const row = db
+			.runSql(
+				`SELECT ul.host, ul.etag, ul.last_modified, ul.robots_allowed, ul.fetch_count, ul.unchanged_count, ul.changed_count, uh.minimum_delay_ms FROM url_lifecycle ul JOIN url_host_lifecycle uh ON uh.host = ul.host WHERE ul.source_id = ${sqlLiteral(sourceId)};`,
+			)
+			.split('|');
+		expect(row).toEqual([host, articleEtag, articleLastModified, 't', '1', '0', '0', '0']);
+
+		const status = await runCli(['url', 'status', sourceId]);
+		expect(status.exitCode, `${status.stdout}\n${status.stderr}`).toBe(0);
+		expect(status.stdout).toContain(`${baseUrl}/article`);
+		expect(status.stdout).toContain(host);
+		expect(status.stdout).toContain(articleEtag);
+		expect(status.stdout).toMatch(/Fetch count\s+1/);
+	});
+
+	it('QA-03: 304 re-fetch updates freshness only', async () => {
+		if (!pgAvailable) return;
+		const sourceId = await ingestArticle();
+		const before = db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`);
+
+		const refetch = await runCli(['url', 'refetch', sourceId]);
+		expect(refetch.exitCode, `${refetch.stdout}\n${refetch.stderr}`).toBe(0);
+		expect(refetch.stdout).toMatch(/Result\s+unchanged/);
+		expect(refetch.stdout).toMatch(/Not modified\s+yes/);
+		expect(lastIfNoneMatch).toBe(articleEtag);
+
+		const after = db
+			.runSql(
+				`SELECT s.file_hash, ul.last_http_status, ul.fetch_count, ul.unchanged_count, ul.changed_count FROM sources s JOIN url_lifecycle ul ON ul.source_id = s.id WHERE s.id = ${sqlLiteral(sourceId)};`,
+			)
+			.split('|');
+		expect(after).toEqual([before, '304', '2', '1', '0']);
+		expect(rawHtmlForSource(sourceId)).toContain('Initial lifecycle article body');
+	});
+
+	it('QA-04: changed re-fetch refreshes the source snapshot and resets extraction state', async () => {
+		if (!pgAvailable) return;
+		const sourceId = await ingestArticle();
+		const beforeHash = db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`);
+		const extract = await runCli(['extract', sourceId]);
+		expect(extract.exitCode, `${extract.stdout}\n${extract.stderr}`).toBe(0);
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+
+		articleBody = 'Refreshed lifecycle article body after explicit re-fetch.';
+		articleEtag = '"spec-94-v2"';
+		articleLastModified = 'Mon, 04 May 2026 09:00:00 GMT';
+		const refetch = await runCli(['url', 'refetch', sourceId]);
+		expect(refetch.exitCode, `${refetch.stdout}\n${refetch.stderr}`).toBe(0);
+		expect(refetch.stdout).toMatch(/Result\s+changed/);
+
+		const row = db
+			.runSql(
+				`SELECT s.file_hash, s.status::text, s.format_metadata->>'etag', ul.fetch_count, ul.changed_count FROM sources s JOIN url_lifecycle ul ON ul.source_id = s.id WHERE s.id = ${sqlLiteral(sourceId)};`,
+			)
+			.split('|');
+		expect(row[0]).not.toBe(beforeHash);
+		expect(row.slice(1)).toEqual(['ingested', articleEtag, '2', '1']);
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('0');
+		expect(
+			db.runSql(
+				`SELECT COUNT(*) FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'extract';`,
+			),
+		).toBe('0');
+		expect(
+			db.runSql(`SELECT status FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = 'ingest';`),
+		).toBe('completed');
+		expect(rawHtmlForSource(sourceId)).toContain('Refreshed lifecycle article body');
+	});
+
+	it('QA-05/06: dry-run writes nothing, and force skips conditional validators', async () => {
+		if (!pgAvailable) return;
+		const sourceId = await ingestArticle();
+		const beforeHash = db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`);
+		const beforeRaw = rawHtmlForSource(sourceId);
+		articleBody = 'Dry-run body that should not be stored yet.';
+		articleEtag = '"spec-94-v3"';
+		articleLastModified = 'Mon, 04 May 2026 10:00:00 GMT';
+
+		const dryRun = await runCli(['url', 'refetch', sourceId, '--dry-run']);
+		expect(dryRun.exitCode, `${dryRun.stdout}\n${dryRun.stderr}`).toBe(0);
+		expect(dryRun.stdout).toMatch(/Result\s+dry-run changed/);
+		expect(lastIfNoneMatch).toBe('"spec-94-v1"');
+		expect(db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe(beforeHash);
+		expect(db.runSql(`SELECT fetch_count FROM url_lifecycle WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+		expect(rawHtmlForSource(sourceId)).toBe(beforeRaw);
+
+		lastIfNoneMatch = 'not-reset';
+		const force = await runCli(['url', 'refetch', sourceId, '--force']);
+		expect(force.exitCode, `${force.stdout}\n${force.stderr}`).toBe(0);
+		expect(force.stdout).toMatch(/Result\s+changed/);
+		expect(lastIfNoneMatch).toBeNull();
+		expect(rawHtmlForSource(sourceId)).toContain('Dry-run body that should not be stored yet');
+	});
+
+	it('QA-07/08: robots-blocked refetch and non-URL sources fail without source mutations', async () => {
+		if (!pgAvailable) return;
+		const sourceId = await ingestArticle();
+		const beforeHash = db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`);
+		robotsDisallowArticle = true;
+		articleBody = 'Robots blocked body that must not be stored.';
+		articleEtag = '"spec-94-v4"';
+
+		const blocked = await runCli(['url', 'refetch', sourceId]);
+		expect(blocked.exitCode, `${blocked.stdout}\n${blocked.stderr}`).not.toBe(0);
+		expect(`${blocked.stdout}\n${blocked.stderr}`).toMatch(/robots|re-fetch failed/i);
+		expect(db.runSql(`SELECT file_hash FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe(beforeHash);
+		expect(db.runSql(`SELECT fetch_count FROM url_lifecycle WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+
+		db.runSql(
+			`INSERT INTO sources (id, filename, storage_path, file_hash, source_type, format_metadata, metadata) VALUES (${sqlLiteral(SOURCE_ID_TEXT)}, 'spec-94.txt', 'raw/spec-94/original.txt', 'spec-94-text-hash', 'text', '{}'::jsonb, '{}'::jsonb);`,
+		);
+		const nonUrl = await runCli(['url', 'status', SOURCE_ID_TEXT]);
+		expect(nonUrl.exitCode, `${nonUrl.stdout}\n${nonUrl.stderr}`).not.toBe(0);
+		expect(`${nonUrl.stdout}\n${nonUrl.stderr}`).toMatch(/URL source/i);
+	});
+});


### PR DESCRIPTION
## Summary
- add Spec 94 URL lifecycle persistence for URL sources and per-host politeness state
- add conditional URL fetch support plus explicit `mulder url status` and `mulder url refetch` CLI flows
- refresh changed URL snapshots in place, reset downstream extraction state, and keep J8/J9 URL regressions green

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run tests/specs/92_url_ingestion_prestructured_path.test.ts tests/specs/93_url_rendering_playwright_fallback.test.ts tests/specs/94_url_lifecycle_refetch.test.ts`

Closes #252