### PR TITLE
chore: parallelize affected test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -29,6 +30,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -50,6 +52,7 @@ jobs:
   health:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     services:
       postgres:
@@ -119,6 +122,7 @@ jobs:
   unit-tests:
     name: unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - uses: actions/checkout@v6
@@ -154,11 +158,64 @@ jobs:
           path: .test-results
           if-no-files-found: ignore
 
-  pr-affected-tests:
+  pr-affected-plan:
     if: github.event_name == 'pull_request'
-    name: affected tests
+    name: affected plan
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [build, health]
+    outputs:
+      has_schema: ${{ steps.plan.outputs.has_schema }}
+      has_db: ${{ steps.plan.outputs.has_db }}
+      has_heavy: ${{ steps.plan.outputs.has_heavy }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Prepare test results
+        run: mkdir -p .test-results
+
+      - name: Build affected plan
+        id: plan
+        run: |
+          node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} --json > .test-results/affected-plan.json
+          node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-plan.txt
+          node <<'NODE'
+          const fs = require('node:fs');
+          const plan = JSON.parse(fs.readFileSync('.test-results/affected-plan.json', 'utf8'));
+          const output = process.env.GITHUB_OUTPUT;
+          for (const lane of ['schema', 'db', 'heavy']) {
+            fs.appendFileSync(output, `has_${lane}=${plan.lanes[lane].count > 0 ? 'true' : 'false'}\n`);
+          }
+          NODE
+        env:
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Upload affected plan artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: affected-plan
+          path: .test-results
+          if-no-files-found: ignore
+
+  pr-affected-schema:
+    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_schema == 'true'
+    name: affected schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build, health, pr-affected-plan]
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -208,8 +265,13 @@ jobs:
       - name: Prepare test results
         run: mkdir -p .test-results
 
-      - name: Run affected tests
-        run: pnpm test:affected -- origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-junit.xml
+      - name: Show affected schema plan
+        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-schema-plan.txt
+        env:
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Run affected schema tests
+        run: pnpm test:affected:lane -- schema origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-schema-junit.xml
         env:
           NODE_ENV: test
           PGHOST: localhost
@@ -220,18 +282,217 @@ jobs:
           MULDER_TEST_ISOLATED_DB: "true"
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
 
-      - name: Upload affected test artifacts
+      - name: Upload affected schema artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: affected-test-results
+          name: affected-schema-test-results
           path: .test-results
           if-no-files-found: ignore
