### PR TITLE
[Pipeline] Multi-format golden tests — M9-J13

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -263,7 +263,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
 | 🟢 | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | 🟢 | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
-| 🟡 | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
+| 🟢 | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
 
 **Also read for all M9 steps:** §2 (global step conventions), §3 (pipeline orchestration — step skipping), §4.5 (service abstraction — format extractors follow same interface pattern)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -263,7 +263,7 @@ Images, Office docs, emails, URLs — every format converges to the same Markdow
 | 🟢 | J10 | URL lifecycle — `robots.txt` respect, rate limiting, freshness tracking, re-fetch support | §2.1 |
 | 🟢 | J11 | Format-aware extract routing — dispatch to correct extractor by `source_type` | §2.2 |
 | 🟢 | J12 | Cross-format dedup — early dedup at ingest (title/hash matching) before graph-level MinHash | §2.7 |
-| ⚪ | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
+| 🟡 | J13 | Golden tests: multi-format — one fixture per format, Vitest assertions | §15.1, §15.2 |
 
 **Also read for all M9 steps:** §2 (global step conventions), §3 (pipeline orchestration — step skipping), §4.5 (service abstraction — format extractors follow same interface pattern)
 

--- a/docs/specs/97_multi_format_golden_tests.spec.md
+++ b/docs/specs/97_multi_format_golden_tests.spec.md
@@ -1,0 +1,144 @@
+---
+spec: "97"
+title: "Multi-Format Golden Tests"
+roadmap_step: M9-J13
+functional_spec: ["§15.1", "§15.2", "§2", "§3", "§4.5"]
+scope: single
+issue: "https://github.com/mulkatz/mulder/issues/258"
+created: 2026-05-04
+---
+
+# Spec 97: Multi-Format Golden Tests
+
+## 1. Objective
+
+Complete M9-J13 by adding a deterministic multi-format golden test layer for the completed M9 ingest and extract surface. The milestone goal is not another extractor rewrite; it is a black-box confidence net proving that PDF, image, text/Markdown, DOCX, spreadsheet, email, and URL sources all enter the same source/story/status model and that downstream pipeline rules stay format-agnostic.
+
+This fulfills functional spec §15.1 by adding a manually curated golden fixture set and §15.2 by asserting step-level quality signals that are observable in the local test harness: source type classification, story creation, route behavior, segment skipping, and duplicate handling. It also protects the M9 shared contracts from §2, §3, and §4.5: extractors stay behind service abstractions, pre-structured sources bypass segment, and no format-specific path should leak into downstream story semantics.
+
+## 2. Boundaries
+
+**Roadmap step:** M9-J13 - Golden tests: multi-format - one fixture per format, Vitest assertions.
+
+**Base branch:** `milestone/9`. This spec is delivered to the M9 integration branch, not directly to `main`.
+
+**Target branch:** `feat/258-multi-format-golden-tests`.
+
+**Target files:**
+
+- `eval/golden/multi-format/manifest.json`
+- `eval/golden/README.md`
+- `tests/specs/97_multi_format_golden_tests.test.ts`
+- Optional test-local helper files under `tests/lib/` if the implementation would otherwise duplicate large fixture builders
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Add a committed golden manifest with one deterministic case for each supported M9 source type: `pdf`, `image`, `text`, `docx`, `spreadsheet`, `email`, and `url`.
+- Let the test harness materialize binary or server-backed fixtures from the manifest when committing raw binary files would add noise.
+- Run black-box CLI/database/storage assertions for ingest and extract behavior.
+- Verify that layout-capable sources (`pdf`, `image`) and pre-structured sources (`text`, `docx`, `spreadsheet`, `email`, `url`) both create stories with stable metadata shape.
+- Verify that pre-structured sources record segment skipping after pipeline/extract orchestration while layout sources remain on the layout path.
+- Include a Spec 96 duplicate scenario for a cheap strong-signal pair so obvious cross-format duplicates do not inflate the source set.
+- Re-run the relevant M9 regression matrix.
+
+**Out of scope:**
+
+- New source formats.
+- New paid service calls, live GCP fixtures, or model-generated golden annotations.
+- Changing production extraction behavior solely to make tests pass.
+- Forcing PDF/DOCX ingest-time source collapse. Spec 96 intentionally keeps early dedup conservative for sources without a cheap ingest-time text signal; graph-level MinHash remains responsible for later PDF/DOCX equivalence.
+- Adding or changing `mulder eval` CLI behavior.
+
+## 3. Dependencies
+
+- M9-J1 / Spec 85: first-class `source_type` and `format_metadata`.
+- M9-J2 / Spec 86: pipeline step skipping for pre-structured sources.
+- M9-J3 through M9-J10: all M9 formats have ingest/extract paths.
+- M9-J11 / Spec 95: extract routing by `source_type`.
+- M9-J12 / Spec 96: conservative cross-format ingest dedup for cheap strong signals.
+- Existing eval package and golden directory from Specs 21 and 31.
+
+This spec is the final M9 task and blocks the milestone-level review/merge to `main`.
+
+## 4. Blueprint
+
+1. Add `eval/golden/multi-format/manifest.json`.
+   - Each entry should include `id`, `source_type`, `fixture_kind`, expected filename/source type, expected story count minimum, expected route kind, and expected stable metadata keys.
+   - Manifest entries may reference existing committed fixtures such as `fixtures/raw/native-text-sample.pdf` or define deterministic fixture content that the test materializes into a temporary directory.
+2. Update `eval/golden/README.md` with the multi-format manifest purpose and annotation rules.
+3. Add `tests/specs/97_multi_format_golden_tests.test.ts`.
+   - Build required packages once.
+   - Migrate the test database when PostgreSQL is available.
+   - Start a local HTTP server for the URL fixture and run that CLI case asynchronously so the server can respond.
+   - Materialize DOCX/XLSX/email/text/image fixtures deterministically in a temp directory.
+   - Clean `sources`, related pipeline/story tables, URL lifecycle tables, and storage snapshots between cases.
+4. Test the golden manifest structure without importing private implementation code.
+5. Test ingest/extract for each manifest entry through `node apps/cli/dist/index.js`.
+6. Assert converged story contracts:
+   - `sources.source_type` equals the manifest source type
+   - at least one `stories` row exists after extract or pipeline
+   - story metadata includes `source_type`
+   - pre-structured sources do not create layout JSON as their primary route
+   - layout sources create layout artifacts
+7. Test the duplicate scenario with a text/Markdown or Markdown/URL pair whose normalized content key is identical.
+8. Run the relevant M9 regression suite.
+
+No database migration or config change is required.
+
+## 5. QA Contract
+
+1. **QA-01: Multi-format golden manifest exists**
+   - Given: the repository is checked out
+   - When: `eval/golden/multi-format/manifest.json` is read
+   - Then: it is valid JSON and contains exactly one primary case for each source type: `pdf`, `image`, `text`, `docx`, `spreadsheet`, `email`, and `url`.
+
+2. **QA-02: Manifest entries are complete**
+   - Given: the manifest entries
+   - When: each entry is validated
+   - Then: each entry has `id`, `source_type`, `fixture_kind`, `expected_filename`, `expected_route`, `expected_story_min`, and `expected_metadata_keys`.
+
+3. **QA-03: Ingest classifies every golden fixture**
+   - Given: each manifest fixture materialized locally
+   - When: `mulder ingest <fixture>` runs
+   - Then: the command exits 0, creates one source row, and persists the manifest source type and required metadata keys.
+
+4. **QA-04: Extract converges every format to stories**
+   - Given: each golden fixture has been ingested
+   - When: `mulder extract <source-id>` runs
+   - Then: at least the manifest minimum story count exists, each story has Markdown and metadata storage URIs, and story metadata includes the source type.
+
+5. **QA-05: Route artifacts match layout versus pre-structured expectations**
+   - Given: extracted golden sources
+   - When: storage and source steps are inspected
+   - Then: `pdf` and `image` sources have layout artifacts, while `text`, `docx`, `spreadsheet`, `email`, and `url` sources do not create a route-primary layout JSON and are eligible for segment skipping.
+
+6. **QA-06: Pipeline orchestration skips segment for pre-structured formats**
+   - Given: at least one pre-structured golden source
+   - When: `mulder pipeline run <fixture>` runs
+   - Then: the source reaches extracted/enriched pipeline flow with `segment` recorded as skipped.
+
+7. **QA-07: Cross-format duplicate golden case does not inflate source set**
+   - Given: two manifest-backed fixtures with the same strong normalized cheap content signal
+   - When: they are ingested sequentially
+   - Then: the second ingest reports a duplicate and only one source row exists for that content.
+
+8. **QA-08: M9 regression suite remains green**
+   - Given: existing M9 spec tests
+   - When: the relevant M9 regression matrix is run
+   - Then: all previously green ingest/extract/routing/dedup behavior remains green.
+
+## 5b. CLI Test Matrix
+
+This step does not add a new command, but it exercises existing CLI behavior.
+
+| Command | Expected |
+| --- | --- |
+| `mulder ingest <golden-fixture>` | exits 0 and persists the expected source type |
+| `mulder extract <source-id>` | creates story Markdown and metadata for every source type |
+| `mulder pipeline run <prestructured-fixture>` | records segment as skipped |
+| `mulder ingest <duplicate-a>` then `mulder ingest <duplicate-b>` | second ingest reports duplicate and source count stays stable |
+
+## 6. Cost Considerations
+
+All fixtures must run with local/dev services. Do not add live Document AI, Gemini, Playwright-only, embedding, or other paid service calls solely for this golden test. URL tests may use a local HTTP server with unsafe URL override enabled only under `NODE_ENV=test`.

