### PR TITLE
[Pipeline] Format-aware extract routing — M9-J11

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -261,7 +261,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J8 | URL ingestion — fetch + snapshot to GCS, Readability extraction → Markdown | §2.1 |
 | 🟢 | J9 | URL rendering — Playwright fallback for JS-rendered pages | §2.1 |
 | 🟢 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
-| 🟡 | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
+| 🟢 | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | ⚪ | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
 | ⚪ | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -261,7 +261,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J8 | URL ingestion — fetch + snapshot to GCS, Readability extraction → Markdown | §2.1 |
 | 🟢 | J9 | URL rendering — Playwright fallback for JS-rendered pages | §2.1 |
 | 🟢 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
-| ⚪ | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
+| 🟡 | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | ⚪ | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
 | ⚪ | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
 

--- a/docs/specs/95_format_aware_extract_routing.spec.md
+++ b/docs/specs/95_format_aware_extract_routing.spec.md
@@ -1,0 +1,123 @@
+---
+spec: "95"
+title: "Format-Aware Extract Routing"
+roadmap_step: M9-J11
+functional_spec: ["§2.2", "§2", "§3", "§4.5"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/254"
+created: 2026-05-04
+---
+
+# Spec 95: Format-Aware Extract Routing
+
+## 1. Objective
+
+Complete M9-J11 by making `source_type` the explicit routing contract for the Extract step. Mulder already accepts PDF, image, text, DOCX, spreadsheet, email, and URL sources; this step hardens the dispatch boundary so extraction behavior is selected by the persisted source type and only then validated with route-local media metadata or content detection.
+
+This fulfills the Extract contract in functional spec §2.2 while preserving the pipeline composition rules from §3 and the service abstraction rule from §4.5. The outcome should be easier to reason about than a long branch chain: layout-capable sources use the layout extractor, pre-structured sources create story Markdown directly, and unsupported combinations fail clearly before writing partial artifacts.
+
+## 2. Boundaries
+
+**Roadmap step:** M9-J11 - Format-aware extract routing: dispatch to correct extractor by `source_type`.
+
+**Base branch:** `milestone/9`. This spec is delivered to the M9 integration branch, not directly to `main`.
+
+**Target branch:** `feat/254-format-aware-extract-routing`.
+
+**Target files:**
+
+- `packages/pipeline/src/extract/index.ts`
+- `packages/pipeline/src/extract/source-routing.ts`
+- `packages/pipeline/src/index.ts`
+- `tests/specs/95_format_aware_extract_routing.test.ts`
+- Existing M9 regression tests as needed
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Add a small Extract routing layer keyed by `Source.sourceType`.
+- Route `pdf` and `image` through the layout extraction path.
+- Route `text`, `docx`, `spreadsheet`, `email`, and `url` through their pre-structured extractors.
+- Keep media-type and magic-byte checks as validation inside the selected route, not as global dispatch inputs.
+- Preserve `--fallback-only` only for layout-capable sources and fail clearly for pre-structured sources.
+- Preserve pre-structured segment skipping and source/story status transitions.
+- Keep pipeline code on service abstractions; no direct GCP clients.
+
+**Out of scope:**
+
+- New source formats.
+- Changes to ingest detection, upload finalization, or URL lifecycle behavior.
+- Rewriting the individual format extractors.
+- Cross-format duplicate detection. That is M9-J12.
+- Golden fixture breadth. That is M9-J13.
+
+## 3. Dependencies
+
+- M9-J1 / Spec 85: first-class `source_type` and `format_metadata`.
+- M9-J2 / Spec 86: pre-structured source types skip `segment`.
+- M9-J3 through M9-J10: all source formats have executable ingest/extract paths.
+
+This spec blocks M9-J12 and M9-J13 because both rely on predictable multi-format extraction semantics.
+
+## 4. Blueprint
+
+1. Add `packages/pipeline/src/extract/source-routing.ts` with a typed routing helper:
+   - accepted source types
+   - route kind: `layout` or `prestructured`
+   - fallback-only support
+   - clear error metadata for unsupported combinations
+2. Update `packages/pipeline/src/extract/index.ts` to select the route once after loading the source and before running extraction.
+3. Replace the repeated source-type branch chain with route-based dispatch while keeping existing extractor functions intact.
+4. Keep `resolveSourceMediaType` route-local to the layout path.
+5. Export only helpers needed by tests from the package barrel.
+6. Add black-box tests that exercise CLI behavior and public exports without peeking into private implementation details.
+7. Run the relevant M9 regression matrix.
+
+No database migration or config change is required.
+
+## 5. QA Contract
+
+1. **QA-01: Public routing helper reports every M9 source type**
+   - Given: the pipeline package is imported from tests
+   - When: each source type is passed to the routing helper
+   - Then: `pdf` and `image` are classified as layout routes, while `text`, `docx`, `spreadsheet`, `email`, and `url` are classified as pre-structured routes.
+
+2. **QA-02: Fallback-only is rejected for pre-structured sources**
+   - Given: a valid pre-structured source exists in PostgreSQL
+   - When: `mulder extract <source-id> --fallback-only` is run
+   - Then: the command exits non-zero with a clear source-type fallback error and does not write extracted artifacts.
+
+3. **QA-03: Source type controls extraction even when filenames are misleading**
+   - Given: a text source whose filename looks like a PDF but whose persisted `source_type` is `text`
+   - When: `mulder extract <source-id>` is run
+   - Then: Mulder extracts the source as text, writes direct story Markdown, skips `segment`, and does not create layout page images.
+
+4. **QA-04: Layout sources stay on the layout path**
+   - Given: an image source is ingested
+   - When: `mulder extract <source-id>` is run
+   - Then: Mulder writes `extracted/<source-id>/layout.json` and page image artifacts, and `segment` is not marked skipped by extract itself.
+
+5. **QA-05: Mixed-format extraction remains composable**
+   - Given: one layout source and one pre-structured source are ingested
+   - When: `mulder extract --all` or the equivalent pipeline route processes them
+   - Then: each source reaches `extracted` using its route without causing the other route to fail.
+
+6. **QA-06: M9 regression suite remains green**
+   - Given: existing M9 URL, email, spreadsheet, DOCX, text, image, and step-skipping tests
+   - When: the targeted spec tests are run
+   - Then: all previously green behavior remains green.
+
+## 5b. CLI Test Matrix
+
+This step does not add a new command, but it changes `mulder extract` routing behavior.
+
+| Command | Expected |
+| --- | --- |
+| `mulder extract <text-source>` | direct text extraction, story created, no layout artifacts |
+| `mulder extract <text-source> --fallback-only` | non-zero, clear unsupported fallback message |
+| `mulder extract <image-source>` | layout extraction artifacts written |
+| `mulder extract --all` | mixed source types dispatch independently |
+
+## 6. Cost Considerations
+
+This step should not add new paid-service calls. It should reduce accidental cost risk by keeping pre-structured sources away from Document AI / Vision fallback routes and by making layout-only service calls explicit for `pdf` and `image` sources.

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -2128,6 +2128,9 @@ export async function execute(
 		});
 	}
 	const route = requireExtractRoute(source.sourceType, { sourceId: input.sourceId });