+
+  pr-affected-db:
+    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_db == 'true'
+    name: affected db (${{ matrix.shard_index }}/${{ matrix.shard_total }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, health, pr-affected-plan]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [1, 2]
+        shard_total: [2]
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: mulder
+          POSTGRES_PASSWORD: mulder
+          POSTGRES_DB: mulder
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U mulder"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Install PostGIS into PostgreSQL container
+        run: |
+          PG_CONTAINER=$(docker ps -q --filter "ancestor=pgvector/pgvector:pg17")
+          docker exec "$PG_CONTAINER" bash -c "apt-get update && apt-get install -y --no-install-recommends postgresql-17-postgis-3 postgresql-17-postgis-3-scripts && rm -rf /var/lib/apt/lists/*"
+
+      - name: Install PostgreSQL extensions
+        run: |
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+      - name: Setup test config
+        run: cp mulder.config.example.yaml mulder.config.yaml
+
+      - name: Prepare test results
+        run: mkdir -p .test-results
+
+      - name: Show affected db plan
+        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-db-${{ matrix.shard_index }}-plan.txt
+        env:
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Run affected db tests
+        run: pnpm test:affected:lane -- db ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-db-${{ matrix.shard_index }}-junit.xml
+        env:
+          NODE_ENV: test
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: mulder
+          PGPASSWORD: mulder
+          PGDATABASE: mulder
+          MULDER_TEST_ISOLATED_DB: "true"
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Upload affected DB artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: affected-db-test-results-${{ matrix.shard_index }}
+          path: .test-results
+          if-no-files-found: ignore
+
+  pr-affected-heavy:
+    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_heavy == 'true'
+    name: affected heavy (${{ matrix.shard_index }}/${{ matrix.shard_total }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, health, pr-affected-plan]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [1, 2, 3]
+        shard_total: [3]
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: mulder
+          POSTGRES_PASSWORD: mulder
+          POSTGRES_DB: mulder
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U mulder"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Install PostGIS into PostgreSQL container
+        run: |
+          PG_CONTAINER=$(docker ps -q --filter "ancestor=pgvector/pgvector:pg17")
+          docker exec "$PG_CONTAINER" bash -c "apt-get update && apt-get install -y --no-install-recommends postgresql-17-postgis-3 postgresql-17-postgis-3-scripts && rm -rf /var/lib/apt/lists/*"
+
+      - name: Install PostgreSQL extensions
+        run: |
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+          PGPASSWORD=mulder psql -h localhost -U mulder -d mulder -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+      - name: Setup test config
+        run: cp mulder.config.example.yaml mulder.config.yaml
+
+      - name: Prepare test results
+        run: mkdir -p .test-results
+
+      - name: Show affected heavy plan
+        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-heavy-${{ matrix.shard_index }}-plan.txt
+        env:
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Run affected heavy tests
+        run: pnpm test:affected:lane -- heavy ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-heavy-${{ matrix.shard_index }}-junit.xml
+        env:
+          NODE_ENV: test
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: mulder
+          PGPASSWORD: mulder
+          PGDATABASE: mulder
+          MULDER_TEST_ISOLATED_DB: "true"
+          MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+
+      - name: Upload affected heavy artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: affected-heavy-test-results-${{ matrix.shard_index }}
+          path: .test-results
+          if-no-files-found: ignore
+
+  pr-affected-tests:
+    if: always() && github.event_name == 'pull_request'
+    name: affected tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [pr-affected-plan, pr-affected-schema, pr-affected-db, pr-affected-heavy]
+    steps:
+      - name: Check affected lane results
+        run: |
+          echo "plan: ${{ needs.pr-affected-plan.result }}"
+          echo "schema: ${{ needs.pr-affected-schema.result }}"
+          echo "db: ${{ needs.pr-affected-db.result }}"
+          echo "heavy: ${{ needs.pr-affected-heavy.result }}"
+
+          if [ "${{ needs.pr-affected-plan.result }}" != "success" ]; then
+            exit 1
+          fi
+
+          for result in "${{ needs.pr-affected-schema.result }}" "${{ needs.pr-affected-db.result }}" "${{ needs.pr-affected-heavy.result }}"; do
+            case "$result" in
+              success|skipped)
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+          done
 
   full-schema-tests:
     if: github.event_name != 'pull_request'
     name: schema tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     services:
       postgres:
@@ -306,6 +567,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: db tests (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: build
     strategy:
       fail-fast: false
@@ -385,6 +647,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: heavy tests (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: build
     strategy:
       fail-fast: false
@@ -464,6 +727,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     name: external tests (manual)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: build
     steps:
       - uses: actions/checkout@v6
@@ -504,6 +768,7 @@ jobs:
 
   app:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -27,8 +27,11 @@ Use scoped or affected tests during feature work:
 
 ```bash
 pnpm test:scope run step Mx-Yz -- --reporter=verbose
+pnpm test:affected:plan -- origin/main
 pnpm test:affected -- origin/main -- --reporter=verbose
 ```
+
+The affected runner is intentionally explainable: `test:affected:plan` prints the changed files, the rule that matched each file, selected specs, lanes, and estimated weight. A normal feature PR should stay near 8-15 minutes; broad changes may use the parallel affected lane jobs and should still target 20 minutes. If an affected plan unexpectedly selects most of the suite for an ordinary feature change, refine the mapping before continuing feature work.
 
 Use full lane runs when changing shared infrastructure, migrations, worker dispatch, storage, or pipeline orchestration:
 
@@ -38,3 +41,4 @@ MULDER_TEST_ISOLATED_DB=true pnpm test:lane -- db 1 2 -- --reporter=verbose
 MULDER_TEST_ISOLATED_DB=true pnpm test:lane -- heavy 1 3 -- --reporter=verbose
 ```
 
+The full suite remains the merge safety net for pushes to `milestone/**` and `main`. PR affected mappings may be narrower than the full suite, but milestone tips must still pass the complete schema/db/heavy gates before merging onward.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"worker:service": "node scripts/run-worker-service.mjs",
 		"test:scope": "node scripts/test-scope.mjs",
 		"test:affected": "node scripts/test-lanes.mjs affected",
+		"test:affected:plan": "node scripts/test-lanes.mjs affected-plan",
+		"test:affected:lane": "node scripts/test-lanes.mjs affected-lane",
 		"test:lane": "node scripts/test-lanes.mjs run",
 		"test:lanes:verify": "node scripts/test-lanes.mjs verify",
 		"test:lanes:summary": "node scripts/test-lanes.mjs summary",

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -12,6 +12,11 @@ const TEST_RUNNER = resolve(ROOT, 'scripts/test-runner.mjs');
 
 const SERIAL_VITEST_ARGS = ['--no-file-parallelism', '--maxWorkers=1'];
 const PARALLEL_VITEST_ARGS = ['--fileParallelism=true'];
+const LANE_ORDER = ['unit', 'schema', 'db', 'heavy', 'external'];
+const HEALTH_SMOKE_TEST = 'tests/specs/44_e2e_pipeline_integration.test.ts';
+const SPEC_DOC_TEST_OVERRIDES = new Map([
+	['77_document_observability_aggregation', ['tests/specs/77_document_observability_route.test.ts']],
+]);
 
 function usage() {
 	return [
@@ -21,6 +26,8 @@ function usage() {
 		'  node scripts/test-lanes.mjs list <lane> [shardIndex shardTotal]',
 		'  node scripts/test-lanes.mjs run <lane> [shardIndex shardTotal] [-- vitest args...]',
 		'  node scripts/test-lanes.mjs affected [baseRef] [-- vitest args...]',
+		'  node scripts/test-lanes.mjs affected-plan [baseRef] [--json] [--changed-file <path> ...]',
+		'  node scripts/test-lanes.mjs affected-lane <lane> [shardIndex shardTotal] [baseRef|--changed-file <path> ...] [-- vitest args...]',
 		'',
 		'Lanes: unit, schema, db, heavy, external',
 	].join('\n');
@@ -327,7 +334,7 @@ function testsForSpecNumber(specNumber, discoveredByPath) {
 	return [...discoveredByPath.keys()].filter((path) => path.startsWith(`tests/specs/${padded}_`));
 }
 
-function addSpecTests(selected, discoveredByPath, specNumbers) {
+function addSpecTestsToSet(selected, discoveredByPath, specNumbers) {
 	for (const specNumber of specNumbers) {
 		for (const testPath of testsForSpecNumber(specNumber, discoveredByPath)) {
 			selected.add(testPath);
@@ -335,7 +342,36 @@ function addSpecTests(selected, discoveredByPath, specNumbers) {
 	}
 }
 
-function addLaneFiles(selected, lanes, laneNames) {
+function addExactTestsToSet(selected, discoveredByPath, testPaths) {
+	for (const testPath of testPaths) {
+		if (!discoveredByPath.has(testPath)) {
+			throw new Error(`Affected test mapping points to a missing test file: ${testPath}`);
+		}
+		selected.add(testPath);
+	}
+}
+
+function addDocSpecTestsToSet(selected, discoveredByPath, specFile) {
+	const key = specFile.replace(/^docs\/specs\//, '').replace(/\.spec\.md$/, '');
+	const override = SPEC_DOC_TEST_OVERRIDES.get(key);
+	if (override) {
+		addExactTestsToSet(selected, discoveredByPath, override);
+		return;
+	}
+
+	const exactTest = `tests/specs/${key}.test.ts`;
+	if (discoveredByPath.has(exactTest)) {
+		selected.add(exactTest);
+		return;
+	}
+
+	const specMatch = key.match(/^(\d+)_/);
+	if (specMatch) {
+		addSpecTestsToSet(selected, discoveredByPath, [specMatch[1]]);
+	}
+}
+
+function addLaneFilesToSet(selected, lanes, laneNames) {
 	for (const laneName of laneNames) {
 		for (const testFile of lanes[laneName].files) {
 			selected.add(testFile.relativePath);
@@ -344,142 +380,380 @@ function addLaneFiles(selected, lanes, laneNames) {
 }
 
 function removeHealthSmokeTests(selected) {
-	selected.delete('tests/specs/44_e2e_pipeline_integration.test.ts');
+	selected.delete(HEALTH_SMOKE_TEST);
 }
 
-function selectAffectedFiles(baseRef) {
-	const { discoveredByPath, lanes } = classifyFiles();
-	const weightedByPath = new Map(
-		Object.values(lanes).flatMap((lane) => lane.files.map((file) => [file.relativePath, file])),
-	);
-	const changed = gitChangedFiles(baseRef);
+const TEST_GROUPS = {
+	testinfra: ['tests/specs/02_monorepo_setup.test.ts', 'tests/specs/59_hermetic_test_infrastructure.test.ts'],
+	reprocessConfig: [
+		'tests/specs/03_config_loader.test.ts',
+		'tests/specs/30_cascading_reset_function.test.ts',
+		'tests/specs/35_qa_cascading_reset.test.ts',
+		'tests/specs/77_cost_estimator.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	coreConfig: [
+		'tests/specs/03_config_loader.test.ts',
+		'tests/specs/77_cost_estimator.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	coreDatabase: [
+		'tests/specs/07_database_client_migration_runner.test.ts',
+		'tests/specs/08_core_schema_migrations.test.ts',
+		'tests/specs/09_job_queue_pipeline_tracking_migrations.test.ts',
+		'tests/specs/14_source_repository.test.ts',
+		'tests/specs/22_pdf_metadata_extraction.test.ts',
+		'tests/specs/22_story_repository.test.ts',
+		'tests/specs/24_entity_alias_repositories.test.ts',
+		'tests/specs/25_edge_repository.test.ts',
+		'tests/specs/32_embedding_wrapper_semantic_chunker_chunk_repository.test.ts',
+		'tests/specs/38_fulltext_search_retrieval.test.ts',
+		'tests/specs/39_graph_traversal_retrieval.test.ts',
+		'tests/specs/54_v2_schema_migrations.test.ts',
+		'tests/specs/67_job_queue_repository.test.ts',
+	],
+	corePdf: [
+		'tests/specs/15_native_text_detection.test.ts',
+		'tests/specs/16_ingest_step.test.ts',
+		'tests/specs/22_pdf_metadata_extraction.test.ts',
+	],
+	coreServices: [
+		'tests/specs/11_service_abstraction.test.ts',
+		'tests/specs/13_gcp_service_implementations.test.ts',
+		'tests/specs/17_vertex_ai_wrapper_dev_cache.test.ts',
+	],
+	quality: [
+		'tests/specs/77_cost_estimator.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/86_pipeline_step_skipping.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	pipelineFormat: [
+		'tests/specs/85_source_type_discriminator_format_metadata.test.ts',
+		'tests/specs/86_pipeline_step_skipping.test.ts',
+		'tests/specs/86_pipeline_step_skipping_prestructured_sources.test.ts',
+		'tests/specs/87_image_ingestion_layout_path.test.ts',
+		'tests/specs/88_plain_text_ingestion_prestructured_path.test.ts',
+		'tests/specs/89_docx_ingestion_prestructured_path.test.ts',
+		'tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts',
+		'tests/specs/91_email_ingestion_prestructured_path.test.ts',
+		'tests/specs/92_url_ingestion_prestructured_path.test.ts',
+		'tests/specs/95_format_aware_extract_routing.test.ts',
+		'tests/specs/96_cross_format_ingest_dedup.test.ts',
+		'tests/specs/98_content_addressed_storage.test.ts',
+	],
+	pipelineGeneric: [
+		'tests/specs/16_ingest_duplicate_race.test.ts',
+		'tests/specs/16_ingest_step.test.ts',
+		'tests/specs/19_extract_step.test.ts',
+		'tests/specs/23_segment_step.test.ts',
+		'tests/specs/29_enrich_step.test.ts',
+		'tests/specs/34_embed_step.test.ts',
+		'tests/specs/35_graph_step.test.ts',
+		'tests/specs/35_qa_cascading_reset.test.ts',
+		'tests/specs/36_pipeline_orchestrator.test.ts',
+		'tests/specs/36_qa_pipeline_integration.test.ts',
+		'tests/specs/77_cost_estimator.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/86_pipeline_step_skipping.test.ts',
+		'tests/specs/86_pipeline_step_skipping_prestructured_sources.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	worker: [
+		'tests/specs/68_worker_loop.test.ts',
+		'tests/specs/77_budget_reservation_status_gate.test.ts',
+		'tests/specs/77_document_observability_route.test.ts',
+		'tests/specs/78_dead_letter_queue_retry.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/79_step_scoped_worker_job_contract.test.ts',
+		'tests/specs/80_step_chained_pipeline_api_jobs.test.ts',
+		'tests/specs/81_queue_retry_before_dead_letter.test.ts',
+		'tests/specs/88_plain_text_ingestion_prestructured_path.test.ts',
+		'tests/specs/89_docx_ingestion_prestructured_path.test.ts',
+		'tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts',
+		'tests/specs/91_email_ingestion_prestructured_path.test.ts',
+		'tests/specs/92_url_ingestion_prestructured_path.test.ts',
+		'tests/specs/96_cross_format_ingest_dedup.test.ts',
+		'tests/specs/98_content_addressed_storage.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	api: [
+		'tests/specs/69_hono_server_scaffold.test.ts',
+		'tests/specs/70_api_middleware_stack.test.ts',
+		'tests/specs/71_pipeline_api_routes.test.ts',
+		'tests/specs/72_job_status_api.test.ts',
+		'tests/specs/73_search_api_routes.test.ts',
+		'tests/specs/74_entity_api_routes.test.ts',
+		'tests/specs/75_evidence_api_routes.test.ts',
+		'tests/specs/76_document_retrieval_routes.test.ts',
+		'tests/specs/77_browser_safe_email_password_auth.test.ts',
+		'tests/specs/77_document_observability_route.test.ts',
+		'tests/specs/80_step_chained_pipeline_api_jobs.test.ts',
+		'tests/specs/89_docx_ingestion_prestructured_path.test.ts',
+		'tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts',
+		'tests/specs/98_content_addressed_storage.test.ts',
+	],
+	cli: [
+		'tests/specs/06_cli_scaffold.test.ts',
+		'tests/specs/16_ingest_step.test.ts',
+		'tests/specs/45_cli_config_smoke.test.ts',
+		'tests/specs/46_taxonomy_bootstrap.test.ts',
+		'tests/specs/49_mulder_show_command.test.ts',
+		'tests/specs/51_entity_management_cli.test.ts',
+		'tests/specs/53_export_commands.test.ts',
+		'tests/specs/77_cost_estimator.test.ts',
+		'tests/specs/78_selective_reprocessing.test.ts',
+		'tests/specs/88_plain_text_ingestion_prestructured_path.test.ts',
+		'tests/specs/89_docx_ingestion_prestructured_path.test.ts',
+		'tests/specs/90_spreadsheet_ingestion_prestructured_path.test.ts',
+		'tests/specs/91_email_ingestion_prestructured_path.test.ts',
+		'tests/specs/92_url_ingestion_prestructured_path.test.ts',
+		'tests/specs/96_cross_format_ingest_dedup.test.ts',
+		'tests/specs/98_content_addressed_storage.test.ts',
+		'tests/specs/100_document_quality_assessment_step.test.ts',
+	],
+	retrieval: [
+		'tests/specs/37_vector_search_retrieval.test.ts',
+		'tests/specs/38_fulltext_search_retrieval.test.ts',
+		'tests/specs/39_graph_traversal_retrieval.test.ts',
+		'tests/specs/40_rrf_fusion.test.ts',
+		'tests/specs/41_llm_reranking.test.ts',
+		'tests/specs/42_hybrid_retrieval_orchestrator.test.ts',
+		'tests/specs/43_retrieval_metrics.test.ts',
+	],
+	taxonomy: [
+		'tests/specs/27_taxonomy_normalization.test.ts',
+		'tests/specs/46_taxonomy_bootstrap.test.ts',
+		'tests/specs/50_taxonomy_export_curate_merge.test.ts',
+		'tests/specs/51_entity_management_cli.test.ts',
+	],
+	eval: ['tests/specs/43_retrieval_metrics.test.ts', 'tests/specs/77_eval_cli_reporter.test.ts'],
+	evidence: [
+		'tests/specs/63_evidence_chains.test.ts',
+		'tests/specs/66_evidence_package_boundary.test.ts',
+		'tests/specs/75_evidence_api_routes.test.ts',
+	],
+};
+
+function selectTestGroup(selected, discoveredByPath, groupName) {
+	addExactTestsToSet(selected, discoveredByPath, TEST_GROUPS[groupName]);
+}
+
+function resolveAffectedRule(file, discoveredByPath, lanes) {
 	const selected = new Set();
+	const selectGroup = (groupName) => selectTestGroup(selected, discoveredByPath, groupName);
+	const selectExact = (testPaths) => addExactTestsToSet(selected, discoveredByPath, testPaths);
+	const selectLanes = (laneNames) => addLaneFilesToSet(selected, lanes, laneNames);
 
-	for (const file of changed) {
-		if (discoveredByPath.has(file)) {
-			selected.add(file);
-			continue;
-		}
-
-		const specMatch = file.match(/^docs\/specs\/(\d+)_.*\.spec\.md$/);
-		if (specMatch) {
-			addSpecTests(selected, discoveredByPath, [specMatch[1]]);
-			continue;
-		}
-
-		if (
-			/^(package\.json|pnpm-lock\.yaml|vitest\.config\.ts|scripts\/test-|tests\/test-runtime-manifest\.json|\.github\/workflows\/ci\.yml)$/.test(
-				file,
-			)
-		) {
-			addLaneFiles(selected, lanes, ['schema', 'db', 'heavy']);
-			continue;
-		}
-
-		if (file.startsWith('packages/core/src/database/')) {
-			addSpecTests(selected, discoveredByPath, [
-				'07',
-				'08',
-				'09',
-				'14',
-				'22',
-				'24',
-				'25',
-				'32',
-				'38',
-				'39',
-				'54',
-				'67',
-			]);
-			continue;
-		}
-
-		if (file.startsWith('packages/worker/')) {
-			addSpecTests(selected, discoveredByPath, ['68', '77', '78', '79', '80', '81']);
-			continue;
-		}
-
-		if (file.startsWith('apps/api/')) {
-			addSpecTests(selected, discoveredByPath, [
-				'69',
-				'70',
-				'71',
-				'72',
-				'73',
-				'74',
-				'75',
-				'76',
-				'77',
-				'80',
-				'89',
-				'90',
-				'98',
-			]);
-			continue;
-		}
-
-		if (file.startsWith('apps/cli/')) {
-			addSpecTests(selected, discoveredByPath, [
-				'06',
-				'16',
-				'20',
-				'45',
-				'46',
-				'49',
-				'51',
-				'53',
-				'88',
-				'89',
-				'90',
-				'91',
-				'92',
-				'96',
-				'98',
-			]);
-			continue;
-		}
-
-		if (file.startsWith('packages/pipeline/') || file.startsWith('packages/core/src/shared/')) {
-			addSpecTests(selected, discoveredByPath, [
-				'16',
-				'19',
-				'23',
-				'29',
-				'34',
-				'35',
-				'36',
-				'44',
-				'77',
-				'86',
-				'87',
-				'88',
-				'89',
-				'90',
-				'91',
-				'92',
-				'93',
-				'94',
-				'95',
-				'96',
-				'97',
-				'98',
-			]);
-			continue;
-		}
-
-		if (file.startsWith('apps/') || file.startsWith('packages/') || file.startsWith('tests/lib/')) {
-			addLaneFiles(selected, lanes, ['schema', 'db', 'heavy']);
-		}
+	if (discoveredByPath.has(file)) {
+		selected.add(file);
+		return { rule: 'changed test file', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
-	if (process.env.MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED === 'true') {
-		removeHealthSmokeTests(selected);
+	const specMatch = file.match(/^docs\/specs\/(\d+)_.*\.spec\.md$/);
+	if (specMatch) {
+		addDocSpecTestsToSet(selected, discoveredByPath, file);
+		return { rule: `docs spec ${specMatch[1]}`, selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
-	return [...selected]
-		.sort((a, b) => a.localeCompare(b))
-		.map((path) => weightedByPath.get(path))
-		.filter(Boolean);
+	if (file === 'README.md' || file === 'docs/testing-strategy.md' || file === 'package.json') {
+		selectGroup('testinfra');
+		return {
+			rule: 'testinfra documentation/scripts smoke',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (/^(scripts\/test-.*|tests\/test-runtime-manifest\.json|\.github\/workflows\/ci\.yml)$/.test(file)) {
+		selectGroup('testinfra');
+		return { rule: 'testinfra runner/ci smoke', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (/^(pnpm-lock\.yaml|vitest\.config\.ts)$/.test(file)) {
+		selectLanes(['schema', 'db', 'heavy']);
+		return {
+			rule: 'global dependency/test-runtime change',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (file === 'packages/core/src/config/reprocess-hash.ts') {
+		selectGroup('reprocessConfig');
+		return { rule: 'reprocess config hash', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/config/')) {
+		selectGroup('coreConfig');
+		return { rule: 'core config', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (/^packages\/core\/src\/database\/migrations\/02[6-8]_/.test(file)) {
+		selectExact([
+			'tests/specs/08_core_schema_migrations.test.ts',
+			'tests/specs/30_cascading_reset_function.test.ts',
+			'tests/specs/35_qa_cascading_reset.test.ts',
+			'tests/specs/100_document_quality_assessment_step.test.ts',
+		]);
+		return {
+			rule: 'document quality/reset migration',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (file.startsWith('packages/core/src/database/migrations/')) {
+		selectLanes(['schema', 'db', 'heavy']);
+		return { rule: 'unknown migration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/document-quality')) {
+		selectExact(['tests/specs/100_document_quality_assessment_step.test.ts']);
+		return { rule: 'document quality repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/pipeline-reset')) {
+		selectExact([
+			'tests/specs/30_cascading_reset_function.test.ts',
+			'tests/specs/35_qa_cascading_reset.test.ts',
+			'tests/specs/100_document_quality_assessment_step.test.ts',
+		]);
+		return { rule: 'pipeline reset repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/')) {
+		selectGroup('coreDatabase');
+		return { rule: 'core database/repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/pipeline/')) {
+		selectGroup('corePdf');
+		return { rule: 'core pdf pipeline helpers', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/prompts/templates/')) {
+		selectGroup('pipelineGeneric');
+		return { rule: 'pipeline prompt template', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/prompts/')) {
+		selectExact(['tests/specs/18_prompt_template_engine.test.ts']);
+		return { rule: 'prompt template engine', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (
+		file === 'packages/core/src/llm-cache.ts' ||
+		file === 'packages/core/src/vertex.ts' ||
+		file === 'packages/core/src/shared/gcp.ts' ||
+		file.startsWith('packages/core/src/shared/services') ||
+		file.startsWith('packages/core/src/shared/rate-limiter') ||
+		file.startsWith('packages/core/src/shared/retry')
+	) {
+		selectGroup('coreServices');
+		return { rule: 'core service/gcp wrappers', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/shared/cost-estimator')) {
+		selectExact(['tests/specs/77_cost_estimator.test.ts', 'tests/specs/78_selective_reprocessing.test.ts']);
+		return { rule: 'cost estimator', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/shared/')) {
+		selectExact([
+			'tests/specs/04_custom_error_classes.test.ts',
+			'tests/specs/05_logger_setup.test.ts',
+			'tests/specs/11_service_abstraction.test.ts',
+			'tests/specs/16_ingest_step.test.ts',
+			'tests/specs/68_worker_loop.test.ts',
+			...TEST_GROUPS.pipelineFormat,
+		]);
+		return {
+			rule: 'core shared services/storage/utilities',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (file === 'packages/core/src/index.ts') {
+		selectExact([
+			'tests/specs/02_monorepo_setup.test.ts',
+			'tests/specs/03_config_loader.test.ts',
+			'tests/specs/11_service_abstraction.test.ts',
+			'tests/specs/14_source_repository.test.ts',
+			'tests/specs/16_ingest_step.test.ts',
+			'tests/specs/100_document_quality_assessment_step.test.ts',
+		]);
+		return { rule: 'core public exports', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/pipeline/src/quality/')) {
+		selectGroup('quality');
+		return { rule: 'quality assessment pipeline', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/pipeline/src/reprocess/')) {
+		selectGroup('reprocessConfig');
+		return { rule: 'selective reprocessing pipeline', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/pipeline/src/ingest/') || file.startsWith('packages/pipeline/src/extract/')) {
+		selectGroup('pipelineFormat');
+		return {
+			rule: 'format-aware ingest/extract pipeline',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (file.startsWith('packages/pipeline/')) {
+		selectGroup('pipelineGeneric');
+		return { rule: 'pipeline step/orchestration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/worker/')) {
+		selectGroup('worker');
+		return { rule: 'worker dispatch/queue', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/retrieval/')) {
+		selectGroup('retrieval');
+		return { rule: 'retrieval package', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/taxonomy/')) {
+		selectGroup('taxonomy');
+		return { rule: 'taxonomy package', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/eval/')) {
+		selectGroup('eval');
+		return { rule: 'eval package', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/evidence/')) {
+		selectGroup('evidence');
+		return { rule: 'evidence package', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('apps/api/')) {
+		selectGroup('api');
+		return { rule: 'api routes/runtime', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('apps/cli/')) {
+		selectGroup('cli');
+		return { rule: 'cli commands/runtime', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('tests/lib/')) {
+		selectLanes(['schema', 'db', 'heavy']);
+		return { rule: 'shared test helper change', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('apps/') || file.startsWith('packages/')) {
+		selectGroup('testinfra');
+		return { rule: 'unknown app/package smoke', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	return { rule: 'no affected tests mapped', selectedFiles: [] };
 }
 
 function laneNameForFile(relativePath, lanes) {
@@ -489,6 +763,67 @@ function laneNameForFile(relativePath, lanes) {
 		}
 	}
 	return 'db';
+}
+
+function buildAffectedPlan(baseRef, explicitChangedFiles = null) {
+	const { discoveredByPath, lanes } = classifyFiles();
+	const weightedByPath = new Map(
+		Object.values(lanes).flatMap((lane) => lane.files.map((file) => [file.relativePath, file])),
+	);
+	const changed = explicitChangedFiles ?? gitChangedFiles(baseRef);
+	const selected = new Set();
+	const rules = [];
+
+	for (const file of changed) {
+		const result = resolveAffectedRule(file, discoveredByPath, lanes);
+		for (const selectedFile of result.selectedFiles) selected.add(selectedFile);
+		rules.push({ changedFile: file, rule: result.rule, selectedFiles: result.selectedFiles });
+	}
+
+	if (process.env.MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED === 'true') {
+		removeHealthSmokeTests(selected);
+		for (const rule of rules) {
+			rule.selectedFiles = rule.selectedFiles.filter((file) => file !== HEALTH_SMOKE_TEST);
+		}
+	}
+
+	const files = [...selected]
+		.sort((a, b) => a.localeCompare(b))
+		.map((path) => weightedByPath.get(path))
+		.filter(Boolean)
+		.map((file) => ({
+			...file,
+			lane: laneNameForFile(file.relativePath, lanes),
+		}));
+	const totalWeight = files.reduce((sum, file) => sum + file.weight, 0);
+	const laneSummaries = Object.fromEntries(
+		LANE_ORDER.map((laneName) => {
+			const laneFiles = files.filter((file) => file.lane === laneName);
+			return [
+				laneName,
+				{
+					count: laneFiles.length,
+					totalWeight: laneFiles.reduce((sum, file) => sum + file.weight, 0),
+					files: laneFiles.map((file) => file.relativePath),
+				},
+			];
+		}),
+	);
+
+	return {
+		baseRef: baseRef ?? null,
+		changedFiles: changed,
+		totalFiles: files.length,
+		totalWeight,
+		lanes: laneSummaries,
+		rules,
+		files: files.map((file) => ({
+			relativePath: file.relativePath,
+			lane: file.lane,
+			weight: file.weight,
+		})),
+		weightedFiles: files,
+	};
 }
 
 function rewriteJUnitOutputArgs(extraArgs, suffix) {
@@ -507,21 +842,90 @@ function rewriteJUnitOutputArgs(extraArgs, suffix) {
 	});
 }
 
+function formatAffectedPlan(plan) {
+	const lines = [
+		`Affected tests${plan.baseRef ? ` against ${plan.baseRef}` : ''}`,
+		`Changed files: ${plan.changedFiles.length}`,
+		...plan.changedFiles.map((file) => ` - ${file}`),
+		'Rules:',
+		...plan.rules.map(
+			(rule) => ` - ${rule.changedFile}: ${rule.rule} (${rule.selectedFiles.length} selected before merge/dedupe)`,
+		),
+		'Lane summary:',
+		...LANE_ORDER.map((laneName) => {
+			const lane = plan.lanes[laneName];
+			return ` - ${laneName}: ${lane.count} files, estimated weight ${lane.totalWeight}`;
+		}),
+		`Files: ${plan.totalFiles}`,
+		`Estimated weight: ${plan.totalWeight}`,
+		...plan.files.map((file) => ` - ${file.relativePath} [${file.lane}] (${file.weight})`),
+		'',
+	];
+	return lines.join('\n');
+}
+
+function parseAffectedPlanArgs(commandArgs) {
+	let baseRef = null;
+	let json = false;
+	const changedFiles = [];
+
+	for (let index = 0; index < commandArgs.length; index += 1) {
+		const arg = commandArgs[index];
+		if (arg === '--json') {
+			json = true;
+			continue;
+		}
+		if (arg === '--changed-file') {
+			const changedFile = commandArgs[index + 1];
+			if (!changedFile) {
+				throw new Error('affected-plan --changed-file requires a path.');
+			}
+			changedFiles.push(changedFile);
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith('--')) {
+			throw new Error(`Unknown affected-plan option: ${arg}`);
+		}
+		if (baseRef) {
+			throw new Error(`Unexpected affected-plan argument: ${arg}`);
+		}
+		baseRef = arg;
+	}
+
+	return {
+		baseRef,
+		json,
+		changedFiles: changedFiles.length > 0 ? changedFiles : null,
+	};
+}
+
+function printAffectedPlan(commandArgs) {
+	const { baseRef, json, changedFiles } = parseAffectedPlanArgs(commandArgs);
+	const plan = buildAffectedPlan(baseRef, changedFiles);
+	if (json) {
+		const jsonPlan = { ...plan };
+		delete jsonPlan.weightedFiles;
+		process.stdout.write(`${JSON.stringify(jsonPlan, null, 2)}\n`);
+		return;
+	}
+	process.stdout.write(formatAffectedPlan(plan));
+}
+
 function runAffected(baseRef, extraArgs) {
 	const { lanes } = classifyFiles();
-	const files = selectAffectedFiles(baseRef);
-	const weight = files.reduce((sum, file) => sum + file.weight, 0);
-	process.stdout.write(formatPlan(`Affected tests${baseRef ? ` against ${baseRef}` : ''}`, files, weight));
+	const plan = buildAffectedPlan(baseRef);
+	const files = plan.weightedFiles;
+	process.stdout.write(formatAffectedPlan(plan));
 
-	const laneOrder = ['unit', 'schema', 'db', 'heavy', 'external'];
-	const filesByLane = new Map(laneOrder.map((laneName) => [laneName, []]));
+	const filesByLane = new Map(LANE_ORDER.map((laneName) => [laneName, []]));
 	for (const file of files) {
-		filesByLane.get(laneNameForFile(file.relativePath, lanes)).push(file);
+		filesByLane.get(file.lane).push(file);
 	}
 
 	let exitCode = 0;
 	const selectedLaneCount = [...filesByLane.values()].filter((laneFiles) => laneFiles.length > 0).length;
-	for (const laneName of laneOrder) {
+	for (const laneName of LANE_ORDER) {
 		const laneFiles = filesByLane.get(laneName);
 		if (laneFiles.length === 0) {
 			continue;
@@ -537,6 +941,79 @@ function runAffected(baseRef, extraArgs) {
 	}
 
 	process.exit(exitCode);
+}
+
+function parseAffectedLaneArgs(commandArgs) {
+	const [laneName, ...rest] = commandArgs;
+	if (!laneName) {
+		throw new Error(usage());
+	}
+
+	let shardIndex = null;
+	let shardTotal = null;
+	let remaining = rest;
+	if (/^\d+$/.test(remaining[0] ?? '') && /^\d+$/.test(remaining[1] ?? '')) {
+		shardIndex = Number.parseInt(remaining[0], 10);
+		shardTotal = Number.parseInt(remaining[1], 10);
+		remaining = remaining.slice(2);
+	}
+
+	let baseRef = null;
+	const changedFiles = [];
+	for (let index = 0; index < remaining.length; index += 1) {
+		const arg = remaining[index];
+		if (arg === '--changed-file') {
+			const changedFile = remaining[index + 1];
+			if (!changedFile) {
+				throw new Error('affected-lane --changed-file requires a path.');
+			}
+			changedFiles.push(changedFile);
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith('--')) {
+			throw new Error(`Unknown affected-lane option: ${arg}`);
+		}
+		if (baseRef) {
+			throw new Error(`Unexpected affected-lane argument: ${arg}`);
+		}
+		baseRef = arg;
+	}
+
+	return { laneName, shardIndex, shardTotal, baseRef, changedFiles: changedFiles.length > 0 ? changedFiles : null };
+}
+
+function runAffectedLane(commandArgs, extraArgs) {
+	const { laneName, shardIndex, shardTotal, baseRef, changedFiles } = parseAffectedLaneArgs(commandArgs);
+	const { lanes } = classifyFiles();
+	const lane = lanes[laneName];
+	if (!lane) {
+		throw new Error(`Unknown lane: ${laneName}\n${usage()}`);
+	}
+
+	const plan = buildAffectedPlan(baseRef, changedFiles);
+	const laneFiles = plan.weightedFiles.filter((file) => file.lane === laneName);
+	let selected = {
+		index: 1,
+		totalWeight: laneFiles.reduce((sum, file) => sum + file.weight, 0),
+		files: laneFiles,
+	};
+	if (shardIndex !== null || shardTotal !== null) {
+		if (shardIndex === null || shardTotal === null) {
+			throw new Error('affected-lane sharding requires both shardIndex and shardTotal.');
+		}
+		if (!Number.isInteger(shardIndex) || shardIndex <= 0 || shardIndex > shardTotal) {
+			throw new Error(`Shard index must be between 1 and ${shardTotal}, got: ${shardIndex}`);
+		}
+		selected = partitionFiles(laneFiles, shardTotal)[shardIndex - 1];
+	}
+
+	const label =
+		shardTotal === null ? `affected-${laneName}` : `affected-${laneName}-${selected.index}-of-${shardTotal}`;
+	process.stdout.write(
+		formatPlan(`Running ${label}${baseRef ? ` against ${baseRef}` : ''}`, selected.files, selected.totalWeight),
+	);
+	process.exit(runVitest(label, selected.files, lane.serial, extraArgs));
 }
 
 const rawArgs = process.argv.slice(2);
@@ -575,7 +1052,15 @@ try {
 		);
 	} else if (command === 'affected') {
 		const [baseRef] = commandArgs;
-		runAffected(baseRef, extraArgs);
+		if (baseRef?.startsWith('--')) {
+			runAffected(null, [...commandArgs, ...extraArgs]);
+		} else {
+			runAffected(baseRef, extraArgs);
+		}
+	} else if (command === 'affected-plan') {
+		printAffectedPlan(commandArgs);
+	} else if (command === 'affected-lane') {
+		runAffectedLane(commandArgs, extraArgs);
 	} else {
 		throw new Error(usage());
 	}

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -11,7 +11,15 @@ const GCP_WORKFLOW = resolve(ROOT, '.github/workflows/gcp-tests.yml');
 const README = resolve(ROOT, 'README.md');
 const TESTING_STRATEGY_DOC = resolve(ROOT, 'docs/testing-strategy.md');
 const TEST_SCOPE_SCRIPT = resolve(ROOT, 'scripts/test-scope.mjs');
+const TEST_LANES_SCRIPT = resolve(ROOT, 'scripts/test-lanes.mjs');
 const PACKAGE_JSON = resolve(ROOT, 'package.json');
+
+type AffectedPlan = {
+	totalFiles: number;
+	lanes: Record<string, { count: number; files: string[]; totalWeight: number }>;
+	files: Array<{ relativePath: string; lane: string; weight: number }>;
+	rules: Array<{ changedFile: string; rule: string; selectedFiles: string[] }>;
+};
 
 function runVitest(args: string[], env?: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
 	const result = spawnSync('pnpm', ['vitest', 'run', ...args], {
@@ -36,6 +44,27 @@ function runVitest(args: string[], env?: Record<string, string>): { stdout: stri
 		stderr: result.stderr ?? '',
 		exitCode: result.status ?? 1,
 	};
+}
+
+function runTestLanes(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [TEST_LANES_SCRIPT, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: 60_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function affectedPlanFor(changedFile: string): AffectedPlan {
+	const result = runTestLanes(['affected-plan', '--changed-file', changedFile, '--json']);
+	expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+	return JSON.parse(result.stdout) as AffectedPlan;
 }
 
 function resetSchemaToMissing(): void {
@@ -112,12 +141,21 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		const gcpWorkflow = readFileSync(GCP_WORKFLOW, 'utf-8');
 
 		expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
+		expect(ciWorkflow).toContain('pr-affected-plan');
+		expect(ciWorkflow).toContain('pr-affected-schema');
+		expect(ciWorkflow).toContain('pr-affected-db');
+		expect(ciWorkflow).toContain('pr-affected-heavy');
 		expect(ciWorkflow).toContain('pr-affected-tests');
+		expect(ciWorkflow).toContain('Check affected lane results');
 		expect(ciWorkflow).toContain('full-schema-tests');
 		expect(ciWorkflow).toContain('full-db-tests');
 		expect(ciWorkflow).toContain('full-heavy-tests');
 		expect(ciWorkflow).toContain('full-external-tests');
-		expect(ciWorkflow).toContain('pnpm test:affected');
+		expect(ciWorkflow).toContain('affected-plan origin/');
+		expect(ciWorkflow).toContain('--json > .test-results/affected-plan.json');
+		expect(ciWorkflow).toContain('pnpm test:affected:lane -- schema');
+		expect(ciWorkflow).toContain('pnpm test:affected:lane -- db');
+		expect(ciWorkflow).toContain('pnpm test:affected:lane -- heavy');
 		expect(ciWorkflow).toContain('pnpm test:lane -- schema');
 		expect(ciWorkflow).toContain('pnpm test:lane -- db');
 		expect(ciWorkflow).toContain('pnpm test:lane -- heavy');
@@ -146,7 +184,103 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		expect(testingStrategy).toContain(
 			'Put tests that require real Docker, GCP credentials, paid services, or live external services in `external`',
 		);
+		expect(testingStrategy).toContain('pnpm test:affected:plan');
+		expect(testingStrategy).toContain('normal feature PR should stay near 8-15 minutes');
 		expect(testingStrategy).toContain('pnpm test:lanes:verify');
+	});
+
+	it('QA-05d: affected planning stays narrow for reprocess config changes', () => {
+		const plan = affectedPlanFor('packages/core/src/config/reprocess-hash.ts');
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(plan.totalFiles).toBeLessThan(20);
+		expect(files).toEqual(
+			expect.arrayContaining([
+				'tests/specs/03_config_loader.test.ts',
+				'tests/specs/77_cost_estimator.test.ts',
+				'tests/specs/78_selective_reprocessing.test.ts',
+				'tests/specs/100_document_quality_assessment_step.test.ts',
+			]),
+		);
+		expect(files).not.toContain('tests/specs/77_large_pdf_browser_upload_flow.test.ts');
+		expect(files).not.toContain('tests/specs/78_devlog_system.test.ts');
+		expect(plan.lanes.heavy.count).toBe(0);
+	});
+
+	it('QA-05e: testinfra changes select infrastructure smokes instead of the full suite', () => {
+		const plan = affectedPlanFor('scripts/test-lanes.mjs');
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(plan.totalFiles).toBe(2);
+		expect(files).toEqual(
+			expect.arrayContaining([
+				'tests/specs/02_monorepo_setup.test.ts',
+				'tests/specs/59_hermetic_test_infrastructure.test.ts',
+			]),
+		);
+		expect(plan.lanes.heavy.count).toBe(0);
+		expect(plan.lanes.db.count + plan.lanes.schema.count).toBe(2);
+	});
+
+	it('QA-05e2: affected planning maps colliding spec docs to exact tests', () => {
+		const plan = affectedPlanFor('docs/specs/77_cost_estimator.spec.md');
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(plan.totalFiles).toBe(1);
+		expect(files).toEqual(['tests/specs/77_cost_estimator.test.ts']);
+		expect(files).not.toContain('tests/specs/77_large_pdf_browser_upload_flow.test.ts');
+		expect(files).not.toContain('tests/specs/77_document_observability_route.test.ts');
+	});
+
+	it('QA-05e3: package-level affected planning uses package-specific mappings', () => {
+		const retrievalPlan = affectedPlanFor('packages/retrieval/src/orchestrator.ts');
+		const taxonomyPlan = affectedPlanFor('packages/taxonomy/src/merge.ts');
+
+		expect(retrievalPlan.files.map((file) => file.relativePath)).toEqual(
+			expect.arrayContaining([
+				'tests/specs/37_vector_search_retrieval.test.ts',
+				'tests/specs/42_hybrid_retrieval_orchestrator.test.ts',
+				'tests/specs/43_retrieval_metrics.test.ts',
+			]),
+		);
+		expect(retrievalPlan.totalFiles).toBeLessThan(10);
+		expect(retrievalPlan.lanes.heavy.count).toBe(0);
+
+		expect(taxonomyPlan.files.map((file) => file.relativePath)).toEqual(
+			expect.arrayContaining([
+				'tests/specs/27_taxonomy_normalization.test.ts',
+				'tests/specs/50_taxonomy_export_curate_merge.test.ts',
+			]),
+		);
+		expect(taxonomyPlan.totalFiles).toBeLessThan(10);
+	});
+
+	it('QA-05f: affected lane shards pass cleanly when their selected shard is empty', () => {
+		const emptyDbShard = runTestLanes([
+			'affected-lane',
+			'db',
+			'2',
+			'2',
+			'--changed-file',
+			'scripts/test-lanes.mjs',
+			'--',
+			'--reporter=verbose',
+		]);
+		const emptyHeavyShard = runTestLanes([
+			'affected-lane',
+			'heavy',
+			'1',
+			'3',
+			'--changed-file',
+			'packages/core/src/config/reprocess-hash.ts',
+			'--',
+			'--reporter=verbose',
+		]);
+
+		expect(emptyDbShard.exitCode, `${emptyDbShard.stdout}\n${emptyDbShard.stderr}`).toBe(0);
+		expect(emptyDbShard.stdout).toContain('No tests selected for affected-db-2-of-2; passing.');
+		expect(emptyHeavyShard.exitCode, `${emptyHeavyShard.stdout}\n${emptyHeavyShard.stderr}`).toBe(0);
+		expect(emptyHeavyShard.stdout).toContain('No tests selected for affected-heavy-1-of-3; passing.');
 	});
 
 	it('QA-06: the lane runner and dev storage honor isolated test storage roots', () => {


### PR DESCRIPTION
## Summary
- add explainable affected test plans and per-lane affected execution
- split PR affected checks into plan/schema/db/heavy jobs with an aggregator check
- tighten affected mappings for M10 testinfra, config, package, and colliding spec-doc cases

## Verification
- pnpm lint
- pnpm build
- pnpm test:lanes:verify
- pnpm vitest run tests/specs/59_hermetic_test_infrastructure.test.ts --reporter=verbose
- MULDER_TEST_ISOLATED_DB=true MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED=true pnpm test:affected -- --reporter=verbose