--- a/eval/golden/README.md
+++ b/eval/golden/README.md
@@ -8,8 +8,48 @@ Ground-truth annotations for evaluating pipeline quality. Each JSON file in a su
 - `segmentation/` — Ground truth for segment boundaries (Boundary Accuracy, Segment Count)
 - `entities/` — Ground truth for entity extraction (Precision/Recall/F1 per type)
 - `retrieval/` — Ground truth for hybrid retrieval (Precision@k, Recall@k, MRR, nDCG@10)
+- `multi-format/` — Deterministic M9 black-box manifest for source type, route, story, skip, and duplicate contracts
 
 ## Annotation Formats
+
+### Multi-Format (`multi-format/manifest.json`)
+
+The multi-format manifest is not model output annotation. It is a curated
+fixture index used by the Spec 97 Vitest harness to prove every supported M9
+source type enters the same source/story/status model.
+
+```json
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "string — stable case identifier",
+      "source_type": "pdf | image | text | docx | spreadsheet | email | url",
+      "fixture_kind": "committed_file | generated_png | generated_markdown | generated_docx | generated_xlsx | generated_eml | local_http_url",
+      "fixture_ref": "string (optional) — committed path or local HTTP route",
+      "expected_filename": "string — filename persisted by ingest",
+      "expected_route": "layout | prestructured",
+      "expected_story_min": "number — minimum story rows after extract",
+      "expected_metadata_keys": ["format_metadata keys required on sources"]
+    }
+  ],
+  "duplicate_scenario": {
+    "id": "string — stable duplicate case identifier",
+    "first": { "fixture_kind": "string", "expected_filename": "string" },
+    "second": { "fixture_kind": "string", "expected_filename": "string" },
+    "expected_source_type": "text",
+    "expected_duplicate_basis": "text_content"
+  }
+}
+```
+
+Rules:
+
+1. Keep exactly one primary case per supported M9 source type.
+2. Prefer deterministic generated fixtures for DOCX, XLSX, email, text, image, and local URL cases.
+3. Reuse committed PDFs when they already exercise the layout path.
+4. Do not commit binary golden files solely for this manifest unless a future spec explicitly requires them.
+5. Expected metadata keys should be stable contract keys, not incidental parser diagnostics.
 
 ### Extraction (`extraction/*.json`)
 