+	if (input.fallbackOnly) {
+		assertFallbackOnlySupported(route, { sourceId: input.sourceId });
+	}
 
 	// 2. Validate status
 	const validStatuses = ['ingested', 'extracted', 'segmented', 'enriched', 'embedded', 'graphed', 'analyzed'];
@@ -2162,10 +2165,6 @@ export async function execute(
 
 	const errors: StepError[] = [];
 	let extractionData: ExtractionData;
-
-	if (input.fallbackOnly) {
-		assertFallbackOnlySupported(route, { sourceId: input.sourceId });
-	}
 
 	if (!input.fallbackOnly && route.kind === 'prestructured') {
 		switch (route.sourceType) {

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -65,9 +65,27 @@ import {
 	isSupportedTextMediaType,
 } from '../ingest/source-type.js';
 import { layoutToMarkdown } from './layout-to-markdown.js';
+import { assertFallbackOnlySupported, requireExtractRoute } from './source-routing.js';
 import type { ExtractInput, ExtractionData, ExtractResult, LayoutBlock, LayoutDocument, LayoutPage } from './types.js';
 
 export { layoutToMarkdown } from './layout-to-markdown.js';
+export type {
+	ExtractRouteKind,
+	ExtractSourceRoute,
+	LayoutExtractRoute,
+	LayoutExtractSourceType,
+	PrestructuredExtractRoute,
+	PrestructuredExtractSourceType,
+} from './source-routing.js';
+export {
+	assertFallbackOnlySupported,
+	EXTRACT_LAYOUT_SOURCE_TYPES,
+	EXTRACT_PRESTRUCTURED_SOURCE_TYPES,
+	EXTRACT_SOURCE_TYPES,
+	isAcceptedExtractSourceType,
+	requireExtractRoute,
+	resolveExtractRoute,
+} from './source-routing.js';
 export type {
 	ExtractInput,
 	ExtractionData,
@@ -2109,6 +2127,7 @@ export async function execute(
 			context: { sourceId: input.sourceId },
 		});
 	}
+	const route = requireExtractRoute(source.sourceType, { sourceId: input.sourceId });
 
 	// 2. Validate status
 	const validStatuses = ['ingested', 'extracted', 'segmented', 'enriched', 'embedded', 'graphed', 'analyzed'];
@@ -2144,81 +2163,77 @@ export async function execute(
 	const errors: StepError[] = [];
 	let extractionData: ExtractionData;
 
-	// ── Path C: Fallback only ────────────────────────────
-	if (
-		(source.sourceType === 'text' ||
-			source.sourceType === 'docx' ||
-			source.sourceType === 'spreadsheet' ||
-			source.sourceType === 'email' ||
-			source.sourceType === 'url') &&
-		input.fallbackOnly
-	) {
-		throw new ExtractError(
-			`Source type "${source.sourceType}" does not support vision fallback`,
-			EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
-			{ context: { sourceId: input.sourceId, sourceType: source.sourceType } },
-		);
+	if (input.fallbackOnly) {
+		assertFallbackOnlySupported(route, { sourceId: input.sourceId });
 	}
 
-	if (!input.fallbackOnly && source.sourceType === 'text') {
-		extractionData = await extractTextSource({
-			sourceId: input.sourceId,
-			filename: source.filename,
-			storagePath: source.storagePath,
-			formatMetadata: source.formatMetadata,
-			config,
-			services,
-			pool,
-			stepConfigHash,
-			logger: log,
-		});
-	} else if (!input.fallbackOnly && source.sourceType === 'docx') {
-		extractionData = await extractDocxSource({
-			sourceId: input.sourceId,
-			filename: source.filename,
-			storagePath: source.storagePath,
-			config,
-			services,
-			pool,
-			stepConfigHash,
-			logger: log,
-		});
-	} else if (!input.fallbackOnly && source.sourceType === 'spreadsheet') {
-		extractionData = await extractSpreadsheetSource({
-			sourceId: input.sourceId,
-			filename: source.filename,
-			storagePath: source.storagePath,
-			formatMetadata: source.formatMetadata,
-			config,
-			services,
-			pool,
-			stepConfigHash,
-			logger: log,
-		});
-	} else if (!input.fallbackOnly && source.sourceType === 'email') {
-		extractionData = await extractEmailSource({
-			sourceId: input.sourceId,
-			filename: source.filename,
-			storagePath: source.storagePath,
-			formatMetadata: source.formatMetadata,
-			config,
-			services,
-			pool,
-			stepConfigHash,
-			logger: log,
-		});
-	} else if (!input.fallbackOnly && source.sourceType === 'url') {
-		extractionData = await extractUrlSource({
-			sourceId: input.sourceId,
-			filename: source.filename,
-			storagePath: source.storagePath,
-			formatMetadata: source.formatMetadata,
-			config,
-			services,
-			pool,
-			stepConfigHash,
-			logger: log,
-		});
+	if (!input.fallbackOnly && route.kind === 'prestructured') {
+		switch (route.sourceType) {
+			case 'text':
+				extractionData = await extractTextSource({
+					sourceId: input.sourceId,
+					filename: source.filename,
+					storagePath: source.storagePath,
+					formatMetadata: source.formatMetadata,
+					config,
+					services,
+					pool,
+					stepConfigHash,
+					logger: log,
+				});
+				break;
+			case 'docx':
+				extractionData = await extractDocxSource({
+					sourceId: input.sourceId,
+					filename: source.filename,
+					storagePath: source.storagePath,
+					config,
+					services,
+					pool,
+					stepConfigHash,
+					logger: log,
+				});
+				break;
+			case 'spreadsheet':
+				extractionData = await extractSpreadsheetSource({
+					sourceId: input.sourceId,
+					filename: source.filename,
+					storagePath: source.storagePath,
+					formatMetadata: source.formatMetadata,
+					config,
+					services,
+					pool,
+					stepConfigHash,
+					logger: log,
+				});
+				break;
+			case 'email':
+				extractionData = await extractEmailSource({
+					sourceId: input.sourceId,
+					filename: source.filename,
+					storagePath: source.storagePath,
+					formatMetadata: source.formatMetadata,
+					config,
+					services,
+					pool,
+					stepConfigHash,
+					logger: log,
+				});
+				break;
+			case 'url':
+				extractionData = await extractUrlSource({
+					sourceId: input.sourceId,
+					filename: source.filename,
+					storagePath: source.storagePath,
+					formatMetadata: source.formatMetadata,
+					config,
+					services,
+					pool,
+					stepConfigHash,
+					logger: log,
+				});
+				break;
+		}
 	} else if (input.fallbackOnly) {
 		log.info('Running vision fallback only on existing extraction');
 
@@ -2285,14 +2300,6 @@ export async function execute(
 		};
 	} else {
 		// ── Path A or B: Full extraction ────────────────────
-		if (source.sourceType !== 'pdf' && source.sourceType !== 'image') {
-			throw new ExtractError(
-				`Source type "${source.sourceType}" is not supported by the layout extract step`,
-				EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
-				{ context: { sourceId: input.sourceId, sourceType: source.sourceType } },
-			);
-		}
-
 		// 3. Download source original
 		const storagePath = source.storagePath;
 		let sourceBuffer: Buffer;

--- a/packages/pipeline/src/extract/source-routing.ts
+++ b/packages/pipeline/src/extract/source-routing.ts
@@ -1,0 +1,121 @@
+/**
+ * Source-type keyed routing for the extract step.
+ *
+ * The persisted `sources.source_type` value is the dispatch contract. Route
+ * local validation may still inspect media metadata or content bytes after a
+ * route is selected.
+ *
+ * @see docs/specs/95_format_aware_extract_routing.spec.md
+ */
+
+import type { SourceType } from '@mulder/core';
+import { EXTRACT_ERROR_CODES, ExtractError } from '@mulder/core';
+
+export type ExtractRouteKind = 'layout' | 'prestructured';
+
+export type LayoutExtractSourceType = Extract<SourceType, 'pdf' | 'image'>;
+export type PrestructuredExtractSourceType = Extract<SourceType, 'text' | 'docx' | 'spreadsheet' | 'email' | 'url'>;
+
+export interface LayoutExtractRoute {
+	sourceType: LayoutExtractSourceType;
+	kind: 'layout';
+	fallbackOnlySupported: true;
+}
+
+export interface PrestructuredExtractRoute {
+	sourceType: PrestructuredExtractSourceType;
+	kind: 'prestructured';
+	fallbackOnlySupported: false;
+}
+
+export type ExtractSourceRoute = LayoutExtractRoute | PrestructuredExtractRoute;
+
+export const EXTRACT_LAYOUT_SOURCE_TYPES: readonly SourceType[] = ['pdf', 'image'];
+
+export const EXTRACT_PRESTRUCTURED_SOURCE_TYPES: readonly SourceType[] = [
+	'text',
+	'docx',
+	'spreadsheet',
+	'email',
+	'url',
+];
+
+export const EXTRACT_SOURCE_TYPES: readonly SourceType[] = [
+	...EXTRACT_LAYOUT_SOURCE_TYPES,
+	...EXTRACT_PRESTRUCTURED_SOURCE_TYPES,
+];
+
+export function isAcceptedExtractSourceType(sourceType: string): sourceType is SourceType {
+	switch (sourceType) {
+		case 'pdf':
+		case 'image':
+		case 'text':
+		case 'docx':
+		case 'spreadsheet':
+		case 'email':
+		case 'url':
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function resolveExtractRoute(sourceType: SourceType): ExtractSourceRoute {
+	switch (sourceType) {
+		case 'pdf':
+		case 'image':
+			return {
+				sourceType,
+				kind: 'layout',
+				fallbackOnlySupported: true,
+			};
+		case 'text':
+		case 'docx':
+		case 'spreadsheet':
+		case 'email':
+		case 'url':
+			return {
+				sourceType,
+				kind: 'prestructured',
+				fallbackOnlySupported: false,
+			};
+	}
+}
+
+export function requireExtractRoute(sourceType: string, context: Record<string, unknown> = {}): ExtractSourceRoute {
+	if (isAcceptedExtractSourceType(sourceType)) {
+		return resolveExtractRoute(sourceType);
+	}
+
+	throw new ExtractError(
+		`Source type "${sourceType}" is not supported by extract`,
+		EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
+		{
+			context: {
+				...context,
+				sourceType,
+				acceptedSourceTypes: [...EXTRACT_SOURCE_TYPES],
+			},
+		},
+	);
+}
+
+export function assertFallbackOnlySupported(route: ExtractSourceRoute, context: Record<string, unknown> = {}): void {
+	if (route.fallbackOnlySupported) {
+		return;
+	}
+
+	throw new ExtractError(
+		`Source type "${route.sourceType}" does not support vision fallback`,
+		EXTRACT_ERROR_CODES.EXTRACT_INVALID_STATUS,
+		{
+			context: {
+				...context,
+				sourceType: route.sourceType,
+				routeKind: route.kind,
+				fallbackOnly: true,
+				fallbackOnlySupportedSourceTypes: [...EXTRACT_LAYOUT_SOURCE_TYPES],
+			},
+		},
+	);
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -65,11 +65,27 @@ export type {
 	ExtractionData,
 	ExtractionMethod,
 	ExtractResult,
+	ExtractRouteKind,
+	ExtractSourceRoute,
 	LayoutDocument,
+	LayoutExtractRoute,
+	LayoutExtractSourceType,
 	PageExtraction,
+	PrestructuredExtractRoute,
+	PrestructuredExtractSourceType,
 	PrimaryExtractionMethod,
 } from './extract/index.js';
-export { execute as executeExtract, layoutToMarkdown } from './extract/index.js';
+export {
+	assertFallbackOnlySupported,
+	EXTRACT_LAYOUT_SOURCE_TYPES,
+	EXTRACT_PRESTRUCTURED_SOURCE_TYPES,
+	EXTRACT_SOURCE_TYPES,
+	execute as executeExtract,
+	isAcceptedExtractSourceType,
+	layoutToMarkdown,
+	requireExtractRoute,
+	resolveExtractRoute,
+} from './extract/index.js';
 export type {
 	FixtureArtifact,
 	FixtureError,

--- a/tests/specs/95_format_aware_extract_routing.test.ts
+++ b/tests/specs/95_format_aware_extract_routing.test.ts
@@ -1,0 +1,287 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const PIPELINE_DIST = resolve(PIPELINE_DIR, 'dist/index.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const EXTRACTED_STORAGE_DIR = resolve(STORAGE_DIR, 'extracted');
+const SEGMENTS_STORAGE_DIR = resolve(STORAGE_DIR, 'segments');
+
+const PNG_BYTES = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+	'base64',
+);
+
+type ResolveExtractRoute = (sourceType: string) => {
+	sourceType: string;
+	kind: 'layout' | 'prestructured';
+	fallbackOnlySupported: boolean;
+};
+
+interface PipelinePublicApi {
+	resolveExtractRoute: ResolveExtractRoute;
+	EXTRACT_SOURCE_TYPES: readonly string[];
+}
+
+let tmpDir = '';
+let imageFile = '';
+let pipelineModule: PipelinePublicApi;
+let pgAvailable = false;
+let rawSnapshot: StorageSnapshot | null = null;
+let extractedSnapshot: StorageSnapshot | null = null;
+let segmentsSnapshot: StorageSnapshot | null = null;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 180_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_CONFIG: EXAMPLE_CONFIG,
+			MULDER_LOG_LEVEL: 'silent',
+			NODE_ENV: 'test',
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+		},
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM monthly_budget_reservations',
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM url_lifecycle',
+			'DELETE FROM url_host_lifecycle',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function resetStorage(): void {
+	for (const snapshot of [rawSnapshot, extractedSnapshot, segmentsSnapshot]) {
+		if (snapshot) {
+			cleanStorageDirSince(snapshot);
+		}
+	}
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function writeStoredObject(storagePath: string, content: Buffer | string): void {
+	const fullPath = resolve(STORAGE_DIR, storagePath);
+	mkdirSync(dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, content);
+}
+
+function sourceIdForFilename(filename: string): string {
+	return db.runSql(`SELECT id FROM sources WHERE filename = ${sqlLiteral(filename)} ORDER BY created_at DESC LIMIT 1;`);
+}
+
+function seedTextSource(filename = 'misleading.pdf'): string {
+	const sourceId = randomUUID();
+	const storagePath = `raw/${sourceId}/original.txt`;
+	const body = '# Routed Text Source\n\nThis source_type=text row must not enter the PDF layout path.\n';
+	writeStoredObject(storagePath, body);
+	const formatMetadata = {
+		media_type: 'text/plain',
+		encoding: 'utf-8',
+		line_count: 3,
+	};
+	db.runSql(
+		`INSERT INTO sources (id, filename, storage_path, file_hash, page_count, has_native_text, native_text_ratio, status, reliability_score, tags, metadata, source_type, format_metadata)
+		 VALUES (${sqlLiteral(sourceId)}, ${sqlLiteral(filename)}, ${sqlLiteral(storagePath)}, ${sqlLiteral(`spec-95-${sourceId}`)}, 0, false, 0, 'ingested', NULL, ARRAY[]::text[], '{}'::jsonb, 'text', ${sqlLiteral(JSON.stringify(formatMetadata))}::jsonb);`,
+	);
+	return sourceId;
+}
+
+function sourceStepStatus(sourceId: string, stepName: string): string {
+	return db.runSql(
+		`SELECT COALESCE((SELECT status::text FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = ${sqlLiteral(stepName)}), 'missing');`,
+	);
+}
+
+beforeAll(async () => {
+	process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+	process.env.MULDER_LOG_LEVEL = 'silent';
+	process.env.NODE_ENV = 'test';
+
+	tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-95-'));
+	imageFile = join(tmpDir, 'scan.png');
+	writeFileSync(imageFile, PNG_BYTES);
+
+	rawSnapshot = snapshotStorageDir(RAW_STORAGE_DIR);
+	extractedSnapshot = snapshotStorageDir(EXTRACTED_STORAGE_DIR);
+	segmentsSnapshot = snapshotStorageDir(SEGMENTS_STORAGE_DIR);
+
+	buildPackage(CORE_DIR);
+	buildPackage(PIPELINE_DIR);
+	buildPackage(CLI_DIR);
+	pipelineModule = (await import(pathToFileURL(PIPELINE_DIST).href)) as PipelinePublicApi;
+
+	pgAvailable = db.isPgAvailable();
+	if (pgAvailable) {
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode, `${migrate.stdout}\n${migrate.stderr}`).toBe(0);
+	}
+}, 600_000);
+
+beforeEach(() => {
+	if (!pgAvailable) return;
+	cleanState();
+	resetStorage();
+});
+
+afterAll(() => {
+	try {
+		if (pgAvailable) {
+			cleanState();
+			resetStorage();
+		}
+	} catch {
+		// Ignore cleanup failures.
+	}
+	if (tmpDir) {
+		rmSync(tmpDir, { recursive: true, force: true });
+	}
+});
+
+describe('Spec 95 - Format-aware extract routing', () => {
+	it('QA-01: public routing helper reports every M9 source type', () => {
+		expect([...pipelineModule.EXTRACT_SOURCE_TYPES].sort()).toEqual(
+			['docx', 'email', 'image', 'pdf', 'spreadsheet', 'text', 'url'].sort(),
+		);
+
+		for (const sourceType of ['pdf', 'image']) {
+			expect(pipelineModule.resolveExtractRoute(sourceType)).toMatchObject({
+				sourceType,
+				kind: 'layout',
+				fallbackOnlySupported: true,
+			});
+		}
+
+		for (const sourceType of ['text', 'docx', 'spreadsheet', 'email', 'url']) {
+			expect(pipelineModule.resolveExtractRoute(sourceType)).toMatchObject({
+				sourceType,
+				kind: 'prestructured',
+				fallbackOnlySupported: false,
+			});
+		}
+	});
+
+	it('QA-02: fallback-only is rejected for pre-structured sources without artifacts', () => {
+		if (!pgAvailable) return;
+		const sourceId = seedTextSource();
+
+		const result = runCli(['extract', sourceId, '--fallback-only']);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(/does not support vision fallback/i);
+
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('0');
+		expect(sourceStepStatus(sourceId, 'extract')).toBe('missing');
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(false);
+	});
+
+	it('QA-03: source_type controls text extraction even when the filename is misleading', () => {
+		if (!pgAvailable) return;
+		const sourceId = seedTextSource('misleading.pdf');
+
+		const result = runCli(['extract', sourceId]);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('extracted');
+		expect(sourceStepStatus(sourceId, 'extract')).toBe('completed');
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(false);
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/pages/page-001.png`))).toBe(false);
+
+		const storyRow = db.runSql(
+			`SELECT id, gcs_markdown_uri, gcs_metadata_uri FROM stories WHERE source_id = ${sqlLiteral(sourceId)} LIMIT 1;`,
+		);
+		const [storyId, markdownUri, metadataUri] = storyRow.split('|');
+		expect(markdownUri).toBe(`segments/${sourceId}/${storyId}.md`);
+		expect(metadataUri).toBe(`segments/${sourceId}/${storyId}.meta.json`);
+		expect(readFileSync(resolve(STORAGE_DIR, markdownUri), 'utf-8')).toContain('Routed Text Source');
+		expect(JSON.parse(readFileSync(resolve(STORAGE_DIR, metadataUri), 'utf-8'))).toMatchObject({
+			document_id: sourceId,
+			source_type: 'text',
+		});
+	});
+
+	it('QA-04: layout sources stay on the layout path', () => {
+		if (!pgAvailable) return;
+		const ingest = runCli(['ingest', imageFile]);
+		expect(ingest.exitCode, `${ingest.stdout}\n${ingest.stderr}`).toBe(0);
+		const sourceId = sourceIdForFilename(basename(imageFile));
+
+		const extract = runCli(['extract', sourceId], { timeout: 180_000 });
+		expect(extract.exitCode, `${extract.stdout}\n${extract.stderr}`).toBe(0);
+
+		expect(db.runSql(`SELECT source_type::text, status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe(
+			'image|extracted',
+		);
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(true);
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/pages/page-001.png`))).toBe(true);
+		expect(sourceStepStatus(sourceId, 'segment')).toBe('missing');
+	});
+
+	it('QA-05: extract --all dispatches mixed layout and pre-structured sources independently', () => {
+		if (!pgAvailable) return;
+		const textSourceId = seedTextSource('mixed-note.pdf');
+		const imageIngest = runCli(['ingest', imageFile]);
+		expect(imageIngest.exitCode, `${imageIngest.stdout}\n${imageIngest.stderr}`).toBe(0);
+		const imageSourceId = sourceIdForFilename(basename(imageFile));
+
+		const extractAll = runCli(['extract', '--all'], { timeout: 240_000 });
+		expect(extractAll.exitCode, `${extractAll.stdout}\n${extractAll.stderr}`).toBe(0);
+
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(textSourceId)};`)).toBe('extracted');
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(imageSourceId)};`)).toBe('extracted');
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(textSourceId)};`)).toBe('1');
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${textSourceId}/layout.json`))).toBe(false);
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${imageSourceId}/layout.json`))).toBe(true);
+	});
+});

--- a/tests/specs/95_format_aware_extract_routing.test.ts
+++ b/tests/specs/95_format_aware_extract_routing.test.ts
@@ -225,6 +225,34 @@ describe('Spec 95 - Format-aware extract routing', () => {
 		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(false);
 	});
 
+	it('QA-02 regression: pre-structured --force --fallback-only fails before cleanup', () => {
+		if (!pgAvailable) return;
+		const sourceId = seedTextSource('force-fallback-note.txt');
+		const extract = runCli(['extract', sourceId]);
+		expect(extract.exitCode, `${extract.stdout}\n${extract.stderr}`).toBe(0);
+
+		const storyRow = db.runSql(
+			`SELECT id, gcs_markdown_uri, gcs_metadata_uri FROM stories WHERE source_id = ${sqlLiteral(sourceId)} LIMIT 1;`,
+		);
+		const [storyId, markdownUri, metadataUri] = storyRow.split('|');
+		const markdownBefore = readFileSync(resolve(STORAGE_DIR, markdownUri), 'utf-8');
+
+		const result = runCli(['extract', sourceId, '--force', '--fallback-only']);
+		expect(result.exitCode, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(/does not support vision fallback/i);
+
+		expect(db.runSql(`SELECT status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe('extracted');
+		expect(sourceStepStatus(sourceId, 'extract')).toBe('completed');
+		expect(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('1');
+		expect(
+			db.runSql(`SELECT id FROM stories WHERE source_id = ${sqlLiteral(sourceId)} ORDER BY created_at DESC LIMIT 1;`),
+		).toBe(storyId);
+		expect(existsSync(resolve(STORAGE_DIR, markdownUri))).toBe(true);
+		expect(existsSync(resolve(STORAGE_DIR, metadataUri))).toBe(true);
+		expect(readFileSync(resolve(STORAGE_DIR, markdownUri), 'utf-8')).toBe(markdownBefore);
+		expect(existsSync(resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`))).toBe(false);
+	});
+
 	it('QA-03: source_type controls text extraction even when the filename is misleading', () => {
 		if (!pgAvailable) return;
 		const sourceId = seedTextSource('misleading.pdf');


### PR DESCRIPTION
## Summary
- adds Spec 95 for M9-J11 and marks the roadmap step in progress
- adds an explicit source_type keyed extract routing helper and public exports
- routes layout vs pre-structured extraction through the shared routing contract
- adds black-box coverage for routing exports, fallback-only rejection, misleading filenames, layout sources, and extract --all mixed dispatch

## Verification
- pnpm exec vitest run tests/specs/95_format_aware_extract_routing.test.ts --reporter=verbose
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm exec vitest run tests/specs/86_pipeline_step_skipping_prestructured_sources.test.ts tests/specs/87_image_ingestion_layout_path.test.ts tests/specs/88_plain_text_ingestion_prestructured_path.test.ts tests/specs/89_docx_ingestion_prestructured_path.test.ts tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts tests/specs/91_email_ingestion_prestructured_path.test.ts tests/specs/92_url_ingestion_prestructured_path.test.ts tests/specs/93_url_rendering_playwright_fallback.test.ts tests/specs/94_url_lifecycle_refetch.test.ts tests/specs/95_format_aware_extract_routing.test.ts

Spec: docs/specs/95_format_aware_extract_routing.spec.md
Roadmap: M9-J11

Closes #254