--- a/eval/golden/multi-format/manifest.json
+++ b/eval/golden/multi-format/manifest.json
@@ -1,0 +1,84 @@
+{
+	"schema_version": 1,
+	"description": "Spec 97 deterministic multi-format golden cases for M9 ingest/extract convergence.",
+	"cases": [
+		{
+			"id": "golden-pdf-native-text",
+			"source_type": "pdf",
+			"fixture_kind": "committed_file",
+			"fixture_ref": "fixtures/raw/native-text-sample.pdf",
+			"expected_filename": "native-text-sample.pdf",
+			"expected_route": "layout",
+			"expected_story_min": 1,
+			"expected_metadata_keys": []
+		},
+		{
+			"id": "golden-image-png",
+			"source_type": "image",
+			"fixture_kind": "generated_png",
+			"expected_filename": "golden-scan.png",
+			"expected_route": "layout",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["media_type", "width", "height"]
+		},
+		{
+			"id": "golden-text-markdown",
+			"source_type": "text",
+			"fixture_kind": "generated_markdown",
+			"expected_filename": "golden-note.md",
+			"expected_route": "prestructured",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["media_type", "encoding", "line_count"]
+		},
+		{
+			"id": "golden-docx-brief",
+			"source_type": "docx",
+			"fixture_kind": "generated_docx",
+			"expected_filename": "golden-brief.docx",
+			"expected_route": "prestructured",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["media_type", "office_format", "container", "extraction_engine"]
+		},
+		{
+			"id": "golden-spreadsheet-xlsx",
+			"source_type": "spreadsheet",
+			"fixture_kind": "generated_xlsx",
+			"expected_filename": "golden-ledger.xlsx",
+			"expected_route": "prestructured",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["media_type", "tabular_format", "container", "sheet_count", "sheet_names"]
+		},
+		{
+			"id": "golden-email-eml",
+			"source_type": "email",
+			"fixture_kind": "generated_eml",
+			"expected_filename": "golden-message.eml",
+			"expected_route": "prestructured",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["media_type", "email_format", "message_id", "subject"]
+		},
+		{
+			"id": "golden-url-local-article",
+			"source_type": "url",
+			"fixture_kind": "local_http_url",
+			"fixture_ref": "/golden-url-article",
+			"expected_filename": "spec-97-golden-url-127-0-0-1.html",
+			"expected_route": "prestructured",
+			"expected_story_min": 1,
+			"expected_metadata_keys": ["original_url", "final_url", "http_status", "robots_allowed", "parser_engine"]
+		}
+	],
+	"duplicate_scenario": {
+		"id": "golden-markdown-text-duplicate",
+		"first": {
+			"fixture_kind": "generated_markdown",
+			"expected_filename": "duplicate-report.md"
+		},
+		"second": {
+			"fixture_kind": "generated_text",
+			"expected_filename": "duplicate-report.txt"
+		},
+		"expected_source_type": "text",
+		"expected_duplicate_basis": "text_content"
+	}
+}

--- a/packages/pipeline/src/segment/index.ts
+++ b/packages/pipeline/src/segment/index.ts
@@ -106,6 +106,7 @@ async function loadPageImages(
 interface SegmentMetadataJson {
 	id: string;
 	document_id: string;
+	source_type: string;
 	title: string;
 	subtitle: string | null;
 	language: string;
@@ -119,6 +120,7 @@ interface SegmentMetadataJson {
 function buildSegmentMetadata(
 	storyId: string,
 	sourceId: string,
+	sourceType: string,
 	story: {
 		title: string;
 		subtitle: string | null;
@@ -139,6 +141,7 @@ function buildSegmentMetadata(
 	return {
 		id: storyId,
 		document_id: sourceId,
+		source_type: sourceType,
 		title: story.title,
 		subtitle: story.subtitle,
 		language: story.language,
@@ -332,7 +335,7 @@ export async function execute(
 		const storyId = randomUUID();
 
 		// Build metadata JSON
-		const metadata = buildSegmentMetadata(storyId, input.sourceId, story);
+		const metadata = buildSegmentMetadata(storyId, input.sourceId, source.sourceType, story);
 
 		const markdownUri = `segments/${input.sourceId}/${storyId}.md`;
 		const metadataUri = `segments/${input.sourceId}/${storyId}.meta.json`;
@@ -377,6 +380,7 @@ export async function execute(
 			gcsMetadataUri: metadataUri,
 			extractionConfidence: story.confidence,
 			metadata: {
+				source_type: source.sourceType,
 				dateReferences: story.date_references,
 				geographicReferences: story.geographic_references,
 			},

--- a/tests/lib/multi-format-fixtures.ts
+++ b/tests/lib/multi-format-fixtures.ts
@@ -1,0 +1,227 @@
+const CRC_TABLE = new Uint32Array(256);
+for (let n = 0; n < 256; n += 1) {
+	let c = n;
+	for (let k = 0; k < 8; k += 1) {
+		c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+	}
+	CRC_TABLE[n] = c >>> 0;
+}
+
+export const PNG_BYTES = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+	'base64',
+);
+
+function crc32(buffer: Buffer): number {
+	let crc = 0xffffffff;
+	for (const byte of buffer) {
+		crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+	}
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createZip(entries: Array<{ name: string; data: Buffer | string }>): Buffer {
+	const localParts: Buffer[] = [];
+	const centralParts: Buffer[] = [];
+	let offset = 0;
+
+	for (const entry of entries) {
+		const name = Buffer.from(entry.name, 'utf-8');
+		const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, 'utf-8');
+		const checksum = crc32(data);
+		const localHeader = Buffer.alloc(30);
+		localHeader.writeUInt32LE(0x04034b50, 0);
+		localHeader.writeUInt16LE(20, 4);
+		localHeader.writeUInt16LE(0, 6);
+		localHeader.writeUInt16LE(0, 8);
+		localHeader.writeUInt16LE(0, 10);
+		localHeader.writeUInt16LE(0x21, 12);
+		localHeader.writeUInt32LE(checksum, 14);
+		localHeader.writeUInt32LE(data.length, 18);
+		localHeader.writeUInt32LE(data.length, 22);
+		localHeader.writeUInt16LE(name.length, 26);
+		localHeader.writeUInt16LE(0, 28);
+		localParts.push(localHeader, name, data);
+
+		const centralHeader = Buffer.alloc(46);
+		centralHeader.writeUInt32LE(0x02014b50, 0);
+		centralHeader.writeUInt16LE(20, 4);
+		centralHeader.writeUInt16LE(20, 6);
+		centralHeader.writeUInt16LE(0, 8);
+		centralHeader.writeUInt16LE(0, 10);
+		centralHeader.writeUInt16LE(0, 12);
+		centralHeader.writeUInt16LE(0x21, 14);
+		centralHeader.writeUInt32LE(checksum, 16);
+		centralHeader.writeUInt32LE(data.length, 20);
+		centralHeader.writeUInt32LE(data.length, 24);
+		centralHeader.writeUInt16LE(name.length, 28);
+		centralHeader.writeUInt16LE(0, 30);
+		centralHeader.writeUInt16LE(0, 32);
+		centralHeader.writeUInt16LE(0, 34);
+		centralHeader.writeUInt16LE(0, 36);
+		centralHeader.writeUInt32LE(0, 38);
+		centralHeader.writeUInt32LE(offset, 42);
+		centralParts.push(centralHeader, name);
+
+		offset += localHeader.length + name.length + data.length;
+	}
+
+	const centralDirectory = Buffer.concat(centralParts);
+	const end = Buffer.alloc(22);
+	end.writeUInt32LE(0x06054b50, 0);
+	end.writeUInt16LE(0, 4);
+	end.writeUInt16LE(0, 6);
+	end.writeUInt16LE(entries.length, 8);
+	end.writeUInt16LE(entries.length, 10);
+	end.writeUInt32LE(centralDirectory.length, 12);
+	end.writeUInt32LE(offset, 16);
+	end.writeUInt16LE(0, 20);
+
+	return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+function xmlEscape(value: string): string {
+	return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+}
+
+function columnName(index: number): string {
+	let name = '';
+	let value = index + 1;
+	while (value > 0) {
+		const remainder = (value - 1) % 26;
+		name = String.fromCharCode(65 + remainder) + name;
+		value = Math.floor((value - 1) / 26);
+	}
+	return name;
+}
+
+function worksheetXml(rows: string[][]): string {
+	const xmlRows = rows
+		.map((row, rowIndex) => {
+			const rowNumber = rowIndex + 1;
+			const cells = row
+				.map((value, columnIndex) => {
+					const ref = `${columnName(columnIndex)}${rowNumber}`;
+					return `<c r="${ref}" t="inlineStr"><is><t>${xmlEscape(value)}</t></is></c>`;
+				})
+				.join('');
+			return `<row r="${rowNumber}">${cells}</row>`;
+		})
+		.join('');
+	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>${xmlRows}</sheetData></worksheet>`;
+}
+
+export function createDocxBuffer(title: string, body: string): Buffer {
+	const heading = xmlEscape(title);
+	const paragraph = xmlEscape(body);
+	return createZip([
+		{
+			name: '[Content_Types].xml',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`,
+		},
+		{
+			name: '_rels/.rels',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`,
+		},
+		{
+			name: 'word/_rels/document.xml.rels',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>`,
+		},
+		{
+			name: 'word/styles.xml',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/></w:style>
+</w:styles>`,
+		},
+		{
+			name: 'word/document.xml',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>${heading}</w:t></w:r></w:p>
+    <w:p><w:r><w:t>${paragraph}</w:t></w:r></w:p>
+  </w:body>
+</w:document>`,
+		},
+	]);
+}
+
+export function createXlsxBuffer(sheets: Array<{ name: string; rows: string[][] }>): Buffer {
+	const sheetOverrides = sheets
+		.map(
+			(_sheet, index) =>
+				`<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`,
+		)
+		.join('');
+	const workbookSheets = sheets
+		.map((sheet, index) => `<sheet name="${xmlEscape(sheet.name)}" sheetId="${index + 1}" r:id="rId${index + 1}"/>`)
+		.join('');
+	const workbookRels = sheets
+		.map(
+			(_sheet, index) =>
+				`<Relationship Id="rId${index + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${index + 1}.xml"/>`,
+		)
+		.join('');
+	return createZip([
+		{
+			name: '[Content_Types].xml',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  ${sheetOverrides}
+</Types>`,
+		},
+		{
+			name: '_rels/.rels',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`,
+		},
+		{
+			name: 'xl/workbook.xml',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets>${workbookSheets}</sheets></workbook>`,
+		},
+		{
+			name: 'xl/_rels/workbook.xml.rels',
+			data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${workbookRels}</Relationships>`,
+		},
+		...sheets.map((sheet, index) => ({
+			name: `xl/worksheets/sheet${index + 1}.xml`,
+			data: worksheetXml(sheet.rows),
+		})),
+	]);
+}
+
+export function createEmlContent(input: { messageId: string; subject: string; body: string }): string {
+	return [
+		'From: Golden Sender <sender@example.com>',
+		'To: Golden Recipient <recipient@example.com>',
+		'Date: Fri, 01 May 2026 10:00:00 +0000',
+		`Message-ID: <${input.messageId}>`,
+		`Subject: ${input.subject}`,
+		'MIME-Version: 1.0',
+		'Content-Type: text/plain; charset="utf-8"',
+		'',
+		input.body,
+		'',
+	].join('\r\n');
+}

--- a/tests/specs/97_multi_format_golden_tests.test.ts
+++ b/tests/specs/97_multi_format_golden_tests.test.ts
@@ -1,0 +1,520 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { createDocxBuffer, createEmlContent, createXlsxBuffer, PNG_BYTES } from '../lib/multi-format-fixtures.js';
+import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir } from '../lib/storage.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+const MANIFEST_PATH = resolve(ROOT, 'eval/golden/multi-format/manifest.json');
+const STORAGE_DIR = resolve(ROOT, '.local/storage');
+const RAW_STORAGE_DIR = resolve(STORAGE_DIR, 'raw');
+const EXTRACTED_STORAGE_DIR = resolve(STORAGE_DIR, 'extracted');
+const SEGMENTS_STORAGE_DIR = resolve(STORAGE_DIR, 'segments');
+
+type SourceType = 'pdf' | 'image' | 'text' | 'docx' | 'spreadsheet' | 'email' | 'url';
+type FixtureKind =
+	| 'committed_file'
+	| 'generated_png'
+	| 'generated_markdown'
+	| 'generated_docx'
+	| 'generated_xlsx'
+	| 'generated_eml'
+	| 'generated_text'
+	| 'local_http_url';
+type ExpectedRoute = 'layout' | 'prestructured';
+
+interface ManifestCase {
+	id: string;
+	source_type: SourceType;
+	fixture_kind: FixtureKind;
+	fixture_ref?: string;
+	expected_filename: string;
+	expected_route: ExpectedRoute;
+	expected_story_min: number;
+	expected_metadata_keys: string[];
+}
+
+interface DuplicateManifestFixture {
+	fixture_kind: FixtureKind;
+	expected_filename: string;
+}
+
+interface MultiFormatManifest {
+	schema_version: number;
+	cases: ManifestCase[];
+	duplicate_scenario: {
+		id: string;
+		first: DuplicateManifestFixture;
+		second: DuplicateManifestFixture;
+		expected_source_type: SourceType;
+		expected_duplicate_basis: string;
+	};
+}
+
+const SOURCE_TYPES: SourceType[] = ['pdf', 'image', 'text', 'docx', 'spreadsheet', 'email', 'url'];
+
+let tmpDir = '';
+let server: Server | null = null;
+let baseUrl = '';
+let pgAvailable = false;
+let rawSnapshot: StorageSnapshot | null = null;
+let extractedSnapshot: StorageSnapshot | null = null;
+let segmentsSnapshot: StorageSnapshot | null = null;
+
+function readManifest(): MultiFormatManifest {
+	return JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8')) as MultiFormatManifest;
+}
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(
+			`Build failed in ${packageDir}:\n${result.stdout?.toString() ?? ''}\n${result.stderr?.toString() ?? ''}`,
+		);
+	}
+}
+
+function cliEnv(): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		MULDER_CONFIG: EXAMPLE_CONFIG,
+		MULDER_LOG_LEVEL: 'silent',
+		MULDER_ALLOW_UNSAFE_URLS_FOR_TESTS: 'true',
+		MULDER_URL_POLITENESS_DELAY_MS: '0',
+		NODE_ENV: 'test',
+		PGPASSWORD: db.TEST_PG_PASSWORD,
+	};
+}
+
+function runCli(args: string[], opts?: { timeout?: number }): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 180_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: cliEnv(),
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+async function runCliAsync(
+	args: string[],
+	opts?: { timeout?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	return await new Promise((resolveCli) => {
+		const child = spawn('node', [CLI_DIST, ...args], {
+			cwd: ROOT,
+			stdio: ['ignore', 'pipe', 'pipe'],
+			env: cliEnv(),
+		});
+		let stdout = '';
+		let stderr = '';
+		const timeout = setTimeout(() => {
+			child.kill('SIGTERM');
+		}, opts?.timeout ?? 180_000);
+		child.stdout.setEncoding('utf-8');
+		child.stderr.setEncoding('utf-8');
+		child.stdout.on('data', (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr.on('data', (chunk: string) => {
+			stderr += chunk;
+		});
+		child.on('close', (code) => {
+			clearTimeout(timeout);
+			resolveCli({ stdout, stderr, exitCode: code ?? 1 });
+		});
+	});
+}
+
+function combinedOutput(result: { stdout: string; stderr: string }): string {
+	return `${result.stdout}\n${result.stderr}`;
+}
+
+function cleanState(): void {
+	db.runSql(
+		[
+			'DELETE FROM monthly_budget_reservations',
+			'DELETE FROM jobs',
+			'DELETE FROM pipeline_run_sources',
+			'DELETE FROM pipeline_runs',
+			'DELETE FROM url_lifecycle',
+			'DELETE FROM url_host_lifecycle',
+			'DELETE FROM source_steps',
+			'DELETE FROM chunks',
+			'DELETE FROM story_entities',
+			'DELETE FROM entity_edges',
+			'DELETE FROM entity_aliases',
+			'DELETE FROM entities',
+			'DELETE FROM stories',
+			'DELETE FROM sources',
+		].join('; '),
+	);
+}
+
+function resetStorage(): void {
+	for (const snapshot of [rawSnapshot, extractedSnapshot, segmentsSnapshot]) {
+		if (snapshot) {
+			cleanStorageDirSince(snapshot);
+		}
+	}
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function writeFixture(relativePath: string, content: Buffer | string): string {
+	const filePath = join(tmpDir, relativePath);
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, content);
+	return filePath;
+}
+
+function sourceIdForFilename(filename: string): string {
+	return db.runSql(`SELECT id FROM sources WHERE filename = ${sqlLiteral(filename)} ORDER BY created_at DESC LIMIT 1;`);
+}
+
+function sourceIdForCase(testCase: ManifestCase): string {
+	if (testCase.source_type === 'url') {
+		return db.runSql("SELECT id FROM sources WHERE source_type = 'url' ORDER BY created_at DESC LIMIT 1;");
+	}
+	return sourceIdForFilename(testCase.expected_filename);
+}
+
+function materializeFixture(testCase: ManifestCase): string {
+	switch (testCase.fixture_kind) {
+		case 'committed_file':
+			if (!testCase.fixture_ref) {
+				throw new Error(`Manifest case ${testCase.id} is missing fixture_ref`);
+			}
+			return resolve(ROOT, testCase.fixture_ref);
+		case 'generated_png':
+			return writeFixture(testCase.expected_filename, PNG_BYTES);
+		case 'generated_markdown':
+			return writeFixture(
+				testCase.expected_filename,
+				[
+					'# Spec 97 Golden Note',
+					'',
+					'This deterministic Markdown fixture exercises the pre-structured text route.',
+					'',
+				].join('\n'),
+			);
+		case 'generated_docx':
+			return writeFixture(
+				testCase.expected_filename,
+				createDocxBuffer('Spec 97 Golden DOCX', 'The DOCX fixture converges directly to a Markdown story.'),
+			);
+		case 'generated_xlsx':
+			return writeFixture(
+				testCase.expected_filename,
+				createXlsxBuffer([
+					{
+						name: 'People',
+						rows: [
+							['name', 'date', 'city', 'email'],
+							['Ada Lovelace', '2026-05-01', 'London', 'ada@example.com'],
+						],
+					},
+				]),
+			);
+		case 'generated_eml':
+			return writeFixture(
+				testCase.expected_filename,
+				createEmlContent({
+					messageId: 'spec-97-golden@example.com',
+					subject: 'Spec 97 Golden Email',
+					body: 'This deterministic email body exercises the pre-structured email route.',
+				}),
+			);
+		case 'local_http_url':
+			if (!testCase.fixture_ref) {
+				throw new Error(`Manifest case ${testCase.id} is missing fixture_ref`);
+			}
+			return `${baseUrl}${testCase.fixture_ref}`;
+		default:
+			throw new Error(`Unsupported fixture kind for primary case: ${testCase.fixture_kind}`);
+	}
+}
+
+function materializeDuplicateFixture(fixture: DuplicateManifestFixture, content: string): string {
+	if (fixture.fixture_kind === 'generated_markdown') {
+		return writeFixture(fixture.expected_filename, content);
+	}
+	if (fixture.fixture_kind === 'generated_text') {
+		return writeFixture(fixture.expected_filename, content.replaceAll('\n', '\r\n'));
+	}
+	throw new Error(`Unsupported duplicate fixture kind: ${fixture.fixture_kind}`);
+}
+
+function formatMetadataForSource(sourceId: string): Record<string, unknown> {
+	return JSON.parse(
+		db.runSql(`SELECT format_metadata::text FROM sources WHERE id = ${sqlLiteral(sourceId)};`),
+	) as Record<string, unknown>;
+}
+
+function storyCount(sourceId: string): number {
+	return Number(db.runSql(`SELECT COUNT(*) FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`));
+}
+
+function sourceStepStatus(sourceId: string, stepName: string): string {
+	return db.runSql(
+		`SELECT COALESCE((SELECT status::text FROM source_steps WHERE source_id = ${sqlLiteral(sourceId)} AND step_name = ${sqlLiteral(stepName)}), 'missing');`,
+	);
+}
+
+function storyArtifactRows(sourceId: string): string[] {
+	return db
+		.runSql(
+			`SELECT gcs_markdown_uri || '|' || gcs_metadata_uri FROM stories WHERE source_id = ${sqlLiteral(sourceId)} ORDER BY created_at;`,
+		)
+		.split('\n')
+		.filter(Boolean);
+}
+
+function assertStoryArtifacts(sourceId: string, sourceType: SourceType): void {
+	for (const row of storyArtifactRows(sourceId)) {
+		const [markdownUri, metadataUri] = row.split('|');
+		expect(markdownUri).toMatch(/^segments\//);
+		expect(metadataUri).toMatch(/^segments\//);
+		expect(existsSync(resolve(STORAGE_DIR, markdownUri))).toBe(true);
+		expect(existsSync(resolve(STORAGE_DIR, metadataUri))).toBe(true);
+		const metadata = JSON.parse(readFileSync(resolve(STORAGE_DIR, metadataUri), 'utf-8')) as Record<string, unknown>;
+		expect(metadata.source_type).toBe(sourceType);
+	}
+}
+
+function assertRouteArtifacts(sourceId: string, expectedRoute: ExpectedRoute): void {
+	const layoutJsonPath = resolve(STORAGE_DIR, `extracted/${sourceId}/layout.json`);
+	if (expectedRoute === 'layout') {
+		expect(existsSync(layoutJsonPath)).toBe(true);
+		expect(sourceStepStatus(sourceId, 'segment')).toBe('completed');
+		return;
+	}
+	expect(existsSync(layoutJsonPath)).toBe(false);
+}
+
+function sourceCount(): string {
+	return db.runSql('SELECT COUNT(*) FROM sources;');
+}
+
+function urlArticleHtml(): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <title>Spec 97 Golden URL</title>
+  <meta name="author" content="Golden URL Reporter">
+</head>
+<body>
+  <article>
+    <h1>Spec 97 Golden URL</h1>
+    <p>This deterministic local page exercises URL ingestion without leaving the test process.</p>
+    <p>The readable article body is intentionally stable so the pre-structured URL route creates one Markdown story.</p>
+    <p>It mentions source types, route behavior, and story convergence for the M9 multi-format golden layer.</p>
+  </article>
+</body>
+</html>`;
+}
+
+beforeAll(async () => {
+	process.env.MULDER_CONFIG = EXAMPLE_CONFIG;
+	process.env.MULDER_LOG_LEVEL = 'silent';
+	process.env.NODE_ENV = 'test';
+
+	tmpDir = mkdtempSync(join(tmpdir(), 'mulder-qa-97-'));
+	server = createServer((request, response) => {
+		const url = request.url ?? '/';
+		if (url === '/robots.txt') {
+			response.writeHead(200, { 'content-type': 'text/plain' });
+			response.end('User-agent: *\nAllow: /');
+			return;
+		}
+		if (url === '/golden-url-article') {
+			response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+			response.end(urlArticleHtml());
+			return;
+		}
+		response.writeHead(404, { 'content-type': 'text/plain' });
+		response.end('not found');
+	});
+	await new Promise<void>((resolveServer) => {
+		server?.listen(0, '127.0.0.1', resolveServer);
+	});
+	const address = server.address();
+	if (address && typeof address === 'object') {
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	}
+
+	rawSnapshot = snapshotStorageDir(RAW_STORAGE_DIR);
+	extractedSnapshot = snapshotStorageDir(EXTRACTED_STORAGE_DIR);
+	segmentsSnapshot = snapshotStorageDir(SEGMENTS_STORAGE_DIR);
+
+	buildPackage(CORE_DIR);
+	buildPackage(PIPELINE_DIR);
+	buildPackage(CLI_DIR);
+
+	pgAvailable = db.isPgAvailable();
+	if (pgAvailable) {
+		const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG], { timeout: 300_000 });
+		expect(migrate.exitCode, combinedOutput(migrate)).toBe(0);
+	}
+}, 600_000);
+
+beforeEach(() => {
+	if (!pgAvailable) return;
+	cleanState();
+	resetStorage();
+});
+
+afterAll(async () => {
+	try {
+		if (pgAvailable) {
+			cleanState();
+			resetStorage();
+		}
+	} catch {
+		// Ignore cleanup failures.
+	}
+	if (tmpDir) {
+		rmSync(tmpDir, { recursive: true, force: true });
+	}
+	if (server) {
+		await new Promise<void>((resolveServer) => {
+			server?.close(() => resolveServer());
+			server?.closeAllConnections();
+		});
+	}
+});
+
+describe('Spec 97 - Multi-format golden tests', () => {
+	it('QA-01/02: manifest contains one complete primary case per source type', () => {
+		const manifest = readManifest();
+		expect(manifest.schema_version).toBe(1);
+		expect(manifest.cases).toHaveLength(SOURCE_TYPES.length);
+		expect(manifest.cases.map((testCase) => testCase.source_type).sort()).toEqual([...SOURCE_TYPES].sort());
+
+		for (const sourceType of SOURCE_TYPES) {
+			expect(manifest.cases.filter((testCase) => testCase.source_type === sourceType)).toHaveLength(1);
+		}
+		for (const testCase of manifest.cases) {
+			expect(testCase.id).toMatch(/^golden-/);
+			expect(testCase.fixture_kind).toEqual(expect.any(String));
+			expect(testCase.expected_filename).toEqual(expect.any(String));
+			expect(['layout', 'prestructured']).toContain(testCase.expected_route);
+			expect(testCase.expected_story_min).toEqual(expect.any(Number));
+			expect(Array.isArray(testCase.expected_metadata_keys)).toBe(true);
+		}
+	});
+
+	it('QA-03/04/05: golden fixtures ingest, route, and converge to story artifacts', async () => {
+		if (!pgAvailable) return;
+
+		const manifest = readManifest();
+		for (const testCase of manifest.cases) {
+			cleanState();
+			resetStorage();
+			const fixture = materializeFixture(testCase);
+			const ingest =
+				testCase.source_type === 'url' ? await runCliAsync(['ingest', fixture]) : runCli(['ingest', fixture]);
+			expect(ingest.exitCode, `${testCase.id}\n${combinedOutput(ingest)}`).toBe(0);
+			expect(sourceCount()).toBe('1');
+
+			const sourceId = sourceIdForCase(testCase);
+			const sourceRow = db
+				.runSql(`SELECT filename, source_type::text, status FROM sources WHERE id = ${sqlLiteral(sourceId)};`)
+				.split('|');
+			expect(sourceRow).toEqual([testCase.expected_filename, testCase.source_type, 'ingested']);
+
+			const formatMetadata = formatMetadataForSource(sourceId);
+			for (const key of testCase.expected_metadata_keys) {
+				expect(formatMetadata).toHaveProperty(key);
+			}
+
+			const extract = runCli(['extract', sourceId], { timeout: 240_000 });
+			expect(extract.exitCode, `${testCase.id}\n${combinedOutput(extract)}`).toBe(0);
+
+			if (testCase.expected_route === 'layout') {
+				const segment = runCli(['segment', sourceId], { timeout: 240_000 });
+				expect(segment.exitCode, `${testCase.id}\n${combinedOutput(segment)}`).toBe(0);
+			}
+
+			expect(db.runSql(`SELECT source_type::text FROM sources WHERE id = ${sqlLiteral(sourceId)};`)).toBe(
+				testCase.source_type,
+			);
+			expect(storyCount(sourceId)).toBeGreaterThanOrEqual(testCase.expected_story_min);
+			assertStoryArtifacts(sourceId, testCase.source_type);
+			assertRouteArtifacts(sourceId, testCase.expected_route);
+		}
+	}, 1_500_000);
+
+	it('QA-06: pipeline records segment skipped for a pre-structured golden source', () => {
+		if (!pgAvailable) return;
+
+		const textCase = readManifest().cases.find((testCase) => testCase.source_type === 'text');
+		expect(textCase).toBeDefined();
+		if (!textCase) return;
+
+		const fixture = materializeFixture(textCase);
+		const ingest = runCli(['ingest', fixture]);
+		expect(ingest.exitCode, combinedOutput(ingest)).toBe(0);
+		const sourceId = sourceIdForCase(textCase);
+
+		const pipeline = runCli(['pipeline', 'run', '--from', 'extract', '--up-to', 'enrich', '--source-id', sourceId], {
+			timeout: 240_000,
+		});
+		expect(pipeline.exitCode, combinedOutput(pipeline)).toBe(0);
+		expect(sourceStepStatus(sourceId, 'extract')).toBe('completed');
+		expect(sourceStepStatus(sourceId, 'segment')).toBe('skipped');
+		expect(sourceStepStatus(sourceId, 'enrich')).toBe('completed');
+		expect(db.runSql(`SELECT status FROM stories WHERE source_id = ${sqlLiteral(sourceId)};`)).toBe('enriched');
+	});
+
+	it('QA-07: cheap cross-format duplicate golden pair does not inflate sources', () => {
+		if (!pgAvailable) return;
+
+		const duplicate = readManifest().duplicate_scenario;
+		const content = [
+			'# Spec 97 Duplicate Report',
+			'',
+			'Alpha beta gamma delta epsilon zeta eta theta iota kappa.',
+			'',
+			'This normalized body is identical across Markdown and plain text fixtures.',
+			'',
+		].join('\n');
+		const first = materializeDuplicateFixture(duplicate.first, content);
+		const second = materializeDuplicateFixture(duplicate.second, content);
+
+		const firstIngest = runCli(['ingest', first]);
+		expect(firstIngest.exitCode, combinedOutput(firstIngest)).toBe(0);
+		const existingSourceId = sourceIdForFilename(duplicate.first.expected_filename);
+		const secondIngest = runCli(['ingest', second]);
+		expect(secondIngest.exitCode, combinedOutput(secondIngest)).toBe(0);
+		expect(combinedOutput(secondIngest)).toMatch(/duplicate/i);
+		expect(combinedOutput(secondIngest)).toContain(existingSourceId);
+		expect(sourceCount()).toBe('1');
+
+		const metadata = formatMetadataForSource(existingSourceId);
+		expect(db.runSql(`SELECT source_type::text FROM sources WHERE id = ${sqlLiteral(existingSourceId)};`)).toBe(
+			duplicate.expected_source_type,
+		);
+		expect(metadata.cross_format_dedup_basis).toBe(duplicate.expected_duplicate_basis);
+	});
+});


### PR DESCRIPTION
## Summary
- add the Spec 97 multi-format golden manifest and README contract
- add deterministic fixture builders plus black-box coverage for pdf, image, text, docx, spreadsheet, email, and url ingest/extract convergence
- include a cheap cross-format duplicate golden case and ensure layout-segment metadata carries source_type for layout stories

Closes #258

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm exec vitest run tests/specs/97_multi_format_golden_tests.test.ts --reporter=verbose
- pnpm exec vitest run tests/specs/85_source_type_discriminator_format_metadata.test.ts tests/specs/86_pipeline_step_skipping_prestructured_sources.test.ts tests/specs/87_image_ingestion_layout_path.test.ts tests/specs/88_plain_text_ingestion_prestructured_path.test.ts tests/specs/89_docx_ingestion_prestructured_path.test.ts tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts tests/specs/91_email_ingestion_prestructured_path.test.ts tests/specs/92_url_ingestion_prestructured_path.test.ts tests/specs/93_url_rendering_playwright_fallback.test.ts tests/specs/94_url_lifecycle_refetch.test.ts tests/specs/95_format_aware_extract_routing.test.ts tests/specs/96_cross_format_ingest_dedup.test.ts tests/specs/97_multi_format_golden_tests.test.ts --reporter=verbose