### PR TITLE
Add sensitivity tagging auto-detection for M10-K5

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -291,7 +291,7 @@ Must complete before first real archive data ingest. Without these foundations, 
 | 🟢 | K2 | Provenance tracking — `source_document_ids` on all artifacts | §A6.1 |
 | 🟢 | K3 | Document quality assessment step | §A4 |
 | 🟢 | K4 | Assertion classification in Enrich step | §A3 |
-| ⚪ | K5 | Sensitivity level tagging + auto-detection | §A5 |
+| 🟡 | K5 | Sensitivity level tagging + auto-detection | §A5 |
 | ⚪ | K6 | Source rollback — soft-delete + cascading purge | §A6 |
 | ⚪ | K7 | Ingest provenance data model — AcquisitionContext, ArchiveLocation, Archive, CustodyChain | §A2.3 |
 | ⚪ | K8 | Collection management — create, tag, defaults | §A2.3 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -291,7 +291,7 @@ Must complete before first real archive data ingest. Without these foundations, 
 | 🟢 | K2 | Provenance tracking — `source_document_ids` on all artifacts | §A6.1 |
 | 🟢 | K3 | Document quality assessment step | §A4 |
 | 🟢 | K4 | Assertion classification in Enrich step | §A3 |
-| 🟡 | K5 | Sensitivity level tagging + auto-detection | §A5 |
+| 🟢 | K5 | Sensitivity level tagging + auto-detection | §A5 |
 | ⚪ | K6 | Source rollback — soft-delete + cascading purge | §A6 |
 | ⚪ | K7 | Ingest provenance data model — AcquisitionContext, ArchiveLocation, Archive, CustodyChain | §A2.3 |
 | ⚪ | K8 | Collection management — create, tag, defaults | §A2.3 |

--- a/docs/specs/102_sensitivity_tagging_auto_detection.spec.md
+++ b/docs/specs/102_sensitivity_tagging_auto_detection.spec.md
@@ -1,0 +1,177 @@
+---
+spec: 102
+title: "Sensitivity Tagging And Auto Detection"
+roadmap_step: "M10-K5"
+functional_spec: "§A5, §A1, §A2"
+scope: "phased"
+issue: "https://github.com/mulkatz/mulder/issues/271"
+created: 2026-05-05
+---
+
+# Spec 102: Sensitivity Tagging And Auto Detection
+
+## 1. Objective
+
+Complete M10-K5 by adding sensitivity levels to Mulder's current document and artifact records, then wiring config-driven auto-detection into Enrich. §A5 defines four generic levels, `public`, `internal`, `restricted`, and `confidential`, and requires sensitivity assignment at the finest practical artifact level with upward propagation. This step creates that data foundation before archive ingest, without implementing RBAC enforcement or external-query filtering.
+
+K5 matters because provenance and assertion records are only safe for real archives if Mulder can distinguish public material from internal or restricted personal information. The default remains conservative: minimal config starts at `internal`, and auto-detection can raise the level when Enrich observes configured PII or sensitive information.
+
+## 2. Boundaries
+
+**Roadmap step:** M10-K5 - Sensitivity level tagging + auto-detection.
+
+**Base branch:** `milestone/10`. This spec is delivered to the M10 integration branch, not directly to `main`.
+
+**Target branch:** `feat/271-sensitivity-tagging-auto-detection`.
+
+**In scope:**
+
+- Add `sensitivity_level` and `sensitivity_metadata` to current document/artifact tables: `sources`, `stories`, `entities`, `entity_aliases`, `story_entities`, `chunks`, `entity_edges`, and `knowledge_assertions`.
+- Add shared sensitivity types and normalization helpers for the §A5 level and metadata shape.
+- Add config under `access_control.sensitivity` with the §A5 defaults needed for tagging and auto-detection.
+- Extend Enrich structured output so auto-detection can return sensitivity metadata for extracted entities, relationships, and assertions when enabled.
+- Persist detected sensitivity on entities, story-entity links, entity edges, and knowledge assertions.
+- Propagate the most restrictive child artifact level upward to the story and source after Enrich writes complete.
+- Preserve backward compatibility for existing rows and repository reads by defaulting to `internal` sensitivity.
+
+**Out of scope:**
+
+- RBAC roles, permissions, request filtering, API authorization, or UI visibility gates. Those belong to M11-L5.
+- External query sanitization or web-research blocking. That belongs to later agent/query-gate work.
+- Human review workflows, sensitivity-change audit screens, or declassification scheduling beyond storing nullable metadata fields.
+- Pseudonymization or redaction of stored content.
+- Sensitivity-aware export filtering. That belongs to M13-P3.
+
+**Primary files:**
+
+- `packages/core/src/database/migrations/031_sensitivity_levels.sql`
+- `packages/core/src/shared/sensitivity.ts`
+- `packages/core/src/config/schema.ts`
+- `packages/core/src/config/defaults.ts`
+- `packages/core/src/config/types.ts`
+- `packages/core/src/database/repositories/source.types.ts`
+- `packages/core/src/database/repositories/story.types.ts`
+- `packages/core/src/database/repositories/entity.types.ts`
+- `packages/core/src/database/repositories/edge.types.ts`
+- `packages/core/src/database/repositories/chunk.types.ts`
+- `packages/core/src/database/repositories/knowledge-assertion.types.ts`
+- `packages/core/src/database/repositories/*.repository.ts` files for those mapped types
+- `packages/core/src/database/repositories/index.ts`
+- `packages/pipeline/src/enrich/schema.ts`
+- `packages/pipeline/src/enrich/types.ts`
+- `packages/pipeline/src/enrich/index.ts`
+- `packages/core/src/prompts/templates/extract-entities.jinja2`
+- `tests/specs/102_sensitivity_tagging_auto_detection.test.ts`
+- `docs/roadmap.md`
+
+## 3. Dependencies
+
+- M10-K1 / Spec 98: source documents are backed by durable content-addressed storage.
+- M10-K2 / Spec 99: artifacts carry source provenance.
+- M10-K3 / Spec 100: quality metadata can coexist with downstream artifacts.
+- M10-K4 / Spec 101: `knowledge_assertions` exists and can receive artifact metadata.
+
+K5 blocks M10-K6 because rollback must preserve or purge sensitivity-bearing artifacts consistently, and it blocks later RBAC/export/query-gate work that consumes `sensitivity_level`.
+
+## 4. Blueprint
+
+1. Add migration `031_sensitivity_levels.sql`:
+   - Add `sensitivity_level TEXT NOT NULL DEFAULT 'internal'` and `sensitivity_metadata JSONB NOT NULL DEFAULT ...` to `sources`, `stories`, `entities`, `entity_aliases`, `story_entities`, `chunks`, `entity_edges`, and `knowledge_assertions`.
+   - Constrain levels to `public`, `internal`, `restricted`, `confidential`.
+   - Require metadata keys `level`, `reason`, `assigned_by`, `assigned_at`, `pii_types`, and `declassify_date`, with `pii_types` as a JSON array and `level` matching `sensitivity_level`.
+   - Backfill existing rows to `internal`, `reason = 'default_policy'`, `assigned_by = 'policy_rule'`, `pii_types = []`, and `declassify_date = null`.
+   - Add indexes for `sensitivity_level` on high-volume tables and keep GIN usage minimal.
+
+2. Add shared sensitivity helpers:
+   - Export `SensitivityLevel`, `SensitivityAssignmentSource`, `PIIType`, `SensitivityMetadata`, and `SensitivityTagged`.
+   - Provide `normalizeSensitivityMetadata`, `defaultSensitivityMetadata`, `mostRestrictiveSensitivityLevel`, and `mergeSensitivityMetadata`.
+   - Keep helpers domain-agnostic and free of RBAC policy decisions.
+
+3. Add config:
+   - `access_control.enabled` default `true`.
+   - `access_control.sensitivity.levels` default `['public', 'internal', 'restricted', 'confidential']`.
+   - `access_control.sensitivity.default_level` default `internal`.
+   - `access_control.sensitivity.auto_detection` default `true`.
+   - `access_control.sensitivity.propagation` enum with `upward` default.
+   - `access_control.sensitivity.pii_types` default to the §A5 PII type list.
+   - Add only lightweight placeholders for RBAC/external query gate if needed for config shape; do not implement enforcement.
+
+4. Update repository mappings:
+   - Add sensitivity fields to public mapped types for sources, stories, entities, aliases, story entities, chunks, edges, and knowledge assertions.
+   - Add optional sensitivity input fields where writers create or upsert those rows.
+   - Normalize missing or legacy values to the configured/default `internal` shape.
+   - Preserve idempotent upsert behavior and provenance merging.
+
+5. Extend Enrich structured output and prompt:
+   - Add optional `sensitivity` metadata to extracted entity, relationship, and assertion objects.
+   - When `access_control.sensitivity.auto_detection` is true, generated JSON Schema requires the sensitivity object and constrains levels and PII types.
+   - When auto-detection is false, existing Enrich response shapes remain valid and writers use the configured default.
+   - Prompt text must explain the four generic levels, the configured PII type vocabulary, and conservative upward classification.
+
+6. Wire Enrich persistence and propagation:
+   - Pass sensitivity metadata to entity, story-entity, edge, and assertion writes.
+   - Use `assigned_by = 'llm_auto'` for model-detected metadata and `assigned_by = 'policy_rule'` for default metadata.
+   - After Enrich writes child artifacts, set the story sensitivity to the most restrictive child level when propagation is `upward`.
+   - Set the source sensitivity to the most restrictive story/artifact level for that source.
+   - Preserve `--force` behavior and avoid duplicate rows or stale child sensitivity after reruns.
+
+7. Update roadmap state only after gates:
+   - Keep K5 marked in progress while implementation is open.
+   - Mark K5 complete only after scoped tests, affected checks, review, and PR merge to `milestone/10`.
+
+## 5. QA Contract
+
+1. **QA-01: Migration adds constrained sensitivity fields**
+   - Given a migrated database
+   - When schema metadata is inspected for current document/artifact tables
+   - Then each table has `sensitivity_level`, `sensitivity_metadata`, valid level constraints, metadata shape checks, and default internal metadata for existing rows.
+
+2. **QA-02: Config exposes §A5 tagging defaults**
+   - Given minimal config
+   - When the public config loader resolves defaults
+   - Then `access_control.sensitivity` is enabled with the four levels, default `internal`, auto-detection true, upward propagation, and the §A5 PII type vocabulary.
+
+3. **QA-03: Shared helpers choose the most restrictive level**
+   - Given multiple sensitivity metadata objects
+   - When helper APIs merge or compare them
+   - Then `confidential` outranks `restricted`, which outranks `internal`, which outranks `public`, and PII type arrays remain unique.
+
+4. **QA-04: Repository reads and writes round-trip sensitivity**
+   - Given sources, stories, entities, edges, chunks, and assertions with explicit sensitivity metadata
+   - When public repository APIs create, upsert, and read those records
+   - Then returned objects expose normalized sensitivity level and metadata.
+
+5. **QA-05: Enrich auto-detection writes child artifact sensitivity**
+   - Given deterministic Enrich fixture output containing `restricted` entity sensitivity, `internal` relationship sensitivity, and `confidential` assertion sensitivity
+   - When Enrich runs with auto-detection enabled
+   - Then the created entity, story-entity link, edge, and assertion rows store the detected levels and metadata.
+
+6. **QA-06: Upward propagation updates story and source**
+   - Given the same Enrich run with child artifacts at multiple levels
+   - When Enrich completes
+   - Then the story and source sensitivity are updated to the most restrictive child level.
+
+7. **QA-07: Disabled auto-detection preserves existing Enrich compatibility**
+   - Given Enrich model output without sensitivity objects
+   - When auto-detection is disabled
+   - Then Enrich succeeds, no validation error is thrown, and created artifacts receive the configured default sensitivity.
+
+8. **QA-08: Force reruns do not leave stale higher sensitivity**
+   - Given a story enriched once with confidential child artifacts
+   - When `--force` reruns Enrich with only internal child artifacts
+   - Then active child artifacts, story, and source no longer retain stale confidential sensitivity from deleted/replaced rows.
+
+## 5b. CLI Test Matrix
+
+No new CLI commands are added. Existing commands must remain valid:
+
+| Command | Fixture | Expected |
+| --- | --- | --- |
+| `mulder config validate <minimal-config>` | Minimal config without `access_control` | Exit 0; default sensitivity config is accepted. |
+| `mulder config show <minimal-config>` | Minimal config without `access_control` | Output includes resolved `access_control.sensitivity` defaults. |
+| `mulder enrich <source-id>` | Segmented source with sensitivity-bearing fixture output | Exit 0; child artifacts plus story/source expose sensitivity metadata. |
+| `mulder enrich --force <source-id>` | Previously enriched source | Exit 0; sensitivity propagation reflects the rerun output. |
+
+## 6. Cost Considerations
+
+K5 does not add a new paid service call. It extends the existing Enrich structured-output payload, so model output tokens may increase when auto-detection is enabled. The feature remains config-driven so local, benchmark, or low-cost runs can disable auto-detection and rely on the default policy-rule sensitivity metadata.

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -89,6 +89,33 @@ export const CONFIG_DEFAULTS = {
 		},
 	},
 
+	access_control: {
+		enabled: true,
+		sensitivity: {
+			levels: ['public', 'internal', 'restricted', 'confidential'],
+			default_level: 'internal' as const,
+			auto_detection: true,
+			propagation: 'upward' as const,
+			pii_types: [
+				'person_name',
+				'contact_info',
+				'medical_data',
+				'location_private',
+				'location_sighting',
+				'financial',
+				'unpublished_research',
+				'legal',
+			],
+		},
+		rbac: {
+			roles_source: 'config/roles.yaml',
+			default_role: 'analyst',
+		},
+		external_query_gate: {
+			enabled: false,
+		},
+	},
+
 	enrichment: {
 		model: 'gemini-2.5-flash',
 		max_story_tokens: 15000,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -11,6 +11,8 @@ export type { ReprocessHashStepName } from './reprocess-hash.js';
 export { computeReprocessConfigHash, getReprocessConfigSubset } from './reprocess-hash.js';
 export { mulderConfigSchema } from './schema.js';
 export type {
+	AccessControlConfig,
+	AccessControlSensitivityConfig,
 	AnalysisConfig,
 	ApiAuthConfig,
 	ApiAuthKeyConfig,

--- a/packages/core/src/config/reprocess-hash.ts
+++ b/packages/core/src/config/reprocess-hash.ts
@@ -23,6 +23,10 @@ type ReprocessHashSubset =
 	| { extraction: MulderConfig['extraction'] }
 	| { extraction: { segmentation: MulderConfig['extraction']['segmentation'] } }
 	| {
+			access_control: {
+				enabled: MulderConfig['access_control']['enabled'];
+				sensitivity: MulderConfig['access_control']['sensitivity'];
+			};
 			ontology: MulderConfig['ontology'];
 			enrichment: MulderConfig['enrichment'];
 			taxonomy: MulderConfig['taxonomy'];
@@ -77,6 +81,10 @@ export function getReprocessConfigSubset(config: MulderConfig, step: ReprocessHa
 			return { extraction: { segmentation: config.extraction.segmentation } };
 		case 'enrich':
 			return {
+				access_control: {
+					enabled: config.access_control.enabled,
+					sensitivity: config.access_control.sensitivity,
+				},
 				ontology: config.ontology,
 				enrichment: config.enrichment,
 				taxonomy: config.taxonomy,

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { PII_TYPES, SENSITIVITY_LEVELS } from '../shared/sensitivity.js';
 
 /**
  * Zod 4 helper: `.default({})` no longer works because the default must match
@@ -209,6 +210,36 @@ const documentQualityObj = z.object({
 	manual_queue: documentQualityManualQueueSchema.default(defaults(documentQualityManualQueueSchema)),
 });
 const documentQualitySchema = documentQualityObj.default(defaults(documentQualityObj));
+
+// --- Access Control ---
+
+const sensitivityLevelSchema = z.enum(SENSITIVITY_LEVELS);
+const piiTypeSchema = z.enum(PII_TYPES);
+
+const accessControlSensitivitySchema = z.object({
+	levels: z.array(sensitivityLevelSchema).default([...SENSITIVITY_LEVELS]),
+	default_level: sensitivityLevelSchema.default('internal'),
+	auto_detection: z.boolean().default(true),
+	propagation: z.enum(['upward']).default('upward'),
+	pii_types: z.array(piiTypeSchema).default([...PII_TYPES]),
+});
+
+const accessControlRbacSchema = z.object({
+	roles_source: z.string().min(1).default('config/roles.yaml'),
+	default_role: z.string().min(1).default('analyst'),
+});
+
+const accessControlExternalQueryGateSchema = z.object({
+	enabled: z.boolean().default(false),
+});
+
+const accessControlObj = z.object({
+	enabled: z.boolean().default(true),
+	sensitivity: accessControlSensitivitySchema.default(defaults(accessControlSensitivitySchema)),
+	rbac: accessControlRbacSchema.default(defaults(accessControlRbacSchema)),
+	external_query_gate: accessControlExternalQueryGateSchema.default(defaults(accessControlExternalQueryGateSchema)),
+});
+const accessControlSchema = accessControlObj.default(defaults(accessControlObj));
 
 // --- Enrichment ---
 
@@ -479,6 +510,7 @@ const baseMulderConfigSchema = z.object({
 	ingestion: ingestionSchema,
 	extraction: extractionSchema,
 	document_quality: documentQualitySchema,
+	access_control: accessControlSchema,
 	enrichment: enrichmentSchema,
 	taxonomy: taxonomySchema,
 	entity_resolution: entityResolutionSchema,
@@ -539,6 +571,8 @@ export const mulderConfigSchema = baseMulderConfigSchema.superRefine((data, ctx)
 
 // Export section schemas for reuse
 export {
+	accessControlSchema,
+	accessControlSensitivitySchema,
 	analysisSchema,
 	apiBudgetSchema,
 	apiSchema,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -5,6 +5,8 @@
 
 import type { z } from 'zod';
 import type {
+	accessControlSchema,
+	accessControlSensitivitySchema,
 	analysisSchema,
 	apiBudgetSchema,
 	apiSchema,
@@ -39,6 +41,8 @@ import type {
 // --- Section Types ---
 
 export type ProjectConfig = z.infer<typeof projectSchema>;
+export type AccessControlConfig = z.infer<typeof accessControlSchema>;
+export type AccessControlSensitivityConfig = z.infer<typeof accessControlSensitivitySchema>;
 export type ApiConfig = z.infer<typeof apiSchema>;
 export type ApiAuthKeyConfig = ApiConfig['auth']['api_keys'][number];
 export type ApiAuthConfig = ApiConfig['auth'];

--- a/packages/core/src/database/migrations/031_sensitivity_levels.sql
+++ b/packages/core/src/database/migrations/031_sensitivity_levels.sql
@@ -1,0 +1,98 @@
+DO $$
+DECLARE
+  table_name TEXT;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'sources',
+    'stories',
+    'entities',
+    'entity_aliases',
+    'story_entities',
+    'chunks',
+    'entity_edges',
+    'knowledge_assertions'
+  ]
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE %I
+        ADD COLUMN IF NOT EXISTS sensitivity_level TEXT NOT NULL DEFAULT ''internal'',
+        ADD COLUMN IF NOT EXISTS sensitivity_metadata JSONB NOT NULL DEFAULT jsonb_build_object(
+          ''level'', ''internal'',
+          ''reason'', ''default_policy'',
+          ''assigned_by'', ''policy_rule'',
+          ''assigned_at'', to_jsonb(now()),
+          ''pii_types'', ''[]''::jsonb,
+          ''declassify_date'', ''null''::jsonb
+        )',
+      table_name
+    );
+
+    EXECUTE format(
+      'UPDATE %I
+        SET
+          sensitivity_level = COALESCE(sensitivity_level, ''internal''),
+          sensitivity_metadata = jsonb_build_object(
+            ''level'', COALESCE(sensitivity_level, ''internal''),
+            ''reason'', COALESCE(NULLIF(sensitivity_metadata->>''reason'', ''''), ''default_policy''),
+            ''assigned_by'', COALESCE(NULLIF(sensitivity_metadata->>''assigned_by'', ''''), ''policy_rule''),
+            ''assigned_at'', COALESCE(NULLIF(sensitivity_metadata->>''assigned_at'', ''''), now()::text),
+            ''pii_types'', CASE
+              WHEN jsonb_typeof(sensitivity_metadata->''pii_types'') = ''array''
+                THEN sensitivity_metadata->''pii_types''
+              ELSE ''[]''::jsonb
+            END,
+            ''declassify_date'', COALESCE(sensitivity_metadata->''declassify_date'', ''null''::jsonb)
+          )',
+      table_name
+    );
+
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = table_name || '_sensitivity_level_check'
+    ) THEN
+      EXECUTE format(
+        'ALTER TABLE %I
+          ADD CONSTRAINT %I CHECK (
+            sensitivity_level IN (''public'', ''internal'', ''restricted'', ''confidential'')
+          )',
+        table_name,
+        table_name || '_sensitivity_level_check'
+      );
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = table_name || '_sensitivity_metadata_shape_check'
+    ) THEN
+      EXECUTE format(
+        'ALTER TABLE %I
+          ADD CONSTRAINT %I CHECK (
+            jsonb_typeof(sensitivity_metadata) = ''object''
+            AND sensitivity_metadata ? ''level''
+            AND sensitivity_metadata ? ''reason''
+            AND sensitivity_metadata ? ''assigned_by''
+            AND sensitivity_metadata ? ''assigned_at''
+            AND sensitivity_metadata ? ''pii_types''
+            AND sensitivity_metadata ? ''declassify_date''
+            AND sensitivity_metadata->>''level'' = sensitivity_level
+            AND sensitivity_metadata->>''level'' IN (''public'', ''internal'', ''restricted'', ''confidential'')
+            AND sensitivity_metadata->>''assigned_by'' IN (''llm_auto'', ''human'', ''policy_rule'')
+            AND jsonb_typeof(sensitivity_metadata->''pii_types'') = ''array''
+            AND (
+              sensitivity_metadata->''declassify_date'' = ''null''::jsonb
+              OR jsonb_typeof(sensitivity_metadata->''declassify_date'') = ''string''
+            )
+          )',
+        table_name,
+        table_name || '_sensitivity_metadata_shape_check'
+      );
+    END IF;
+
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS %I ON %I (sensitivity_level)',
+      'idx_' || table_name || '_sensitivity_level',
+      table_name
+    );
+  END LOOP;
+END;
+$$;

--- a/packages/core/src/database/repositories/chunk.repository.ts
+++ b/packages/core/src/database/repositories/chunk.repository.ts
@@ -29,6 +29,7 @@ import type {
 	FtsSearchResult,
 	VectorSearchResult,
 } from './chunk.types.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'chunk-repository' });
@@ -120,6 +121,22 @@ export async function createChunk(pool: pg.Pool, input: CreateChunkInput): Promi
     VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9, $10::jsonb, $11, $12::jsonb)
     RETURNING *, embedding::text
   `;
+	const legacySql = hasExplicitId
+		? `
+    INSERT INTO chunks (id, story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7::vector, $8, $9, $10, $11::jsonb)
+    ON CONFLICT (id) DO UPDATE SET
+      content = EXCLUDED.content,
+      embedding = EXCLUDED.embedding,
+      metadata = EXCLUDED.metadata,
+      provenance = ${mergeArtifactProvenanceSql('chunks.provenance', 'EXCLUDED.provenance')}
+    RETURNING *, embedding::text
+  `
+		: `
+    INSERT INTO chunks (story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9, $10::jsonb)
+    RETURNING *, embedding::text
+  `;
 	const baseParams = [
 		input.storyId,
 		input.content,
@@ -135,9 +152,11 @@ export async function createChunk(pool: pg.Pool, input: CreateChunkInput): Promi
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
+	const legacyBaseParams = baseParams.slice(0, -2);
+	const legacyParams = hasExplicitId ? [input.id, ...legacyBaseParams] : legacyBaseParams;
 
 	try {
-		const result = await pool.query<ChunkRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<ChunkRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ chunkId: row.id, storyId: input.storyId }, 'Chunk created');
 		return mapChunkRow(row);

--- a/packages/core/src/database/repositories/chunk.repository.ts
+++ b/packages/core/src/database/repositories/chunk.repository.ts
@@ -15,6 +15,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -69,6 +70,8 @@ export function mapChunkRow(row: ChunkRow): Chunk {
 		parentChunkId: row.parent_chunk_id,
 		metadata: row.metadata ?? {},
 		provenance: mapArtifactProvenanceFromDb(row.provenance),
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 	};
 }
@@ -98,20 +101,23 @@ function formatEmbedding(embedding: number[] | null | undefined): string | null 
 export async function createChunk(pool: pg.Pool, input: CreateChunkInput): Promise<Chunk> {
 	const embeddingLiteral = formatEmbedding(input.embedding);
 	const hasExplicitId = input.id !== undefined;
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = hasExplicitId
 		? `
-    INSERT INTO chunks (id, story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7::vector, $8, $9, $10, $11::jsonb)
+    INSERT INTO chunks (id, story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7::vector, $8, $9, $10, $11::jsonb, $12, $13::jsonb)
     ON CONFLICT (id) DO UPDATE SET
       content = EXCLUDED.content,
       embedding = EXCLUDED.embedding,
       metadata = EXCLUDED.metadata,
-      provenance = ${mergeArtifactProvenanceSql('chunks.provenance', 'EXCLUDED.provenance')}
+      provenance = ${mergeArtifactProvenanceSql('chunks.provenance', 'EXCLUDED.provenance')},
+      sensitivity_level = EXCLUDED.sensitivity_level,
+      sensitivity_metadata = EXCLUDED.sensitivity_metadata
     RETURNING *, embedding::text
   `
 		: `
-    INSERT INTO chunks (story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9, $10::jsonb)
+    INSERT INTO chunks (story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9, $10::jsonb, $11, $12::jsonb)
     RETURNING *, embedding::text
   `;
 	const baseParams = [
@@ -125,6 +131,8 @@ export async function createChunk(pool: pg.Pool, input: CreateChunkInput): Promi
 		input.parentChunkId ?? null,
 		JSON.stringify(input.metadata ?? {}),
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
 
@@ -164,6 +172,8 @@ export async function createChunks(pool: pg.Pool, inputs: CreateChunkInput[]): P
 	const parentChunkIds: (string | null)[] = [];
 	const metadatas: string[] = [];
 	const provenances: string[] = [];
+	const sensitivityLevels: string[] = [];
+	const sensitivityMetadatas: string[] = [];
 
 	for (const input of inputs) {
 		storyIds.push(input.storyId);
@@ -176,10 +186,13 @@ export async function createChunks(pool: pg.Pool, inputs: CreateChunkInput[]): P
 		parentChunkIds.push(input.parentChunkId ?? null);
 		metadatas.push(JSON.stringify(input.metadata ?? {}));
 		provenances.push(stringifyArtifactProvenance(input.provenance));
+		const sensitivityLevel = input.sensitivityLevel ?? 'internal';
+		sensitivityLevels.push(sensitivityLevel);
+		sensitivityMetadatas.push(stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel));
 	}
 
 	const sql = `
-    INSERT INTO chunks (story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance)
+    INSERT INTO chunks (story_id, content, chunk_index, page_start, page_end, embedding, is_question, parent_chunk_id, metadata, provenance, sensitivity_level, sensitivity_metadata)
     SELECT
       unnest($1::uuid[]),
       unnest($2::text[]),
@@ -190,7 +203,9 @@ export async function createChunks(pool: pg.Pool, inputs: CreateChunkInput[]): P
       unnest($7::boolean[]),
       unnest($8::uuid[]),
       unnest($9::jsonb[]),
-      unnest($10::jsonb[])
+      unnest($10::jsonb[]),
+      unnest($11::text[]),
+      unnest($12::jsonb[])
     RETURNING *, embedding::text
   `;
 
@@ -206,6 +221,8 @@ export async function createChunks(pool: pg.Pool, inputs: CreateChunkInput[]): P
 			parentChunkIds,
 			metadatas,
 			provenances,
+			sensitivityLevels,
+			sensitivityMetadatas,
 		]);
 		repoLogger.debug({ count: result.rows.length, storyId: inputs[0].storyId }, 'Batch chunks created');
 		return result.rows.map(mapChunkRow);

--- a/packages/core/src/database/repositories/chunk.types.ts
+++ b/packages/core/src/database/repositories/chunk.types.ts
@@ -8,6 +8,7 @@
  * @see docs/functional-spec.md §4.3
  */
 
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
 import type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
 
 // ────────────────────────────────────────────────────────────
@@ -28,6 +29,8 @@ export type ChunkRow = {
 	parent_chunk_id: string | null;
 	metadata: Record<string, unknown>;
 	provenance: unknown;
+	sensitivity_level: SensitivityLevel;
+	sensitivity_metadata: unknown;
 	created_at: Date;
 };
 
@@ -48,6 +51,8 @@ export type Chunk = {
 	parentChunkId: string | null;
 	metadata: Record<string, unknown>;
 	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 };
 
@@ -68,6 +73,8 @@ export type CreateChunkInput = {
 	parentChunkId?: string | null;
 	metadata?: Record<string, unknown>;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 };
 
 /** Filters for querying chunks. */

--- a/packages/core/src/database/repositories/edge.repository.ts
+++ b/packages/core/src/database/repositories/edge.repository.ts
@@ -21,6 +21,7 @@ import {
 	stringifyArtifactProvenance,
 } from './artifact-provenance.js';
 import type { CreateEdgeInput, EdgeFilter, EdgeType, EntityEdge, UpdateEdgeInput } from './edge.types.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'edge-repository' });
@@ -84,6 +85,17 @@ export async function createEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11::jsonb)
     RETURNING *
   `;
+	const legacySql = hasExplicitId
+		? `
+    INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+    RETURNING *
+  `
+		: `
+    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+    RETURNING *
+  `;
 
 	const baseParams = [
 		input.sourceEntityId,
@@ -99,9 +111,11 @@ export async function createEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
+	const legacyBaseParams = baseParams.slice(0, -2);
+	const legacyParams = hasExplicitId ? [input.id, ...legacyBaseParams] : legacyBaseParams;
 
 	try {
-		const result = await pool.query<EdgeRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EdgeRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ edgeId: row.id, relationship: input.relationship, edgeType: row.edge_type }, 'Edge created');
 		return mapEdgeRow(row);
@@ -149,6 +163,18 @@ export async function upsertEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
       sensitivity_metadata = EXCLUDED.sensitivity_metadata
     RETURNING *
   `;
+	const legacySql = `
+    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+    ON CONFLICT (source_entity_id, target_entity_id, relationship, edge_type, story_id)
+    WHERE story_id IS NOT NULL
+    DO UPDATE SET
+      attributes = EXCLUDED.attributes,
+      confidence = EXCLUDED.confidence,
+      analysis = EXCLUDED.analysis,
+      provenance = ${mergeArtifactProvenanceSql('entity_edges.provenance', 'EXCLUDED.provenance')}
+    RETURNING *
+  `;
 
 	const params = [
 		input.sourceEntityId,
@@ -163,9 +189,10 @@ export async function upsertEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
 		sensitivityLevel,
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
+	const legacyParams = params.slice(0, -2);
 
 	try {
-		const result = await pool.query<EdgeRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EdgeRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ edgeId: row.id, relationship: input.relationship, edgeType: row.edge_type }, 'Edge upserted');
 		return mapEdgeRow(row);

--- a/packages/core/src/database/repositories/edge.repository.ts
+++ b/packages/core/src/database/repositories/edge.repository.ts
@@ -14,6 +14,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -39,6 +40,8 @@ interface EdgeRow {
 	edge_type: EdgeType;
 	analysis: Record<string, unknown> | null;
 	provenance: unknown;
+	sensitivity_level: EntityEdge['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	created_at: Date;
 }
 
@@ -54,6 +57,8 @@ function mapEdgeRow(row: EdgeRow): EntityEdge {
 		edgeType: row.edge_type,
 		analysis: row.analysis,
 		provenance: mapArtifactProvenanceFromDb(row.provenance),
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 	};
 }
@@ -67,15 +72,16 @@ function mapEdgeRow(row: EdgeRow): EntityEdge {
  */
 export async function createEdge(pool: pg.Pool, input: CreateEdgeInput): Promise<EntityEdge> {
 	const hasExplicitId = input.id !== undefined;
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = hasExplicitId
 		? `
-    INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+    INSERT INTO entity_edges (id, source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12::jsonb)
     RETURNING *
   `
 		: `
-    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11::jsonb)
     RETURNING *
   `;
 
@@ -89,6 +95,8 @@ export async function createEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
 		input.edgeType ?? 'RELATIONSHIP',
 		input.analysis ? JSON.stringify(input.analysis) : null,
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
 
@@ -126,16 +134,19 @@ export async function upsertEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
 		return createEdge(pool, input);
 	}
 
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = `
-    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+    INSERT INTO entity_edges (source_entity_id, target_entity_id, relationship, attributes, confidence, story_id, edge_type, analysis, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11::jsonb)
     ON CONFLICT (source_entity_id, target_entity_id, relationship, edge_type, story_id)
     WHERE story_id IS NOT NULL
     DO UPDATE SET
       attributes = EXCLUDED.attributes,
       confidence = EXCLUDED.confidence,
       analysis = EXCLUDED.analysis,
-      provenance = ${mergeArtifactProvenanceSql('entity_edges.provenance', 'EXCLUDED.provenance')}
+      provenance = ${mergeArtifactProvenanceSql('entity_edges.provenance', 'EXCLUDED.provenance')},
+      sensitivity_level = EXCLUDED.sensitivity_level,
+      sensitivity_metadata = EXCLUDED.sensitivity_metadata
     RETURNING *
   `;
 
@@ -149,6 +160,8 @@ export async function upsertEdge(pool: pg.Pool, input: CreateEdgeInput): Promise
 		input.edgeType ?? 'RELATIONSHIP',
 		input.analysis ? JSON.stringify(input.analysis) : null,
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 
 	try {
@@ -502,6 +515,16 @@ export async function updateEdge(pool: pg.Pool, id: string, input: UpdateEdgeInp
 	if (input.analysis !== undefined) {
 		setClauses.push(`analysis = $${paramIndex}`);
 		params.push(input.analysis ? JSON.stringify(input.analysis) : null);
+		paramIndex++;
+	}
+
+	if (input.sensitivityLevel !== undefined || input.sensitivityMetadata !== undefined) {
+		const sensitivityLevel = input.sensitivityLevel ?? 'internal';
+		setClauses.push(`sensitivity_level = $${paramIndex}`);
+		params.push(sensitivityLevel);
+		paramIndex++;
+		setClauses.push(`sensitivity_metadata = $${paramIndex}::jsonb`);
+		params.push(stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel));
 		paramIndex++;
 	}
 

--- a/packages/core/src/database/repositories/edge.types.ts
+++ b/packages/core/src/database/repositories/edge.types.ts
@@ -8,6 +8,7 @@
  * @see docs/functional-spec.md §4.3
  */
 
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
 import type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
 
 // ────────────────────────────────────────────────────────────
@@ -38,6 +39,8 @@ export interface EntityEdge {
 	edgeType: EdgeType;
 	analysis: Record<string, unknown> | null;
 	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 }
 
@@ -55,6 +58,8 @@ export interface CreateEdgeInput {
 	edgeType?: EdgeType;
 	analysis?: Record<string, unknown>;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Input for updating an edge. Partial -- only provided fields are updated. */
@@ -63,6 +68,8 @@ export interface UpdateEdgeInput {
 	confidence?: number | null;
 	edgeType?: EdgeType;
 	analysis?: Record<string, unknown> | null;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Filters for querying edges. */

--- a/packages/core/src/database/repositories/entity-alias.repository.ts
+++ b/packages/core/src/database/repositories/entity-alias.repository.ts
@@ -13,6 +13,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -34,6 +35,8 @@ interface EntityAliasRow {
 	alias: string;
 	source: string | null;
 	provenance: unknown;
+	sensitivity_level: EntityAlias['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 }
 
 function mapEntityAliasRow(row: EntityAliasRow): EntityAlias {
@@ -43,6 +46,8 @@ function mapEntityAliasRow(row: EntityAliasRow): EntityAlias {
 		alias: row.alias,
 		source: row.source,
 		provenance: mapArtifactProvenanceFromDb(row.provenance),
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 	};
 }
 
@@ -57,15 +62,25 @@ function mapEntityAliasRow(row: EntityAliasRow): EntityAlias {
  * Uses a CTE to handle the DO NOTHING case by selecting back.
  */
 export async function createEntityAlias(pool: pg.Pool, input: CreateEntityAliasInput): Promise<EntityAlias> {
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = `
-    INSERT INTO entity_aliases (entity_id, alias, source, provenance)
-    VALUES ($1, $2, $3, $4::jsonb)
+    INSERT INTO entity_aliases (entity_id, alias, source, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4::jsonb, $5, $6::jsonb)
     ON CONFLICT (entity_id, alias) DO UPDATE SET
       source = COALESCE(entity_aliases.source, EXCLUDED.source),
-      provenance = ${mergeArtifactProvenanceSql('entity_aliases.provenance', 'EXCLUDED.provenance')}
+      provenance = ${mergeArtifactProvenanceSql('entity_aliases.provenance', 'EXCLUDED.provenance')},
+      sensitivity_level = EXCLUDED.sensitivity_level,
+      sensitivity_metadata = EXCLUDED.sensitivity_metadata
     RETURNING *
   `;
-	const params = [input.entityId, input.alias, input.source ?? null, stringifyArtifactProvenance(input.provenance)];
+	const params = [
+		input.entityId,
+		input.alias,
+		input.source ?? null,
+		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
+	];
 
 	try {
 		const result = await pool.query<EntityAliasRow>(sql, params);

--- a/packages/core/src/database/repositories/entity-alias.repository.ts
+++ b/packages/core/src/database/repositories/entity-alias.repository.ts
@@ -21,6 +21,7 @@ import {
 } from './artifact-provenance.js';
 import { type EntityRow, mapEntityRow } from './entity.repository.js';
 import type { CreateEntityAliasInput, Entity, EntityAlias } from './entity.types.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'entity-alias-repository' });
@@ -73,6 +74,14 @@ export async function createEntityAlias(pool: pg.Pool, input: CreateEntityAliasI
       sensitivity_metadata = EXCLUDED.sensitivity_metadata
     RETURNING *
   `;
+	const legacySql = `
+    INSERT INTO entity_aliases (entity_id, alias, source, provenance)
+    VALUES ($1, $2, $3, $4::jsonb)
+    ON CONFLICT (entity_id, alias) DO UPDATE SET
+      source = COALESCE(entity_aliases.source, EXCLUDED.source),
+      provenance = ${mergeArtifactProvenanceSql('entity_aliases.provenance', 'EXCLUDED.provenance')}
+    RETURNING *
+  `;
 	const params = [
 		input.entityId,
 		input.alias,
@@ -81,9 +90,10 @@ export async function createEntityAlias(pool: pg.Pool, input: CreateEntityAliasI
 		sensitivityLevel,
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
+	const legacyParams = params.slice(0, -2);
 
 	try {
-		const result = await pool.query<EntityAliasRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EntityAliasRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug(
 			{ aliasId: row.id, entityId: input.entityId, alias: input.alias },

--- a/packages/core/src/database/repositories/entity.repository.ts
+++ b/packages/core/src/database/repositories/entity.repository.ts
@@ -13,6 +13,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -52,6 +53,8 @@ export interface EntityRow {
 	taxonomy_status: TaxonomyStatus;
 	taxonomy_id: string | null;
 	provenance: unknown;
+	sensitivity_level: Entity['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	created_at: Date;
 	updated_at: Date;
 }
@@ -70,6 +73,8 @@ export function mapEntityRow(row: EntityRow): Entity {
 		taxonomyStatus: row.taxonomy_status,
 		taxonomyId: row.taxonomy_id,
 		provenance: mapArtifactProvenanceFromDb(row.provenance),
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -88,20 +93,25 @@ export function mapEntityRow(row: EntityRow): Entity {
  */
 export async function createEntity(pool: pg.Pool, input: CreateEntityInput): Promise<Entity> {
 	const hasExplicitId = input.id !== undefined;
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = hasExplicitId
 		? `
-    INSERT INTO entities (id, name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+    INSERT INTO entities (id, name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10::jsonb)
     ON CONFLICT (id) DO UPDATE SET
       provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+      sensitivity_level = EXCLUDED.sensitivity_level,
+      sensitivity_metadata = EXCLUDED.sensitivity_metadata,
       updated_at = now()
     RETURNING *
   `
 		: `
-    INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
-    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+    INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb)
     ON CONFLICT (id) DO UPDATE SET
       provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+      sensitivity_level = EXCLUDED.sensitivity_level,
+      sensitivity_metadata = EXCLUDED.sensitivity_metadata,
       updated_at = now()
     RETURNING *
   `;
@@ -113,6 +123,8 @@ export async function createEntity(pool: pg.Pool, input: CreateEntityInput): Pro
 		input.taxonomyStatus ?? 'auto',
 		input.taxonomyId ?? null,
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
 
@@ -138,6 +150,7 @@ export async function createEntity(pool: pg.Pool, input: CreateEntityInput): Pro
  * and bumps `updated_at`.
  */
 export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityInput): Promise<Entity> {
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = `
     WITH existing AS (
       UPDATE entities
@@ -146,6 +159,8 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
         taxonomy_status = COALESCE($5, entities.taxonomy_status),
         taxonomy_id = COALESCE($6, entities.taxonomy_id),
         provenance = ${mergeArtifactProvenanceSql('entities.provenance', '$7::jsonb')},
+        sensitivity_level = $8,
+        sensitivity_metadata = $9::jsonb,
         updated_at = now()
       WHERE id = (
         SELECT id
@@ -160,14 +175,16 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
       RETURNING *
     ),
     inserted AS (
-      INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
-      SELECT $1, $2, $3, $4, $5, $6, $7::jsonb
+      INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance, sensitivity_level, sensitivity_metadata)
+      SELECT $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb
       WHERE NOT EXISTS (SELECT 1 FROM existing)
       ON CONFLICT (name, type) WHERE canonical_id IS NULL DO UPDATE SET
         attributes = COALESCE(NULLIF($4::jsonb, '{}'::jsonb), entities.attributes),
         taxonomy_status = COALESCE($5, entities.taxonomy_status),
         taxonomy_id = COALESCE($6, entities.taxonomy_id),
         provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+        sensitivity_level = EXCLUDED.sensitivity_level,
+        sensitivity_metadata = EXCLUDED.sensitivity_metadata,
         updated_at = now()
       RETURNING *
     )
@@ -184,6 +201,8 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
 		input.taxonomyStatus ?? 'auto',
 		input.taxonomyId ?? null,
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 
 	try {
@@ -432,6 +451,16 @@ export async function updateEntity(pool: pg.Pool, id: string, input: UpdateEntit
 		const incomingRef = `$${paramIndex}::jsonb`;
 		setClauses.push(`provenance = ${mergeArtifactProvenanceSql('entities.provenance', incomingRef)}`);
 		params.push(stringifyArtifactProvenance(input.provenance));
+		paramIndex++;
+	}
+
+	if (input.sensitivityLevel !== undefined || input.sensitivityMetadata !== undefined) {
+		const sensitivityLevel = input.sensitivityLevel ?? 'internal';
+		setClauses.push(`sensitivity_level = $${paramIndex}`);
+		params.push(sensitivityLevel);
+		paramIndex++;
+		setClauses.push(`sensitivity_metadata = $${paramIndex}::jsonb`);
+		params.push(stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel));
 		paramIndex++;
 	}
 

--- a/packages/core/src/database/repositories/entity.repository.ts
+++ b/packages/core/src/database/repositories/entity.repository.ts
@@ -27,6 +27,7 @@ import type {
 	TaxonomyStatus,
 	UpdateEntityInput,
 } from './entity.types.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'entity-repository' });
@@ -115,6 +116,23 @@ export async function createEntity(pool: pg.Pool, input: CreateEntityInput): Pro
       updated_at = now()
     RETURNING *
   `;
+	const legacySql = hasExplicitId
+		? `
+    INSERT INTO entities (id, name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+    ON CONFLICT (id) DO UPDATE SET
+      provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+      updated_at = now()
+    RETURNING *
+  `
+		: `
+    INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
+    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+    ON CONFLICT (id) DO UPDATE SET
+      provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+      updated_at = now()
+    RETURNING *
+  `;
 	const baseParams = [
 		input.name,
 		input.type,
@@ -127,9 +145,11 @@ export async function createEntity(pool: pg.Pool, input: CreateEntityInput): Pro
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
+	const legacyBaseParams = baseParams.slice(0, -2);
+	const legacyParams = hasExplicitId ? [input.id, ...legacyBaseParams] : legacyBaseParams;
 
 	try {
-		const result = await pool.query<EntityRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EntityRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ entityId: row.id, name: input.name, type: input.type }, 'Entity created or found');
 		return mapEntityRow(row);
@@ -193,6 +213,44 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
     SELECT * FROM inserted
     LIMIT 1
   `;
+	const legacySql = `
+    WITH existing AS (
+      UPDATE entities
+      SET
+        attributes = COALESCE(NULLIF($4::jsonb, '{}'::jsonb), entities.attributes),
+        taxonomy_status = COALESCE($5, entities.taxonomy_status),
+        taxonomy_id = COALESCE($6, entities.taxonomy_id),
+        provenance = ${mergeArtifactProvenanceSql('entities.provenance', '$7::jsonb')},
+        updated_at = now()
+      WHERE id = (
+        SELECT id
+        FROM entities
+        WHERE name = $1
+          AND type = $2
+          AND $3::uuid IS NULL
+          AND (canonical_id IS NULL OR canonical_id = id)
+        ORDER BY created_at ASC, id ASC
+        LIMIT 1
+      )
+      RETURNING *
+    ),
+    inserted AS (
+      INSERT INTO entities (name, type, canonical_id, attributes, taxonomy_status, taxonomy_id, provenance)
+      SELECT $1, $2, $3, $4, $5, $6, $7::jsonb
+      WHERE NOT EXISTS (SELECT 1 FROM existing)
+      ON CONFLICT (name, type) WHERE canonical_id IS NULL DO UPDATE SET
+        attributes = COALESCE(NULLIF($4::jsonb, '{}'::jsonb), entities.attributes),
+        taxonomy_status = COALESCE($5, entities.taxonomy_status),
+        taxonomy_id = COALESCE($6, entities.taxonomy_id),
+        provenance = ${mergeArtifactProvenanceSql('entities.provenance', 'EXCLUDED.provenance')},
+        updated_at = now()
+      RETURNING *
+    )
+    SELECT * FROM existing
+    UNION ALL
+    SELECT * FROM inserted
+    LIMIT 1
+  `;
 	const params = [
 		input.name,
 		input.type,
@@ -204,9 +262,10 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
 		sensitivityLevel,
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
+	const legacyParams = params.slice(0, -2);
 
 	try {
-		const result = await pool.query<EntityRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EntityRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ entityId: row.id, name: input.name, type: input.type }, 'Entity upserted by name+type');
 		return mapEntityRow(row);

--- a/packages/core/src/database/repositories/entity.types.ts
+++ b/packages/core/src/database/repositories/entity.types.ts
@@ -8,6 +8,7 @@
  * @see docs/functional-spec.md §4.3
  */
 
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
 import type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
 import type { Story } from './story.types.js';
 
@@ -42,6 +43,8 @@ export interface Entity {
 	 */
 	taxonomyId: string | null;
 	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -58,6 +61,8 @@ export interface CreateEntityInput {
 	/** Optional FK to the canonical taxonomy entry. */
 	taxonomyId?: string | null;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Input for updating an entity. Partial -- only provided fields are updated. */
@@ -73,6 +78,8 @@ export interface UpdateEntityInput {
 	/** Set to `null` to clear the taxonomy FK. */
 	taxonomyId?: string | null;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Filters for querying entities. */
@@ -144,6 +151,8 @@ export interface EntityAlias {
 	alias: string;
 	source: string | null;
 	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 }
 
 /** Input for creating a new entity alias. */
@@ -152,6 +161,8 @@ export interface CreateEntityAliasInput {
 	alias: string;
 	source?: string;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -165,6 +176,8 @@ export interface StoryEntity {
 	confidence: number | null;
 	mentionCount: number;
 	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 }
 
 /** Input for linking a story to an entity. */
@@ -174,6 +187,8 @@ export interface LinkStoryEntityInput {
 	confidence?: number;
 	mentionCount?: number;
 	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 // ────────────────────────────────────────────────────────────

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -254,6 +254,7 @@ export {
 	findSourcesWithFailedSteps,
 	findSourcesWithSteps,
 	updateSource,
+	updateSourceSensitivityFromArtifacts,
 	updateSourceStatus,
 	upsertSourceStep,
 } from './source.repository.js';
@@ -299,6 +300,7 @@ export {
 	findStoriesBySourceId,
 	findStoryById,
 	updateStory,
+	updateStorySensitivityFromArtifacts,
 	updateStoryStatus,
 } from './story.repository.js';
 export type {

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -261,6 +261,7 @@ export {
 export type {
 	CreateSourceInput,
 	FailedSourceInfo,
+	PersistedSource,
 	Source,
 	SourceFilter,
 	SourceFormatMetadata,

--- a/packages/core/src/database/repositories/knowledge-assertion.repository.ts
+++ b/packages/core/src/database/repositories/knowledge-assertion.repository.ts
@@ -1,5 +1,6 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -34,6 +35,8 @@ interface KnowledgeAssertionRow {
 	extracted_entity_ids: string[];
 	provenance: unknown;
 	quality_metadata: unknown;
+	sensitivity_level: KnowledgeAssertion['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	created_at: Date;
 	updated_at: Date;
 	deleted_at: Date | null;
@@ -127,6 +130,8 @@ function mapKnowledgeAssertionRow(row: KnowledgeAssertionRow): KnowledgeAssertio
 		extractedEntityIds: normalizeUuidArray(row.extracted_entity_ids),
 		provenance: mapArtifactProvenanceFromDb(row.provenance),
 		qualityMetadata: normalizeQualityMetadata(row.quality_metadata),
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		deletedAt: row.deleted_at,
@@ -160,6 +165,7 @@ export async function upsertKnowledgeAssertion(
 	assertKnownEnum(input.assertionType, ASSERTION_TYPES, 'assertionType');
 	const classificationProvenance = input.classificationProvenance ?? 'llm_auto';
 	assertKnownEnum(classificationProvenance, CLASSIFICATION_PROVENANCE_VALUES, 'classificationProvenance');
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 
 	const sql = `
 		INSERT INTO knowledge_assertions (
@@ -171,9 +177,11 @@ export async function upsertKnowledgeAssertion(
 			classification_provenance,
 			extracted_entity_ids,
 			provenance,
-			quality_metadata
+			quality_metadata,
+			sensitivity_level,
+			sensitivity_metadata
 		)
-		VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::uuid[], $8::jsonb, $9::jsonb)
+		VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::uuid[], $8::jsonb, $9::jsonb, $10, $11::jsonb)
 		ON CONFLICT (source_id, story_id, content, assertion_type)
 		WHERE deleted_at IS NULL
 		DO UPDATE SET
@@ -188,6 +196,8 @@ export async function upsertKnowledgeAssertion(
 			extracted_entity_ids = EXCLUDED.extracted_entity_ids,
 			provenance = ${mergeArtifactProvenanceSql('knowledge_assertions.provenance', 'EXCLUDED.provenance')},
 			quality_metadata = COALESCE(EXCLUDED.quality_metadata, knowledge_assertions.quality_metadata),
+			sensitivity_level = EXCLUDED.sensitivity_level,
+			sensitivity_metadata = EXCLUDED.sensitivity_metadata,
 			updated_at = now()
 		RETURNING *
 	`;
@@ -203,6 +213,8 @@ export async function upsertKnowledgeAssertion(
 			normalizeUuidArray(input.extractedEntityIds),
 			stringifyArtifactProvenance(input.provenance),
 			input.qualityMetadata ? JSON.stringify(input.qualityMetadata) : null,
+			sensitivityLevel,
+			stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 		]);
 		return mapKnowledgeAssertionRow(result.rows[0]);
 	} catch (error: unknown) {

--- a/packages/core/src/database/repositories/knowledge-assertion.types.ts
+++ b/packages/core/src/database/repositories/knowledge-assertion.types.ts
@@ -1,3 +1,4 @@
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
 import type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
 
 export type AssertionType = 'observation' | 'interpretation' | 'hypothesis';
@@ -24,6 +25,8 @@ export interface KnowledgeAssertion {
 	extractedEntityIds: string[];
 	provenance: ArtifactProvenance;
 	qualityMetadata: Record<string, unknown> | null;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 	updatedAt: Date;
 	deletedAt: Date | null;
@@ -39,6 +42,8 @@ export interface UpsertKnowledgeAssertionInput {
 	extractedEntityIds?: string[];
 	provenance?: ArtifactProvenanceInput;
 	qualityMetadata?: Record<string, unknown> | null;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 export interface ListKnowledgeAssertionsInput {

--- a/packages/core/src/database/repositories/schema-compat.ts
+++ b/packages/core/src/database/repositories/schema-compat.ts
@@ -1,0 +1,39 @@
+import type pg from 'pg';
+
+type Queryable = pg.Pool | pg.PoolClient;
+
+interface PgErrorLike {
+	code?: unknown;
+	message?: unknown;
+}
+
+function isPgErrorLike(value: unknown): value is PgErrorLike {
+	return value !== null && typeof value === 'object';
+}
+
+function isMissingSensitivityColumnError(error: unknown): boolean {
+	if (!isPgErrorLike(error)) {
+		return false;
+	}
+	if (error.code !== '42703' || typeof error.message !== 'string') {
+		return false;
+	}
+	return error.message.includes('sensitivity_level') || error.message.includes('sensitivity_metadata');
+}
+
+export async function queryWithSensitivityColumnFallback<Row extends pg.QueryResultRow>(
+	pool: Queryable,
+	sql: string,
+	params: unknown[],
+	legacySql: string,
+	legacyParams: unknown[],
+): Promise<pg.QueryResult<Row>> {
+	try {
+		return await pool.query<Row>(sql, params);
+	} catch (error: unknown) {
+		if (!isMissingSensitivityColumnError(error)) {
+			throw error;
+		}
+		return await pool.query<Row>(legacySql, legacyParams);
+	}
+}

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -17,7 +17,7 @@ import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../.
 import type {
 	CreateSourceInput,
 	FailedSourceInfo,
-	Source,
+	PersistedSource,
 	SourceFilter,
 	SourceFormatMetadata,
 	SourceStatus,
@@ -54,7 +54,7 @@ interface SourceRow {
 	reliability_score: number | null;
 	tags: string[] | null;
 	metadata: Record<string, unknown>;
-	sensitivity_level: Source['sensitivityLevel'];
+	sensitivity_level: PersistedSource['sensitivityLevel'];
 	sensitivity_metadata: unknown;
 	created_at: Date;
 	updated_at: Date;
@@ -77,7 +77,7 @@ interface SourceWithStepsRow extends SourceRow {
 	step_error_message: string | null;
 }
 
-function mapSourceRow(row: SourceRow): Source {
+function mapSourceRow(row: SourceRow): PersistedSource {
 	return {
 		id: row.id,
 		filename: row.filename,
@@ -175,7 +175,7 @@ function buildSourceFilterClause(filter?: SourceFilter): { conditions: string[];
  * On conflict (duplicate hash), returns the existing record with an updated
  * `updated_at` timestamp.
  */
-export async function createSource(pool: Queryable, input: CreateSourceInput): Promise<Source> {
+export async function createSource(pool: Queryable, input: CreateSourceInput): Promise<PersistedSource> {
 	const columns = input.id
 		? [
 				'id',
@@ -267,7 +267,7 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
  *
  * @returns The source, or `null` if not found.
  */
-export async function findSourceById(pool: Queryable, id: string): Promise<Source | null> {
+export async function findSourceById(pool: Queryable, id: string): Promise<PersistedSource | null> {
 	const sql = 'SELECT * FROM sources WHERE id = $1';
 
 	try {
@@ -289,7 +289,7 @@ export async function findSourceById(pool: Queryable, id: string): Promise<Sourc
  *
  * @returns The source, or `null` if not found.
  */
-export async function findSourceByHash(pool: Queryable, hash: string): Promise<Source | null> {
+export async function findSourceByHash(pool: Queryable, hash: string): Promise<PersistedSource | null> {
 	const sql = 'SELECT * FROM sources WHERE file_hash = $1';
 
 	try {
@@ -311,7 +311,10 @@ export async function findSourceByHash(pool: Queryable, hash: string): Promise<S
  *
  * The key lives in format_metadata so this remains migration-free for M9-J12.
  */
-export async function findSourceByCrossFormatDedupKey(pool: Queryable, dedupKey: string): Promise<Source | null> {
+export async function findSourceByCrossFormatDedupKey(
+	pool: Queryable,
+	dedupKey: string,
+): Promise<PersistedSource | null> {
 	const sql = `
     SELECT *
     FROM sources
@@ -340,7 +343,7 @@ export async function findSourceByCrossFormatDedupKey(pool: Queryable, dedupKey:
  * Supports filtering by status and tags, with pagination via limit/offset.
  * Results are ordered by `created_at DESC`.
  */
-export async function findAllSources(pool: pg.Pool, filter?: SourceFilter): Promise<Source[]> {
+export async function findAllSources(pool: pg.Pool, filter?: SourceFilter): Promise<PersistedSource[]> {
 	const { conditions, params } = buildSourceFilterClause(filter);
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -370,7 +373,7 @@ export interface SourceReliabilityFilter {
 /**
  * Finds all sources with a persisted reliability score.
  */
-export async function findScoredSources(pool: pg.Pool, filter?: SourceReliabilityFilter): Promise<Source[]> {
+export async function findScoredSources(pool: pg.Pool, filter?: SourceReliabilityFilter): Promise<PersistedSource[]> {
 	const limit = filter?.limit ?? 100;
 	const offset = filter?.offset ?? 0;
 	const sql = `
@@ -433,7 +436,7 @@ export async function countSources(pool: pg.Pool, filter?: SourceFilter): Promis
  *
  * @throws {DatabaseError} with `DB_NOT_FOUND` if the source does not exist.
  */
-export async function updateSource(pool: pg.Pool, id: string, input: UpdateSourceInput): Promise<Source> {
+export async function updateSource(pool: pg.Pool, id: string, input: UpdateSourceInput): Promise<PersistedSource> {
 	const setClauses: string[] = [];
 	const params: unknown[] = [];
 	let paramIndex = 1;
@@ -519,7 +522,7 @@ export async function updateSource(pool: pg.Pool, id: string, input: UpdateSourc
  *
  * @throws {DatabaseError} with `DB_NOT_FOUND` if the source does not exist.
  */
-export async function updateSourceStatus(pool: pg.Pool, id: string, status: SourceStatus): Promise<Source> {
+export async function updateSourceStatus(pool: pg.Pool, id: string, status: SourceStatus): Promise<PersistedSource> {
 	const sql = 'UPDATE sources SET status = $1, updated_at = now() WHERE id = $2 RETURNING *';
 
 	try {
@@ -542,7 +545,7 @@ export async function updateSourceStatus(pool: pg.Pool, id: string, status: Sour
 	}
 }
 
-export async function updateSourceSensitivityFromArtifacts(pool: pg.Pool, sourceId: string): Promise<Source> {
+export async function updateSourceSensitivityFromArtifacts(pool: pg.Pool, sourceId: string): Promise<PersistedSource> {
 	const sql = `
     WITH artifact_sensitivity AS (
       SELECT sensitivity_level, sensitivity_metadata

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -13,6 +13,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import type {
 	CreateSourceInput,
 	FailedSourceInfo,
@@ -53,6 +54,8 @@ interface SourceRow {
 	reliability_score: number | null;
 	tags: string[] | null;
 	metadata: Record<string, unknown>;
+	sensitivity_level: Source['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	created_at: Date;
 	updated_at: Date;
 }
@@ -90,6 +93,8 @@ function mapSourceRow(row: SourceRow): Source {
 		reliabilityScore: row.reliability_score,
 		tags: row.tags ?? [],
 		metadata: row.metadata ?? {},
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -185,6 +190,8 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
 				'native_text_ratio',
 				'tags',
 				'metadata',
+				'sensitivity_level',
+				'sensitivity_metadata',
 			]
 		: [
 				'filename',
@@ -198,7 +205,10 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
 				'native_text_ratio',
 				'tags',
 				'metadata',
+				'sensitivity_level',
+				'sensitivity_metadata',
 			];
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const values = input.id
 		? [
 				input.id,
@@ -213,6 +223,8 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
 				input.nativeTextRatio ?? 0,
 				input.tags ?? [],
 				JSON.stringify(input.metadata ?? {}),
+				sensitivityLevel,
+				stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 			]
 		: [
 				input.filename,
@@ -226,6 +238,8 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
 				input.nativeTextRatio ?? 0,
 				input.tags ?? [],
 				JSON.stringify(input.metadata ?? {}),
+				sensitivityLevel,
+				stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 			];
 	const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
 	const sql = `
@@ -459,6 +473,16 @@ export async function updateSource(pool: pg.Pool, id: string, input: UpdateSourc
 		paramIndex++;
 	}
 
+	if (input.sensitivityLevel !== undefined || input.sensitivityMetadata !== undefined) {
+		const sensitivityLevel = input.sensitivityLevel ?? 'internal';
+		setClauses.push(`sensitivity_level = $${paramIndex}`);
+		params.push(sensitivityLevel);
+		paramIndex++;
+		setClauses.push(`sensitivity_metadata = $${paramIndex}::jsonb`);
+		params.push(stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel));
+		paramIndex++;
+	}
+
 	if (setClauses.length === 0) {
 		// Nothing to update — just refresh timestamp and return
 		setClauses.push('updated_at = now()');
@@ -514,6 +538,85 @@ export async function updateSourceStatus(pool: pg.Pool, id: string, status: Sour
 		throw new DatabaseError('Failed to update source status', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
 			cause: error,
 			context: { id, status },
+		});
+	}
+}
+
+export async function updateSourceSensitivityFromArtifacts(pool: pg.Pool, sourceId: string): Promise<Source> {
+	const sql = `
+    WITH artifact_sensitivity AS (
+      SELECT sensitivity_level, sensitivity_metadata
+      FROM stories
+      WHERE source_id = $1
+      UNION ALL
+      SELECT se.sensitivity_level, se.sensitivity_metadata
+      FROM story_entities se
+      JOIN stories s ON s.id = se.story_id
+      WHERE s.source_id = $1
+      UNION ALL
+      SELECT c.sensitivity_level, c.sensitivity_metadata
+      FROM chunks c
+      JOIN stories s ON s.id = c.story_id
+      WHERE s.source_id = $1
+      UNION ALL
+      SELECT ee.sensitivity_level, ee.sensitivity_metadata
+      FROM entity_edges ee
+      JOIN stories s ON s.id = ee.story_id
+      WHERE s.source_id = $1
+      UNION ALL
+      SELECT ka.sensitivity_level, ka.sensitivity_metadata
+      FROM knowledge_assertions ka
+      WHERE ka.source_id = $1 AND ka.deleted_at IS NULL
+    ),
+    ranked AS (
+      SELECT
+        COALESCE(
+          (ARRAY_AGG(sensitivity_level ORDER BY
+            CASE sensitivity_level
+              WHEN 'confidential' THEN 4
+              WHEN 'restricted' THEN 3
+              WHEN 'internal' THEN 2
+              ELSE 1
+            END DESC
+          ))[1],
+          'internal'
+        ) AS propagated_level,
+        COALESCE(jsonb_agg(DISTINCT pii.value) FILTER (WHERE pii.value IS NOT NULL), '[]'::jsonb) AS pii_types
+      FROM artifact_sensitivity
+      LEFT JOIN LATERAL jsonb_array_elements_text(sensitivity_metadata->'pii_types') AS pii(value) ON true
+    )
+    UPDATE sources
+    SET
+      sensitivity_level = ranked.propagated_level,
+      sensitivity_metadata = jsonb_build_object(
+        'level', ranked.propagated_level,
+        'reason', 'upward_propagation',
+        'assigned_by', 'policy_rule',
+        'assigned_at', to_jsonb(now()),
+        'pii_types', ranked.pii_types,
+        'declassify_date', 'null'::jsonb
+      ),
+      updated_at = now()
+    FROM ranked
+    WHERE sources.id = $1
+    RETURNING sources.*
+  `;
+
+	try {
+		const result = await pool.query<SourceRow>(sql, [sourceId]);
+		if (result.rows.length === 0) {
+			throw new DatabaseError(`Source not found: ${sourceId}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
+				context: { sourceId },
+			});
+		}
+		return mapSourceRow(result.rows[0]);
+	} catch (error: unknown) {
+		if (error instanceof DatabaseError) {
+			throw error;
+		}
+		throw new DatabaseError('Failed to update source sensitivity', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { sourceId },
 		});
 	}
 }

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -14,6 +14,7 @@ import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 import type {
 	CreateSourceInput,
 	FailedSourceInfo,
@@ -248,9 +249,19 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
     ON CONFLICT (file_hash) DO UPDATE SET updated_at = now()
     RETURNING *
   `;
+	const legacyColumnCount = columns.length - 2;
+	const legacyColumns = columns.slice(0, legacyColumnCount);
+	const legacyValues = values.slice(0, legacyColumnCount);
+	const legacyPlaceholders = legacyValues.map((_, index) => `$${index + 1}`).join(', ');
+	const legacySql = `
+    INSERT INTO sources (${legacyColumns.join(', ')})
+    VALUES (${legacyPlaceholders})
+    ON CONFLICT (file_hash) DO UPDATE SET updated_at = now()
+    RETURNING *
+  `;
 
 	try {
-		const result = await pool.query<SourceRow>(sql, values);
+		const result = await queryWithSensitivityColumnFallback<SourceRow>(pool, sql, values, legacySql, legacyValues);
 		const row = result.rows[0];
 		repoLogger.debug({ sourceId: row.id, fileHash: input.fileHash }, 'Source created or found');
 		return mapSourceRow(row);

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -37,7 +37,7 @@ export type SourceFormatMetadata = Record<string, unknown>;
  * that construct source-shaped fixtures can omit them and rely on database
  * defaults or downstream normalization.
  */
-export interface Source extends Partial<SensitivityTagged> {
+export interface Source {
 	id: string;
 	filename: string;
 	storagePath: string;
@@ -52,6 +52,8 @@ export interface Source extends Partial<SensitivityTagged> {
 	reliabilityScore: number | null;
 	tags: string[];
 	metadata: Record<string, unknown>;
+	sensitivityLevel?: SensitivityTagged['sensitivityLevel'];
+	sensitivityMetadata?: SensitivityTagged['sensitivityMetadata'];
 	createdAt: Date;
 	updatedAt: Date;
 }

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -8,7 +8,7 @@
  * @see docs/functional-spec.md §4.3
  */
 
-import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
+import type { SensitivityLevel, SensitivityTagged } from '../../shared/sensitivity.js';
 
 // ────────────────────────────────────────────────────────────
 // Status enums
@@ -30,8 +30,14 @@ export type SourceFormatMetadata = Record<string, unknown>;
 // Source types
 // ────────────────────────────────────────────────────────────
 
-/** A source record from the database. */
-export interface Source {
+/**
+ * A source-like record.
+ *
+ * Repository reads always populate sensitivity fields, while legacy callers
+ * that construct source-shaped fixtures can omit them and rely on database
+ * defaults or downstream normalization.
+ */
+export interface Source extends Partial<SensitivityTagged> {
 	id: string;
 	filename: string;
 	storagePath: string;
@@ -46,11 +52,12 @@ export interface Source {
 	reliabilityScore: number | null;
 	tags: string[];
 	metadata: Record<string, unknown>;
-	sensitivityLevel: SensitivityLevel;
-	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 	updatedAt: Date;
 }
+
+/** A source record returned from the database with normalized sensitivity fields populated. */
+export type PersistedSource = Source & SensitivityTagged;
 
 /** Input for creating a new source. */
 export interface CreateSourceInput {
@@ -116,7 +123,7 @@ export interface SourceStep {
 
 /** A source record bundled with its source_steps rows for planning. */
 export interface SourceWithSteps {
-	source: Source;
+	source: PersistedSource;
 	steps: SourceStep[];
 }
 

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -8,6 +8,8 @@
  * @see docs/functional-spec.md §4.3
  */
 
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
+
 // ────────────────────────────────────────────────────────────
 // Status enums
 // ────────────────────────────────────────────────────────────
@@ -44,6 +46,8 @@ export interface Source {
 	reliabilityScore: number | null;
 	tags: string[];
 	metadata: Record<string, unknown>;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -62,6 +66,8 @@ export interface CreateSourceInput {
 	nativeTextRatio?: number;
 	tags?: string[];
 	metadata?: Record<string, unknown>;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Input for updating a source. Partial -- only provided fields are updated. */
@@ -79,6 +85,8 @@ export interface UpdateSourceInput {
 	reliabilityScore?: number | null;
 	tags?: string[];
 	metadata?: Record<string, unknown>;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Filters for querying sources. */

--- a/packages/core/src/database/repositories/story-entity.repository.ts
+++ b/packages/core/src/database/repositories/story-entity.repository.ts
@@ -21,6 +21,7 @@ import {
 } from './artifact-provenance.js';
 import { type EntityRow, mapEntityRow } from './entity.repository.js';
 import type { LinkStoryEntityInput, StoryEntityWithEntity, StoryEntityWithStory } from './entity.types.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 import { mapStoryRow, type StoryRow } from './story.repository.js';
 
 const logger = createLogger();
@@ -106,6 +107,26 @@ export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput
     FROM upserted u
     JOIN entities e ON e.id = u.entity_id
   `;
+	const legacySql = `
+    WITH upserted AS (
+      INSERT INTO story_entities (story_id, entity_id, confidence, mention_count, provenance)
+      VALUES ($1, $2, $3, $4, $5::jsonb)
+      ON CONFLICT (story_id, entity_id) DO UPDATE SET
+        confidence = EXCLUDED.confidence,
+        mention_count = EXCLUDED.mention_count,
+        provenance = ${mergeArtifactProvenanceSql('story_entities.provenance', 'EXCLUDED.provenance')}
+      RETURNING *
+    )
+    SELECT
+      e.*,
+      u.confidence,
+      u.mention_count,
+      u.provenance AS junction_provenance,
+      NULL::text AS junction_sensitivity_level,
+      NULL::jsonb AS junction_sensitivity_metadata
+    FROM upserted u
+    JOIN entities e ON e.id = u.entity_id
+  `;
 	const params = [
 		input.storyId,
 		input.entityId,
@@ -115,9 +136,16 @@ export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput
 		sensitivityLevel,
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
+	const legacyParams = params.slice(0, -2);
 
 	try {
-		const result = await pool.query<EntityWithJunctionRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<EntityWithJunctionRow>(
+			pool,
+			sql,
+			params,
+			legacySql,
+			legacyParams,
+		);
 		const row = result.rows[0];
 		repoLogger.debug({ storyId: input.storyId, entityId: input.entityId }, 'Story-entity link created or updated');
 		return mapEntityWithJunctionRow(row);
@@ -148,9 +176,29 @@ export async function findEntitiesByStoryId(pool: pg.Pool, storyId: string): Pro
     WHERE se.story_id = $1
     ORDER BY e.name
   `;
+	const legacySql = `
+    SELECT
+      e.*,
+      se.confidence,
+      se.mention_count,
+      se.provenance AS junction_provenance,
+      NULL::text AS junction_sensitivity_level,
+      NULL::jsonb AS junction_sensitivity_metadata
+    FROM entities e
+    JOIN story_entities se ON se.entity_id = e.id
+    WHERE se.story_id = $1
+    ORDER BY e.name
+  `;
+	const params = [storyId];
 
 	try {
-		const result = await pool.query<EntityWithJunctionRow>(sql, [storyId]);
+		const result = await queryWithSensitivityColumnFallback<EntityWithJunctionRow>(
+			pool,
+			sql,
+			params,
+			legacySql,
+			params,
+		);
 		return result.rows.map(mapEntityWithJunctionRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find entities by story ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -179,9 +227,23 @@ export async function findStoriesByEntityId(pool: pg.Pool, entityId: string): Pr
     WHERE se.entity_id = $1
     ORDER BY s.created_at DESC
   `;
+	const legacySql = `
+    SELECT
+      s.*,
+      se.confidence,
+      se.mention_count,
+      se.provenance AS junction_provenance,
+      NULL::text AS junction_sensitivity_level,
+      NULL::jsonb AS junction_sensitivity_metadata
+    FROM stories s
+    JOIN story_entities se ON se.story_id = s.id
+    WHERE se.entity_id = $1
+    ORDER BY s.created_at DESC
+  `;
+	const params = [entityId];
 
 	try {
-		const result = await pool.query<StoryWithJunctionRow>(sql, [entityId]);
+		const result = await queryWithSensitivityColumnFallback<StoryWithJunctionRow>(pool, sql, params, legacySql, params);
 		return result.rows.map(mapStoryWithJunctionRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find stories by entity ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {

--- a/packages/core/src/database/repositories/story-entity.repository.ts
+++ b/packages/core/src/database/repositories/story-entity.repository.ts
@@ -13,6 +13,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import {
 	mapArtifactProvenanceFromDb,
 	mergeArtifactProvenanceSql,
@@ -33,12 +34,16 @@ type EntityWithJunctionRow = EntityRow & {
 	confidence: number | null;
 	mention_count: number;
 	junction_provenance: unknown;
+	junction_sensitivity_level: StoryEntityWithEntity['sensitivityLevel'];
+	junction_sensitivity_metadata: unknown;
 };
 
 type StoryWithJunctionRow = StoryRow & {
 	confidence: number | null;
 	mention_count: number;
 	junction_provenance: unknown;
+	junction_sensitivity_level: StoryEntityWithStory['sensitivityLevel'];
+	junction_sensitivity_metadata: unknown;
 };
 
 function mapEntityWithJunctionRow(row: EntityWithJunctionRow): StoryEntityWithEntity {
@@ -46,6 +51,11 @@ function mapEntityWithJunctionRow(row: EntityWithJunctionRow): StoryEntityWithEn
 		...mapEntityRow({ ...row, provenance: row.junction_provenance }),
 		confidence: row.confidence,
 		mentionCount: row.mention_count,
+		sensitivityLevel: row.junction_sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(
+			row.junction_sensitivity_metadata,
+			row.junction_sensitivity_level ?? 'internal',
+		),
 	};
 }
 
@@ -55,6 +65,11 @@ function mapStoryWithJunctionRow(row: StoryWithJunctionRow): StoryEntityWithStor
 		confidence: row.confidence,
 		mentionCount: row.mention_count,
 		provenance: mapArtifactProvenanceFromDb(row.junction_provenance),
+		sensitivityLevel: row.junction_sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(
+			row.junction_sensitivity_metadata,
+			row.junction_sensitivity_level ?? 'internal',
+		),
 	};
 }
 
@@ -68,17 +83,26 @@ function mapStoryWithJunctionRow(row: StoryWithJunctionRow): StoryEntityWithStor
  * On conflict, updates confidence and mention_count to the new values.
  */
 export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput): Promise<StoryEntityWithEntity> {
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = `
     WITH upserted AS (
-      INSERT INTO story_entities (story_id, entity_id, confidence, mention_count, provenance)
-      VALUES ($1, $2, $3, $4, $5::jsonb)
+      INSERT INTO story_entities (story_id, entity_id, confidence, mention_count, provenance, sensitivity_level, sensitivity_metadata)
+      VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb)
       ON CONFLICT (story_id, entity_id) DO UPDATE SET
         confidence = EXCLUDED.confidence,
         mention_count = EXCLUDED.mention_count,
-        provenance = ${mergeArtifactProvenanceSql('story_entities.provenance', 'EXCLUDED.provenance')}
+        provenance = ${mergeArtifactProvenanceSql('story_entities.provenance', 'EXCLUDED.provenance')},
+        sensitivity_level = EXCLUDED.sensitivity_level,
+        sensitivity_metadata = EXCLUDED.sensitivity_metadata
       RETURNING *
     )
-    SELECT e.*, u.confidence, u.mention_count, u.provenance AS junction_provenance
+    SELECT
+      e.*,
+      u.confidence,
+      u.mention_count,
+      u.provenance AS junction_provenance,
+      u.sensitivity_level AS junction_sensitivity_level,
+      u.sensitivity_metadata AS junction_sensitivity_metadata
     FROM upserted u
     JOIN entities e ON e.id = u.entity_id
   `;
@@ -88,6 +112,8 @@ export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput
 		input.confidence ?? null,
 		input.mentionCount ?? 1,
 		stringifyArtifactProvenance(input.provenance),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 
 	try {
@@ -110,7 +136,13 @@ export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput
  */
 export async function findEntitiesByStoryId(pool: pg.Pool, storyId: string): Promise<StoryEntityWithEntity[]> {
 	const sql = `
-    SELECT e.*, se.confidence, se.mention_count, se.provenance AS junction_provenance
+    SELECT
+      e.*,
+      se.confidence,
+      se.mention_count,
+      se.provenance AS junction_provenance,
+      se.sensitivity_level AS junction_sensitivity_level,
+      se.sensitivity_metadata AS junction_sensitivity_metadata
     FROM entities e
     JOIN story_entities se ON se.entity_id = e.id
     WHERE se.story_id = $1
@@ -135,7 +167,13 @@ export async function findEntitiesByStoryId(pool: pg.Pool, storyId: string): Pro
  */
 export async function findStoriesByEntityId(pool: pg.Pool, entityId: string): Promise<StoryEntityWithStory[]> {
 	const sql = `
-    SELECT s.*, se.confidence, se.mention_count, se.provenance AS junction_provenance
+    SELECT
+      s.*,
+      se.confidence,
+      se.mention_count,
+      se.provenance AS junction_provenance,
+      se.sensitivity_level AS junction_sensitivity_level,
+      se.sensitivity_metadata AS junction_sensitivity_metadata
     FROM stories s
     JOIN story_entities se ON se.story_id = s.id
     WHERE se.entity_id = $1

--- a/packages/core/src/database/repositories/story.repository.ts
+++ b/packages/core/src/database/repositories/story.repository.ts
@@ -13,6 +13,7 @@
 import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
 import type { CreateStoryInput, Story, StoryFilter, StoryStatus, UpdateStoryInput } from './story.types.js';
 
 const logger = createLogger();
@@ -38,6 +39,8 @@ export interface StoryRow {
 	extraction_confidence: number | null;
 	status: StoryStatus;
 	metadata: Record<string, unknown>;
+	sensitivity_level: Story['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	created_at: Date;
 	updated_at: Date;
 }
@@ -59,6 +62,8 @@ export function mapStoryRow(row: StoryRow): Story {
 		extractionConfidence: row.extraction_confidence,
 		status: row.status,
 		metadata: row.metadata ?? {},
+		sensitivityLevel: row.sensitivity_level ?? 'internal',
+		sensitivityMetadata: normalizeSensitivityMetadata(row.sensitivity_metadata, row.sensitivity_level ?? 'internal'),
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -79,16 +84,17 @@ export async function createStory(pool: pg.Pool, input: CreateStoryInput): Promi
 	// When an explicit ID is provided (e.g. from the segment step), include it
 	// in the INSERT so the DB record matches GCS paths and metadata JSON.
 	const hasExplicitId = input.id !== undefined;
+	const sensitivityLevel = input.sensitivityLevel ?? 'internal';
 	const sql = hasExplicitId
 		? `
-    INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::jsonb)
     ON CONFLICT (id) DO UPDATE SET updated_at = now()
     RETURNING *
   `
 		: `
-    INSERT INTO stories (source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    INSERT INTO stories (source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata, sensitivity_level, sensitivity_metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb)
     ON CONFLICT (id) DO UPDATE SET updated_at = now()
     RETURNING *
   `;
@@ -104,6 +110,8 @@ export async function createStory(pool: pg.Pool, input: CreateStoryInput): Promi
 		input.gcsMetadataUri,
 		input.extractionConfidence ?? null,
 		JSON.stringify(input.metadata ?? {}),
+		sensitivityLevel,
+		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
 
@@ -302,6 +310,16 @@ export async function updateStory(pool: pg.Pool, id: string, input: UpdateStoryI
 		paramIndex++;
 	}
 
+	if (input.sensitivityLevel !== undefined || input.sensitivityMetadata !== undefined) {
+		const sensitivityLevel = input.sensitivityLevel ?? 'internal';
+		setClauses.push(`sensitivity_level = $${paramIndex}`);
+		params.push(sensitivityLevel);
+		paramIndex++;
+		setClauses.push(`sensitivity_metadata = $${paramIndex}::jsonb`);
+		params.push(stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel));
+		paramIndex++;
+	}
+
 	// Always update the timestamp
 	setClauses.push('updated_at = now()');
 
@@ -353,6 +371,83 @@ export async function updateStoryStatus(pool: pg.Pool, id: string, status: Story
 		throw new DatabaseError('Failed to update story status', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
 			cause: error,
 			context: { id, status },
+		});
+	}
+}
+
+export async function updateStorySensitivityFromArtifacts(pool: pg.Pool, storyId: string): Promise<Story> {
+	const sql = `
+    WITH artifact_sensitivity AS (
+      SELECT e.sensitivity_level, e.sensitivity_metadata
+      FROM entities e
+      JOIN story_entities se ON se.entity_id = e.id
+      WHERE se.story_id = $1
+      UNION ALL
+      SELECT sensitivity_level, sensitivity_metadata
+      FROM story_entities
+      WHERE story_id = $1
+      UNION ALL
+      SELECT sensitivity_level, sensitivity_metadata
+      FROM chunks
+      WHERE story_id = $1
+      UNION ALL
+      SELECT sensitivity_level, sensitivity_metadata
+      FROM entity_edges
+      WHERE story_id = $1
+      UNION ALL
+      SELECT sensitivity_level, sensitivity_metadata
+      FROM knowledge_assertions
+      WHERE story_id = $1 AND deleted_at IS NULL
+    ),
+    ranked AS (
+      SELECT
+        COALESCE(
+          (ARRAY_AGG(sensitivity_level ORDER BY
+            CASE sensitivity_level
+              WHEN 'confidential' THEN 4
+              WHEN 'restricted' THEN 3
+              WHEN 'internal' THEN 2
+              ELSE 1
+            END DESC
+          ))[1],
+          'internal'
+        ) AS propagated_level,
+        COALESCE(jsonb_agg(DISTINCT pii.value) FILTER (WHERE pii.value IS NOT NULL), '[]'::jsonb) AS pii_types
+      FROM artifact_sensitivity
+      LEFT JOIN LATERAL jsonb_array_elements_text(sensitivity_metadata->'pii_types') AS pii(value) ON true
+    )
+    UPDATE stories
+    SET
+      sensitivity_level = ranked.propagated_level,
+      sensitivity_metadata = jsonb_build_object(
+        'level', ranked.propagated_level,
+        'reason', 'upward_propagation',
+        'assigned_by', 'policy_rule',
+        'assigned_at', to_jsonb(now()),
+        'pii_types', ranked.pii_types,
+        'declassify_date', 'null'::jsonb
+      ),
+      updated_at = now()
+    FROM ranked
+    WHERE stories.id = $1
+    RETURNING stories.*
+  `;
+
+	try {
+		const result = await pool.query<StoryRow>(sql, [storyId]);
+		if (result.rows.length === 0) {
+			throw new DatabaseError(`Story not found: ${storyId}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
+				context: { storyId },
+			});
+		}
+		return mapStoryRow(result.rows[0]);
+	} catch (error: unknown) {
+		if (error instanceof DatabaseError) {
+			throw error;
+		}
+		throw new DatabaseError('Failed to update story sensitivity', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { storyId },
 		});
 	}
 }

--- a/packages/core/src/database/repositories/story.repository.ts
+++ b/packages/core/src/database/repositories/story.repository.ts
@@ -14,6 +14,7 @@ import type pg from 'pg';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
+import { queryWithSensitivityColumnFallback } from './schema-compat.js';
 import type { CreateStoryInput, Story, StoryFilter, StoryStatus, UpdateStoryInput } from './story.types.js';
 
 const logger = createLogger();
@@ -98,6 +99,19 @@ export async function createStory(pool: pg.Pool, input: CreateStoryInput): Promi
     ON CONFLICT (id) DO UPDATE SET updated_at = now()
     RETURNING *
   `;
+	const legacySql = hasExplicitId
+		? `
+    INSERT INTO stories (id, source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    ON CONFLICT (id) DO UPDATE SET updated_at = now()
+    RETURNING *
+  `
+		: `
+    INSERT INTO stories (source_id, title, subtitle, language, category, page_start, page_end, gcs_markdown_uri, gcs_metadata_uri, extraction_confidence, metadata)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    ON CONFLICT (id) DO UPDATE SET updated_at = now()
+    RETURNING *
+  `;
 	const baseParams = [
 		input.sourceId,
 		input.title,
@@ -114,9 +128,11 @@ export async function createStory(pool: pg.Pool, input: CreateStoryInput): Promi
 		stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 	];
 	const params = hasExplicitId ? [input.id, ...baseParams] : baseParams;
+	const legacyBaseParams = baseParams.slice(0, -2);
+	const legacyParams = hasExplicitId ? [input.id, ...legacyBaseParams] : legacyBaseParams;
 
 	try {
-		const result = await pool.query<StoryRow>(sql, params);
+		const result = await queryWithSensitivityColumnFallback<StoryRow>(pool, sql, params, legacySql, legacyParams);
 		const row = result.rows[0];
 		repoLogger.debug({ storyId: row.id, sourceId: input.sourceId }, 'Story created or found');
 		return mapStoryRow(row);

--- a/packages/core/src/database/repositories/story.types.ts
+++ b/packages/core/src/database/repositories/story.types.ts
@@ -8,6 +8,8 @@
  * @see docs/functional-spec.md §4.3
  */
 
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
+
 // ────────────────────────────────────────────────────────────
 // Status enum
 // ────────────────────────────────────────────────────────────
@@ -35,6 +37,8 @@ export interface Story {
 	extractionConfidence: number | null;
 	status: StoryStatus;
 	metadata: Record<string, unknown>;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -54,6 +58,8 @@ export interface CreateStoryInput {
 	gcsMetadataUri: string;
 	extractionConfidence?: number;
 	metadata?: Record<string, unknown>;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Input for updating a story. Partial — only provided fields are updated. */
@@ -70,6 +76,8 @@ export interface UpdateStoryInput {
 	extractionConfidence?: number;
 	status?: StoryStatus;
 	metadata?: Record<string, unknown>;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 }
 
 /** Filters for querying stories. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@
 
 export { ZodError } from 'zod';
 export type {
+	AccessControlConfig,
+	AccessControlSensitivityConfig,
 	AnalysisConfig,
 	ApiAuthConfig,
 	ApiAuthKeyConfig,
@@ -312,8 +314,10 @@ export {
 	updateEntity,
 	updateEntityEmbedding,
 	updateSource,
+	updateSourceSensitivityFromArtifacts,
 	updateSourceStatus,
 	updateStory,
+	updateStorySensitivityFromArtifacts,
 	updateStoryStatus,
 	updateTaxonomyEntry,
 	upsertDocumentBlob,
@@ -459,6 +463,26 @@ export { createServiceRegistry } from './shared/registry.js';
 export type { RetryOptions } from './shared/retry.js';
 // ── Retry ───────────────────────────────────────────────────
 export { withRetry } from './shared/retry.js';
+export type {
+	PIIType,
+	SensitivityAssignmentSource,
+	SensitivityLevel,
+	SensitivityMetadata,
+	SensitivityMetadataInput,
+	SensitivityTagged,
+} from './shared/sensitivity.js';
+export {
+	defaultSensitivityMetadata,
+	isSensitivityLevel,
+	mapSensitivityMetadataToDb,
+	mergeSensitivityMetadata,
+	mostRestrictiveSensitivityLevel,
+	normalizeSensitivityMetadata,
+	PII_TYPES,
+	SENSITIVITY_ASSIGNMENT_SOURCES,
+	SENSITIVITY_LEVELS,
+	stringifySensitivityMetadata,
+} from './shared/sensitivity.js';
 export { createGcpServices } from './shared/services.gcp.js';
 export type {
 	DocumentAiResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export type {
 	MonthlyBudgetReservationStatus,
 	MonthlyBudgetSummary,
 	NormalizationResult,
+	PersistedSource,
 	PipelineRun,
 	PipelineRunSource,
 	PipelineRunSourceStatus,

--- a/packages/core/src/prompts/engine.ts
+++ b/packages/core/src/prompts/engine.ts
@@ -16,6 +16,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PROMPT_ERROR_CODES, PromptError } from '../shared/errors.js';
+import { PII_TYPES, SENSITIVITY_LEVELS } from '../shared/sensitivity.js';
 
 // ────────────────────────────────────────────────────────────
 // Path resolution
@@ -187,6 +188,19 @@ function valueToString(value: unknown): string {
 	return String(value);
 }
 
+function templateDefaultVariables(templateName: string): Record<string, unknown> {
+	if (templateName !== 'extract-entities') {
+		return {};
+	}
+
+	return {
+		sensitivity_auto_detection: 'false',
+		sensitivity_levels: SENSITIVITY_LEVELS.join(', '),
+		sensitivity_default_level: 'internal',
+		sensitivity_pii_types: PII_TYPES.join(', '),
+	};
+}
+
 // ────────────────────────────────────────────────────────────
 // Public API
 // ────────────────────────────────────────────────────────────
@@ -214,7 +228,7 @@ export function renderPrompt(templateName: string, variables: Record<string, unk
 	const template = loadTemplate(templateName);
 
 	// 2. Resolve i18n if locale is provided
-	const mergedVars: Record<string, unknown> = { ...variables };
+	const mergedVars: Record<string, unknown> = { ...templateDefaultVariables(templateName), ...variables };
 	if (typeof variables.locale === 'string' && variables.locale.length > 0) {
 		const localeData = loadLocale(variables.locale);
 		mergedVars.i18n = localeData;

--- a/packages/core/src/prompts/templates/extract-entities.jinja2
+++ b/packages/core/src/prompts/templates/extract-entities.jinja2
@@ -22,5 +22,20 @@ For borderline cases, use the more conservative label: prefer interpretation ove
 
 When the output schema does not contain an assertions array, omit assertion classification and return only the schema fields.
 
+## Sensitivity Detection
+Auto-detection: {{ sensitivity_auto_detection }}
+
+When auto-detection is true and the output schema contains a sensitivity object, include sensitivity for every extracted entity, relationship, and assertion. Use only these generic levels, ordered least to most restrictive: {{ sensitivity_levels }}. The default policy level is {{ sensitivity_default_level }}. Use only these pii_types values: {{ sensitivity_pii_types }}.
+
+Level guidance:
+- public: safe to share openly.
+- internal: ordinary non-public project material.
+- restricted: personal information, private locations, legal/financial details, or unpublished research that should be tightly limited.
+- confidential: highly sensitive personal or protected information where disclosure could cause harm.
+
+For borderline cases, classify conservatively upward. Set sensitivity.level to the most restrictive applicable level, sensitivity.reason to a short generic reason, sensitivity.pii_types to the matching configured values, and sensitivity.declassify_date to null unless the text states a concrete declassification date.
+
+When auto-detection is false or the output schema does not contain a sensitivity object, omit sensitivity fields and let the system default apply.
+
 {{ i18n.common.language_instruction }}
 {{ i18n.common.json_instruction }}

--- a/packages/core/src/shared/sensitivity.ts
+++ b/packages/core/src/shared/sensitivity.ts
@@ -129,9 +129,13 @@ export function mostRestrictiveSensitivityLevel(
 	levels: readonly (SensitivityLevel | null | undefined)[],
 	fallback: SensitivityLevel = 'internal',
 ): SensitivityLevel {
-	let result = fallback;
+	let result: SensitivityLevel | undefined;
 	for (const level of levels) {
 		if (!level) {
+			continue;
+		}
+		if (!result) {
+			result = level;
 			continue;
 		}
 		const currentRank = SENSITIVITY_RANK.get(result) ?? 0;
@@ -140,7 +144,7 @@ export function mostRestrictiveSensitivityLevel(
 			result = level;
 		}
 	}
-	return result;
+	return result ?? fallback;
 }
 
 export function mergeSensitivityMetadata(

--- a/packages/core/src/shared/sensitivity.ts
+++ b/packages/core/src/shared/sensitivity.ts
@@ -1,0 +1,191 @@
+export const SENSITIVITY_LEVELS = ['public', 'internal', 'restricted', 'confidential'] as const;
+
+export type SensitivityLevel = (typeof SENSITIVITY_LEVELS)[number];
+
+export const SENSITIVITY_ASSIGNMENT_SOURCES = ['llm_auto', 'human', 'policy_rule'] as const;
+
+export type SensitivityAssignmentSource = (typeof SENSITIVITY_ASSIGNMENT_SOURCES)[number];
+
+export const PII_TYPES = [
+	'person_name',
+	'contact_info',
+	'medical_data',
+	'location_private',
+	'location_sighting',
+	'financial',
+	'unpublished_research',
+	'legal',
+] as const;
+
+export type PIIType = (typeof PII_TYPES)[number];
+
+export interface SensitivityMetadata {
+	level: SensitivityLevel;
+	reason: string;
+	assignedBy: SensitivityAssignmentSource;
+	assignedAt: string;
+	piiTypes: PIIType[];
+	declassifyDate: string | null;
+}
+
+export interface SensitivityTagged {
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
+}
+
+export type SensitivityMetadataInput =
+	| Partial<SensitivityMetadata>
+	| {
+			level?: unknown;
+			reason?: unknown;
+			assigned_by?: unknown;
+			assignedBy?: unknown;
+			assigned_at?: unknown;
+			assignedAt?: unknown;
+			pii_types?: unknown;
+			piiTypes?: unknown;
+			declassify_date?: unknown;
+			declassifyDate?: unknown;
+	  };
+
+const SENSITIVITY_RANK = new Map<SensitivityLevel, number>(SENSITIVITY_LEVELS.map((level, index) => [level, index]));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isSensitivityLevel(value: unknown): value is SensitivityLevel {
+	return typeof value === 'string' && SENSITIVITY_LEVELS.some((level) => level === value);
+}
+
+function isSensitivityAssignmentSource(value: unknown): value is SensitivityAssignmentSource {
+	return typeof value === 'string' && SENSITIVITY_ASSIGNMENT_SOURCES.some((source) => source === value);
+}
+
+function isPIIType(value: unknown): value is PIIType {
+	return typeof value === 'string' && PII_TYPES.some((piiType) => piiType === value);
+}
+
+function readString(value: unknown, fallback: string): string {
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function readNullableString(value: unknown): string | null {
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function uniquePiiTypes(value: unknown): PIIType[] {
+	const types = Array.isArray(value) ? value : [];
+	const unique = new Set<PIIType>();
+	for (const item of types) {
+		if (isPIIType(item)) {
+			unique.add(item);
+		}
+	}
+	return [...unique].sort();
+}
+
+export function defaultSensitivityMetadata(
+	level: SensitivityLevel = 'internal',
+	options?: {
+		reason?: string;
+		assignedBy?: SensitivityAssignmentSource;
+		assignedAt?: string;
+		piiTypes?: readonly PIIType[];
+		declassifyDate?: string | null;
+	},
+): SensitivityMetadata {
+	return {
+		level,
+		reason: options?.reason ?? 'default_policy',
+		assignedBy: options?.assignedBy ?? 'policy_rule',
+		assignedAt: options?.assignedAt ?? new Date().toISOString(),
+		piiTypes: [...new Set(options?.piiTypes ?? [])].sort(),
+		declassifyDate: options?.declassifyDate ?? null,
+	};
+}
+
+export function normalizeSensitivityMetadata(
+	value: unknown,
+	fallbackLevel: SensitivityLevel = 'internal',
+): SensitivityMetadata {
+	const root = isRecord(value) ? value : {};
+	const levelValue = root.level;
+	const level = isSensitivityLevel(levelValue) ? levelValue : fallbackLevel;
+	const assignedByValue = root.assignedBy ?? root.assigned_by;
+	const assignedAt = readString(root.assignedAt ?? root.assigned_at, new Date().toISOString());
+
+	return {
+		level,
+		reason: readString(root.reason, 'default_policy'),
+		assignedBy: isSensitivityAssignmentSource(assignedByValue) ? assignedByValue : 'policy_rule',
+		assignedAt,
+		piiTypes: uniquePiiTypes(root.piiTypes ?? root.pii_types),
+		declassifyDate: readNullableString(root.declassifyDate ?? root.declassify_date),
+	};
+}
+
+export function mostRestrictiveSensitivityLevel(
+	levels: readonly (SensitivityLevel | null | undefined)[],
+	fallback: SensitivityLevel = 'internal',
+): SensitivityLevel {
+	let result = fallback;
+	for (const level of levels) {
+		if (!level) {
+			continue;
+		}
+		const currentRank = SENSITIVITY_RANK.get(result) ?? 0;
+		const nextRank = SENSITIVITY_RANK.get(level) ?? 0;
+		if (nextRank > currentRank) {
+			result = level;
+		}
+	}
+	return result;
+}
+
+export function mergeSensitivityMetadata(
+	items: readonly (SensitivityMetadata | unknown | null | undefined)[],
+	fallbackLevel: SensitivityLevel = 'internal',
+): SensitivityMetadata {
+	const normalized = items.map((item) => normalizeSensitivityMetadata(item, fallbackLevel));
+	const level = mostRestrictiveSensitivityLevel(
+		normalized.map((item) => item.level),
+		fallbackLevel,
+	);
+	const piiTypes = new Set<PIIType>();
+	const reasons = new Set<string>();
+	let assignedBy: SensitivityAssignmentSource = 'policy_rule';
+
+	for (const item of normalized) {
+		for (const piiType of item.piiTypes) {
+			piiTypes.add(piiType);
+		}
+		reasons.add(item.reason);
+		if (item.assignedBy === 'human') {
+			assignedBy = 'human';
+		} else if (assignedBy !== 'human' && item.assignedBy === 'llm_auto') {
+			assignedBy = 'llm_auto';
+		}
+	}
+
+	return defaultSensitivityMetadata(level, {
+		reason: [...reasons].sort().join('+') || 'default_policy',
+		assignedBy,
+		piiTypes: [...piiTypes].sort(),
+	});
+}
+
+export function mapSensitivityMetadataToDb(value: SensitivityMetadata): Record<string, unknown> {
+	return {
+		level: value.level,
+		reason: value.reason,
+		assigned_by: value.assignedBy,
+		assigned_at: value.assignedAt,
+		pii_types: value.piiTypes,
+		declassify_date: value.declassifyDate,
+	};
+}
+
+export function stringifySensitivityMetadata(value?: unknown, fallbackLevel: SensitivityLevel = 'internal'): string {
+	return JSON.stringify(mapSensitivityMetadataToDb(normalizeSensitivityMetadata(value, fallbackLevel)));
+}

--- a/packages/core/src/shared/services.dev.ts
+++ b/packages/core/src/shared/services.dev.ts
@@ -92,6 +92,20 @@ function extractEnumValues(schema: Record<string, unknown>, arrayProp: string, f
 	return enumValues.filter((v): v is string => typeof v === 'string');
 }
 
+function arrayItemRequiresProperty(schema: Record<string, unknown>, arrayProp: string, fieldProp: string): boolean {
+	const required = getNestedProperty(schema, 'properties', arrayProp, 'items', 'required');
+	return Array.isArray(required) && required.some((value) => value === fieldProp);
+}
+
+function devSensitivityFixture(reason: string): Record<string, unknown> {
+	return {
+		level: 'internal',
+		reason,
+		pii_types: [],
+		declassify_date: null,
+	};
+}
+
 function slugify(value: string): string {
 	return (
 		value
@@ -367,52 +381,71 @@ class DevLlmService implements LlmService {
 			// Extract valid entity types and relationship types from the JSON Schema
 			const entityTypes = extractEnumValues(options.schema, 'entities', 'type');
 			const relationshipTypes = extractEnumValues(options.schema, 'relationships', 'relationship_type');
+			const requiresEntitySensitivity = arrayItemRequiresProperty(options.schema, 'entities', 'sensitivity');
+			const requiresRelationshipSensitivity = arrayItemRequiresProperty(options.schema, 'relationships', 'sensitivity');
+			const requiresAssertionSensitivity = arrayItemRequiresProperty(options.schema, 'assertions', 'sensitivity');
 
 			// Build entities using valid types from the schema
 			const entities: Array<Record<string, unknown>> = [];
 			if (entityTypes.includes('person')) {
-				entities.push({
+				const entity: Record<string, unknown> = {
 					name: 'Dev Test Person',
 					type: 'person',
 					confidence: 0.9,
 					attributes: { role: 'researcher' },
 					mentions: ['Dev Test Person'],
-				});
+				};
+				if (requiresEntitySensitivity) {
+					entity.sensitivity = devSensitivityFixture('dev_mode_fixture');
+				}
+				entities.push(entity);
 			}
 			if (entityTypes.includes('location')) {
-				entities.push({
+				const entity: Record<string, unknown> = {
 					name: 'Dev Test Location',
 					type: 'location',
 					confidence: 0.85,
 					attributes: { region: 'Europe' },
 					mentions: ['Dev Test Location'],
-				});
+				};
+				if (requiresEntitySensitivity) {
+					entity.sensitivity = devSensitivityFixture('dev_mode_fixture');
+				}
+				entities.push(entity);
 			}
 			// Fallback: if neither person nor location is in schema, use the first available type
 			if (entities.length === 0 && entityTypes.length > 0) {
-				entities.push({
+				const entity: Record<string, unknown> = {
 					name: 'Dev Test Entity',
 					type: entityTypes[0],
 					confidence: 0.9,
 					attributes: {},
 					mentions: ['Dev Test Entity'],
-				});
+				};
+				if (requiresEntitySensitivity) {
+					entity.sensitivity = devSensitivityFixture('dev_mode_fixture');
+				}
+				entities.push(entity);
 			}
 
 			// Build relationships only if we have a valid relationship type and two entities
 			const relationships: Array<Record<string, unknown>> = [];
 			if (entities.length >= 2 && relationshipTypes.length > 0) {
-				relationships.push({
+				const relationship: Record<string, unknown> = {
 					source_entity: String(entities[0].name),
 					target_entity: String(entities[1].name),
 					relationship_type: relationshipTypes[0],
 					confidence: 0.8,
-				});
+				};
+				if (requiresRelationshipSensitivity) {
+					relationship.sensitivity = devSensitivityFixture('dev_mode_fixture');
+				}
+				relationships.push(relationship);
 			}
 
 			const assertions: Array<Record<string, unknown>> = [];
 			if (hasProperty('assertions')) {
-				assertions.push({
+				const assertion: Record<string, unknown> = {
 					content: 'Dev mode fixture records a classified observation from the story text.',
 					assertion_type: 'observation',
 					confidence_metadata: {
@@ -425,7 +458,11 @@ class DevLlmService implements LlmService {
 					},
 					classification_provenance: 'llm_auto',
 					entity_names: entities.map((entity) => String(entity.name)),
-				});
+				};
+				if (requiresAssertionSensitivity) {
+					assertion.sensitivity = devSensitivityFixture('dev_mode_fixture');
+				}
+				assertions.push(assertion);
 			}
 
 			result = JSON.parse(

--- a/packages/pipeline/src/enrich/index.ts
+++ b/packages/pipeline/src/enrich/index.ts
@@ -224,8 +224,7 @@ function preChunkMarkdown(markdown: string, targetTokens: number): string[] {
  */
 function mergeExtractionResponses(responses: ExtractionResponse[]): ExtractionResponse {
 	const entityMap = new Map<string, ExtractionResponse['entities'][0]>();
-	const relationshipSet = new Set<string>();
-	const mergedRelationships: ExtractionResponse['relationships'] = [];
+	const relationshipMap = new Map<string, ExtractionResponse['relationships'][0]>();
 	const assertionMap = new Map<string, NonNullable<ExtractionResponse['assertions']>[0]>();
 
 	for (const response of responses) {
@@ -249,9 +248,16 @@ function mergeExtractionResponses(responses: ExtractionResponse[]): ExtractionRe
 
 		for (const rel of response.relationships) {
 			const key = `${rel.source_entity}:${rel.target_entity}:${rel.relationship_type}`;
-			if (!relationshipSet.has(key)) {
-				relationshipSet.add(key);
-				mergedRelationships.push(rel);
+			const existing = relationshipMap.get(key);
+			if (existing) {
+				relationshipMap.set(key, {
+					...existing,
+					confidence: Math.max(existing.confidence, rel.confidence),
+					attributes: { ...(existing.attributes ?? {}), ...(rel.attributes ?? {}) },
+					sensitivity: mergeExtractedSensitivity([existing.sensitivity, rel.sensitivity], 'internal'),
+				});
+			} else {
+				relationshipMap.set(key, rel);
 			}
 		}
 
@@ -272,7 +278,7 @@ function mergeExtractionResponses(responses: ExtractionResponse[]): ExtractionRe
 
 	const merged: ExtractionResponse = {
 		entities: [...entityMap.values()],
-		relationships: mergedRelationships,
+		relationships: [...relationshipMap.values()],
 	};
 	if (assertionMap.size > 0) {
 		merged.assertions = [...assertionMap.values()];

--- a/packages/pipeline/src/enrich/index.ts
+++ b/packages/pipeline/src/enrich/index.ts
@@ -12,9 +12,18 @@
  */
 
 import { performance } from 'node:perf_hooks';
-import type { DocumentQualityAssessment, Logger, MulderConfig, Services, StepError } from '@mulder/core';
+import type {
+	DocumentQualityAssessment,
+	Logger,
+	MulderConfig,
+	SensitivityLevel,
+	SensitivityMetadata,
+	Services,
+	StepError,
+} from '@mulder/core';
 import {
 	createChildLogger,
+	defaultSensitivityMetadata,
 	deleteEdgesByStoryId,
 	deleteKnowledgeAssertionsForStory,
 	deleteStoryEntitiesByStoryId,
@@ -24,11 +33,16 @@ import {
 	findStoryById,
 	getStepConfigHash,
 	linkStoryEntity,
+	mapSensitivityMetadataToDb,
+	mergeSensitivityMetadata,
 	normalizeConfidenceMetadata,
+	normalizeSensitivityMetadata,
 	provenanceForSource,
 	renderPrompt,
 	resetPipelineStep,
 	updateEntity,
+	updateSourceSensitivityFromArtifacts,
+	updateStorySensitivityFromArtifacts,
 	updateStoryStatus,
 	upsertEdge,
 	upsertEntityByNameType,
@@ -39,7 +53,13 @@ import { normalizeTaxonomy } from '@mulder/taxonomy';
 import type pg from 'pg';
 import { resolveEntity } from './resolution.js';
 import { generateExtractionSchema, getExtractionResponseSchema } from './schema.js';
-import type { EnrichInput, EnrichmentData, EnrichResult, ExtractionResponse } from './types.js';
+import type {
+	EnrichInput,
+	EnrichmentData,
+	EnrichResult,
+	ExtractedSensitivityMetadata,
+	ExtractionResponse,
+} from './types.js';
 
 export { resolveEntity } from './resolution.js';
 export type {
@@ -61,6 +81,7 @@ export type {
 	ExtractedAssertion,
 	ExtractedEntity,
 	ExtractedRelationship,
+	ExtractedSensitivityMetadata,
 	ExtractionResponse,
 } from './types.js';
 
@@ -127,6 +148,34 @@ function mapAssertionEntityIds(
 	return [...entityIds].sort();
 }
 
+function toExtractedSensitivityMetadata(value: unknown, fallbackLevel: SensitivityLevel): ExtractedSensitivityMetadata {
+	const metadata = normalizeSensitivityMetadata(value, fallbackLevel);
+	const dbMetadata = mapSensitivityMetadataToDb(metadata);
+	return {
+		level: metadata.level,
+		reason: metadata.reason,
+		assigned_by: metadata.assignedBy,
+		assigned_at: metadata.assignedAt,
+		pii_types: metadata.piiTypes,
+		declassify_date: typeof dbMetadata.declassify_date === 'string' ? dbMetadata.declassify_date : null,
+	};
+}
+
+function mergeExtractedSensitivity(
+	items: readonly (ExtractedSensitivityMetadata | undefined)[],
+	fallbackLevel: SensitivityLevel,
+): ExtractedSensitivityMetadata {
+	return toExtractedSensitivityMetadata(mergeSensitivityMetadata(items, fallbackLevel), fallbackLevel);
+}
+
+function detectedSensitivityMetadata(value: unknown, fallbackLevel: SensitivityLevel): SensitivityMetadata {
+	const metadata = normalizeSensitivityMetadata(value, fallbackLevel);
+	return {
+		...metadata,
+		assignedBy: 'llm_auto',
+	};
+}
+
 // ────────────────────────────────────────────────────────────
 // Pre-chunking
 // ────────────────────────────────────────────────────────────
@@ -191,6 +240,7 @@ function mergeExtractionResponses(responses: ExtractionResponse[]): ExtractionRe
 					confidence: Math.max(existing.confidence, entity.confidence),
 					mentions: mergedMentions,
 					attributes: { ...existing.attributes, ...entity.attributes },
+					sensitivity: mergeExtractedSensitivity([existing.sensitivity, entity.sensitivity], 'internal'),
 				});
 			} else {
 				entityMap.set(key, entity);
@@ -212,6 +262,7 @@ function mergeExtractionResponses(responses: ExtractionResponse[]): ExtractionRe
 				assertionMap.set(key, {
 					...existing,
 					entity_names: [...new Set([...(existing.entity_names ?? []), ...(assertion.entity_names ?? [])])].sort(),
+					sensitivity: mergeExtractedSensitivity([existing.sensitivity, assertion.sensitivity], 'internal'),
 				});
 			} else {
 				assertionMap.set(key, assertion);
@@ -301,6 +352,13 @@ export async function execute(
 	const artifactProvenance = provenanceForSource(story.sourceId, input.extractionPipelineRun ?? null);
 	const assertionClassificationConfig = config.enrichment.assertion_classification;
 	const assertionClassificationEnabled = assertionClassificationConfig.enabled;
+	const sensitivityConfig = config.access_control.sensitivity;
+	const defaultSensitivityLevel = sensitivityConfig.default_level;
+	const sensitivityAutoDetectionEnabled = config.access_control.enabled && sensitivityConfig.auto_detection;
+	const defaultSensitivity = defaultSensitivityMetadata(defaultSensitivityLevel, {
+		assignedBy: 'policy_rule',
+		reason: 'default_policy',
+	});
 	const latestQualityAssessment = assertionClassificationEnabled
 		? await findLatestDocumentQualityAssessment(pool, story.sourceId)
 		: null;
@@ -369,7 +427,12 @@ export async function execute(
 
 	// 6. Generate JSON Schema from ontology
 	const ontology = config.ontology;
-	const extractionSchemaOptions = { assertionClassificationEnabled };
+	const extractionSchemaOptions = {
+		assertionClassificationEnabled,
+		sensitivityAutoDetectionEnabled,
+		sensitivityLevels: sensitivityConfig.levels,
+		piiTypes: sensitivityConfig.pii_types,
+	};
 	const jsonSchema = generateExtractionSchema(ontology, extractionSchemaOptions);
 	const responseSchema = getExtractionResponseSchema(ontology, extractionSchemaOptions);
 
@@ -402,6 +465,10 @@ export async function execute(
 			locale,
 			ontology: ontologyDescription,
 			story_text: chunk,
+			sensitivity_auto_detection: sensitivityAutoDetectionEnabled ? 'true' : 'false',
+			sensitivity_levels: sensitivityConfig.levels.join(', '),
+			sensitivity_default_level: defaultSensitivityLevel,
+			sensitivity_pii_types: sensitivityConfig.pii_types.join(', '),
 		});
 
 		try {
@@ -478,6 +545,9 @@ export async function execute(
 
 	for (const extracted of sortedEntities) {
 		try {
+			const sensitivityMetadata = sensitivityAutoDetectionEnabled
+				? detectedSensitivityMetadata(extracted.sensitivity, defaultSensitivityLevel)
+				: defaultSensitivity;
 			// 11a. Taxonomy normalization (must run before upsert so the
 			// resulting entity row carries the canonical taxonomy_id from
 			// the start; cross-story queries can then group entities that
@@ -494,6 +564,8 @@ export async function execute(
 				attributes: extracted.attributes,
 				taxonomyId: normResult.taxonomyEntry.id,
 				provenance: artifactProvenance,
+				sensitivityLevel: sensitivityMetadata.level,
+				sensitivityMetadata,
 			});
 			entityNameToId.set(extracted.name, entity.id);
 			if (entity.taxonomyId) {
@@ -531,6 +603,8 @@ export async function execute(
 				confidence: extracted.confidence,
 				mentionCount: extracted.mentions.length,
 				provenance: artifactProvenance,
+				sensitivityLevel: sensitivityMetadata.level,
+				sensitivityMetadata,
 			});
 		} catch (cause: unknown) {
 			const message = cause instanceof Error ? cause.message : String(cause);
@@ -562,6 +636,9 @@ export async function execute(
 		}
 
 		try {
+			const sensitivityMetadata = sensitivityAutoDetectionEnabled
+				? detectedSensitivityMetadata(rel.sensitivity, defaultSensitivityLevel)
+				: defaultSensitivity;
 			await upsertEdge(pool, {
 				sourceEntityId,
 				targetEntityId,
@@ -571,6 +648,8 @@ export async function execute(
 				edgeType: 'RELATIONSHIP',
 				attributes: rel.attributes ?? {},
 				provenance: artifactProvenance,
+				sensitivityLevel: sensitivityMetadata.level,
+				sensitivityMetadata,
 			});
 			relationshipsCreated++;
 		} catch (cause: unknown) {
@@ -602,6 +681,9 @@ export async function execute(
 			}
 
 			try {
+				const sensitivityMetadata = sensitivityAutoDetectionEnabled
+					? detectedSensitivityMetadata(assertion.sensitivity, defaultSensitivityLevel)
+					: defaultSensitivity;
 				await upsertKnowledgeAssertion(pool, {
 					sourceId: story.sourceId,
 					storyId: input.storyId,
@@ -613,6 +695,8 @@ export async function execute(
 					extractedEntityIds: mapAssertionEntityIds(assertion.entity_names, entityNameToId),
 					provenance: artifactProvenance,
 					qualityMetadata: assertionQualityMetadata,
+					sensitivityLevel: sensitivityMetadata.level,
+					sensitivityMetadata,
 				});
 				assertionsPersisted++;
 			} catch (cause: unknown) {
@@ -639,6 +723,10 @@ export async function execute(
 
 	// 15. Update story status + source step
 	if (status !== 'failed') {
+		if (sensitivityConfig.propagation === 'upward') {
+			await updateStorySensitivityFromArtifacts(pool, input.storyId);
+			await updateSourceSensitivityFromArtifacts(pool, story.sourceId);
+		}
 		await updateStoryStatus(pool, input.storyId, 'enriched');
 		await upsertSourceStep(pool, {
 			sourceId: story.sourceId,

--- a/packages/pipeline/src/enrich/schema.ts
+++ b/packages/pipeline/src/enrich/schema.ts
@@ -12,13 +12,17 @@
  * @see docs/functional-spec.md §2.4
  */
 
-import type { EntityTypeConfig, OntologyConfig } from '@mulder/core';
+import type { EntityTypeConfig, OntologyConfig, PIIType, SensitivityLevel } from '@mulder/core';
+import { PII_TYPES, SENSITIVITY_LEVELS } from '@mulder/core';
 import { z } from 'zod';
 import { z as z3 } from 'zod/v3';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
 export interface ExtractionSchemaOptions {
 	assertionClassificationEnabled?: boolean;
+	sensitivityAutoDetectionEnabled?: boolean;
+	sensitivityLevels?: readonly SensitivityLevel[];
+	piiTypes?: readonly PIIType[];
 }
 
 // ────────────────────────────────────────────────────────────
@@ -134,8 +138,29 @@ function buildConfidenceMetadataSchemaV3(): z3.ZodObject<z3.ZodRawShape> {
 	});
 }
 
-function buildAssertionSchemaV3(): z3.ZodObject<z3.ZodRawShape> {
+function nonEmptySensitivityLevels(options?: ExtractionSchemaOptions): [SensitivityLevel, ...SensitivityLevel[]] {
+	const values = options?.sensitivityLevels?.length ? options.sensitivityLevels : SENSITIVITY_LEVELS;
+	return values as [SensitivityLevel, ...SensitivityLevel[]];
+}
+
+function nonEmptyPiiTypes(options?: ExtractionSchemaOptions): [PIIType, ...PIIType[]] {
+	const values = options?.piiTypes?.length ? options.piiTypes : PII_TYPES;
+	return values as [PIIType, ...PIIType[]];
+}
+
+function buildSensitivitySchemaV3(options?: ExtractionSchemaOptions): z3.ZodObject<z3.ZodRawShape> {
 	return z3.object({
+		level: z3
+			.enum(nonEmptySensitivityLevels(options))
+			.describe('Sensitivity level: public < internal < restricted < confidential'),
+		reason: z3.string().describe('Short generic reason for the assigned sensitivity level'),
+		pii_types: z3.array(z3.enum(nonEmptyPiiTypes(options))).describe('PII or sensitive information types detected'),
+		declassify_date: z3.string().nullable().describe('ISO date when level can be lowered, or null'),
+	});
+}
+
+function buildAssertionSchemaV3(options?: ExtractionSchemaOptions): z3.ZodObject<z3.ZodRawShape> {
+	const shape: z3.ZodRawShape = {
 		content: z3.string().describe('The concise assertion text, preserving the source meaning'),
 		assertion_type: z3
 			.enum(['observation', 'interpretation', 'hypothesis'])
@@ -146,7 +171,13 @@ function buildAssertionSchemaV3(): z3.ZodObject<z3.ZodRawShape> {
 			.optional()
 			.describe('How the assertion classification was determined'),
 		entity_names: z3.array(z3.string()).optional().describe('Extracted entity names referenced by this assertion'),
-	});
+	};
+
+	if (options?.sensitivityAutoDetectionEnabled) {
+		shape.sensitivity = buildSensitivitySchemaV3(options).describe('Sensitivity metadata for this assertion');
+	}
+
+	return z3.object(shape);
 }
 
 function buildExtractionResponseSchemaV3(
@@ -159,16 +190,20 @@ function buildExtractionResponseSchemaV3(
 	const attributesSchema = buildAttributesSchemaV3(ontology.entity_types);
 
 	// Entity schema
-	const entitySchemaV3 = z3.object({
+	const entityShapeV3: z3.ZodRawShape = {
 		name: z3.string().describe('The canonical name of the entity'),
 		type: z3.enum(entityTypeNames as [string, ...string[]]).describe('The entity type from the ontology'),
 		confidence: z3.number().min(0).max(1).describe('Confidence score for entity extraction (0-1)'),
 		attributes: attributesSchema.describe('Entity attributes based on its type'),
 		mentions: z3.array(z3.string()).describe('All text mentions/aliases of this entity in the story'),
-	});
+	};
+	if (options?.sensitivityAutoDetectionEnabled) {
+		entityShapeV3.sensitivity = buildSensitivitySchemaV3(options).describe('Sensitivity metadata for this entity');
+	}
+	const entitySchemaV3 = z3.object(entityShapeV3);
 
 	// Relationship schema
-	const relationshipSchemaV3 = z3.object({
+	const relationshipShapeV3: z3.ZodRawShape = {
 		source_entity: z3.string().describe('Name of the source entity'),
 		target_entity: z3.string().describe('Name of the target entity'),
 		relationship_type:
@@ -177,7 +212,13 @@ function buildExtractionResponseSchemaV3(
 				: z3.string().describe('Relationship type'),
 		confidence: z3.number().min(0).max(1).describe('Confidence score for relationship extraction (0-1)'),
 		attributes: z3.object({}).passthrough().optional().describe('Optional relationship attributes'),
-	});
+	};
+	if (options?.sensitivityAutoDetectionEnabled) {
+		relationshipShapeV3.sensitivity = buildSensitivitySchemaV3(options).describe(
+			'Sensitivity metadata for this relationship',
+		);
+	}
+	const relationshipSchemaV3 = z3.object(relationshipShapeV3);
 
 	const shape: z3.ZodRawShape = {
 		entities: z3.array(entitySchemaV3).describe('All entities extracted from the story'),
@@ -186,7 +227,7 @@ function buildExtractionResponseSchemaV3(
 
 	if (options?.assertionClassificationEnabled) {
 		shape.assertions = z3
-			.array(buildAssertionSchemaV3())
+			.array(buildAssertionSchemaV3(options))
 			.describe('All classified assertions extracted from the story');
 	}
 
@@ -227,14 +268,34 @@ function buildConfidenceMetadataSchemaV4() {
 	});
 }
 
-function buildAssertionSchemaV4() {
+function buildSensitivitySchemaV4(options?: ExtractionSchemaOptions) {
 	return z.object({
+		level: z.enum(nonEmptySensitivityLevels(options)),
+		reason: z.string(),
+		assigned_by: z.optional(z.enum(['llm_auto', 'human', 'policy_rule'])),
+		assigned_at: z.optional(z.string()),
+		pii_types: z.array(z.enum(nonEmptyPiiTypes(options))),
+		declassify_date: z.string().nullable(),
+	});
+}
+
+function buildAssertionSchemaV4(options?: ExtractionSchemaOptions) {
+	const shape = {
 		content: z.string(),
 		assertion_type: z.enum(['observation', 'interpretation', 'hypothesis']),
 		confidence_metadata: buildConfidenceMetadataSchemaV4(),
 		classification_provenance: z.optional(z.enum(['llm_auto', 'human_reviewed', 'author_explicit'])),
 		entity_names: z.optional(z.array(z.string())),
-	});
+	};
+
+	if (options?.sensitivityAutoDetectionEnabled) {
+		return z.object({
+			...shape,
+			sensitivity: buildSensitivitySchemaV4(options),
+		});
+	}
+
+	return z.object(shape);
 }
 
 function buildExtractionResponseSchemaV4(ontology: OntologyConfig, options?: ExtractionSchemaOptions) {
@@ -244,22 +305,34 @@ function buildExtractionResponseSchemaV4(ontology: OntologyConfig, options?: Ext
 	const attributesSchema = buildAttributesSchemaV4(ontology.entity_types);
 
 	// Entity schema
-	const entitySchemaV4 = z.object({
+	const entityShapeV4 = {
 		name: z.string(),
 		type: z.enum(entityTypeNames as [string, ...string[]]),
 		confidence: z.number().min(0).max(1),
 		attributes: attributesSchema,
 		mentions: z.array(z.string()),
-	});
+	};
+	const entitySchemaV4 = options?.sensitivityAutoDetectionEnabled
+		? z.object({
+				...entityShapeV4,
+				sensitivity: buildSensitivitySchemaV4(options),
+			})
+		: z.object(entityShapeV4);
 
 	// Relationship schema
-	const relationshipSchemaV4 = z.object({
+	const relationshipShapeV4 = {
 		source_entity: z.string(),
 		target_entity: z.string(),
 		relationship_type: relationshipNames.length > 0 ? z.enum(relationshipNames as [string, ...string[]]) : z.string(),
 		confidence: z.number().min(0).max(1),
 		attributes: z.optional(z.record(z.string(), z.unknown())),
-	});
+	};
+	const relationshipSchemaV4 = options?.sensitivityAutoDetectionEnabled
+		? z.object({
+				...relationshipShapeV4,
+				sensitivity: buildSensitivitySchemaV4(options),
+			})
+		: z.object(relationshipShapeV4);
 
 	const shape = {
 		entities: z.array(entitySchemaV4),
@@ -269,7 +342,7 @@ function buildExtractionResponseSchemaV4(ontology: OntologyConfig, options?: Ext
 	if (options?.assertionClassificationEnabled) {
 		return z.object({
 			...shape,
-			assertions: z.array(buildAssertionSchemaV4()),
+			assertions: z.array(buildAssertionSchemaV4(options)),
 		});
 	}
 

--- a/packages/pipeline/src/enrich/types.ts
+++ b/packages/pipeline/src/enrich/types.ts
@@ -9,7 +9,15 @@
  * @see docs/functional-spec.md §2.4
  */
 
-import type { AssertionType, ClassificationProvenance, ConfidenceMetadata, StepError } from '@mulder/core';
+import type {
+	AssertionType,
+	ClassificationProvenance,
+	ConfidenceMetadata,
+	PIIType,
+	SensitivityAssignmentSource,
+	SensitivityLevel,
+	StepError,
+} from '@mulder/core';
 
 // ────────────────────────────────────────────────────────────
 // Step input / output
@@ -54,6 +62,15 @@ export interface EnrichmentData {
 	chunksUsed: number;
 }
 
+export interface ExtractedSensitivityMetadata {
+	level: SensitivityLevel;
+	reason: string;
+	assigned_by?: SensitivityAssignmentSource;
+	assigned_at?: string;
+	pii_types: PIIType[];
+	declassify_date: string | null;
+}
+
 // ────────────────────────────────────────────────────────────
 // Extraction response types (from Gemini structured output)
 // ────────────────────────────────────────────────────────────
@@ -65,6 +82,7 @@ export interface ExtractedEntity {
 	confidence: number;
 	attributes: Record<string, unknown>;
 	mentions: string[];
+	sensitivity?: ExtractedSensitivityMetadata;
 }
 
 /** A relationship extracted from a story by Gemini. */
@@ -74,6 +92,7 @@ export interface ExtractedRelationship {
 	relationship_type: string;
 	confidence: number;
 	attributes?: Record<string, unknown>;
+	sensitivity?: ExtractedSensitivityMetadata;
 }
 
 /** A classified assertion extracted from a story by Gemini. */
@@ -90,6 +109,7 @@ export interface ExtractedAssertion {
 	};
 	classification_provenance?: ClassificationProvenance;
 	entity_names?: string[];
+	sensitivity?: ExtractedSensitivityMetadata;
 }
 
 /** The full extraction response from Gemini. */

--- a/packages/pipeline/src/pipeline/index.ts
+++ b/packages/pipeline/src/pipeline/index.ts
@@ -344,6 +344,15 @@ function sourceFromDryRunIngestResult(result: IngestFileResult): Source {
 		reliabilityScore: null,
 		tags: [],
 		metadata: result.formatMetadata,
+		sensitivityLevel: 'internal',
+		sensitivityMetadata: {
+			level: 'internal',
+			reason: 'default_policy',
+			assignedBy: 'policy_rule',
+			assignedAt: now.toISOString(),
+			piiTypes: [],
+			declassifyDate: null,
+		},
 		createdAt: now,
 		updatedAt: now,
 	};

--- a/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
+++ b/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
@@ -209,7 +209,13 @@ function confidenceMetadata(): import('@mulder/core').ConfidenceMetadata {
 	};
 }
 
-function fakeServices(storyUri: string, response: ExtractionResponse): import('@mulder/core').Services {
+function fakeServices(
+	storyUri: string,
+	response: ExtractionResponse | ExtractionResponse[],
+	options?: { markdown?: string; tokenCount?: number },
+): import('@mulder/core').Services {
+	const markdown = options?.markdown ?? '# Spec 102 Story\n\nA named person attended a private event.';
+	let responseIndex = 0;
 	return {
 		storage: {
 			upload: async () => 'gs://test/spec102',
@@ -217,7 +223,7 @@ function fakeServices(storyUri: string, response: ExtractionResponse): import('@
 				if (path !== storyUri) {
 					throw new Error(`unexpected storage download: ${path}`);
 				}
-				return Buffer.from('# Spec 102 Story\n\nA named person attended a private event.', 'utf-8');
+				return Buffer.from(markdown, 'utf-8');
 			},
 			delete: async () => undefined,
 			exists: async () => true,
@@ -237,14 +243,21 @@ function fakeServices(storyUri: string, response: ExtractionResponse): import('@
 			},
 		},
 		llm: {
-			countTokens: async () => 32,
+			countTokens: async () => options?.tokenCount ?? 32,
 			generateText: async () => {
 				throw new Error('generateText should not be called by Spec 102 enrich tests');
 			},
 			generateGrounded: async () => {
 				throw new Error('generateGrounded should not be called by Spec 102 enrich tests');
 			},
-			generateStructured: async () => response,
+			generateStructured: async () => {
+				if (!Array.isArray(response)) {
+					return response;
+				}
+				const next = response[Math.min(responseIndex, response.length - 1)];
+				responseIndex++;
+				return next;
+			},
 		},
 		embeddings: {
 			embed: async () => {
@@ -428,6 +441,73 @@ function extractionResponseWithoutSensitivity(): ExtractionResponse {
 			},
 		],
 	};
+}
+
+function duplicateRelationshipResponse(
+	level: SensitivityLevel,
+	options: { reason: string; confidence: number; piiTypes: PIIType[] },
+): ExtractionResponse {
+	const entityName = 'Spec Duplicate Person';
+	const eventName = 'Spec Duplicate Event';
+	return {
+		entities: [
+			{
+				name: entityName,
+				type: 'person',
+				confidence: 0.91,
+				attributes: {},
+				mentions: [entityName],
+				sensitivity: {
+					level: 'internal',
+					reason: 'internal_entity',
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: [],
+					declassify_date: null,
+				},
+			},
+			{
+				name: eventName,
+				type: 'event',
+				confidence: 0.88,
+				attributes: {},
+				mentions: [eventName],
+				sensitivity: {
+					level: 'internal',
+					reason: 'internal_event',
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: [],
+					declassify_date: null,
+				},
+			},
+		],
+		relationships: [
+			{
+				source_entity: entityName,
+				target_entity: eventName,
+				relationship_type: 'PARTICIPATED_IN',
+				confidence: options.confidence,
+				attributes: {},
+				sensitivity: {
+					level,
+					reason: options.reason,
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: options.piiTypes,
+					declassify_date: null,
+				},
+			},
+		],
+		assertions: [],
+	};
+}
+
+function longPrechunkMarkdown(): string {
+	return [
+		`# Spec 102 Story\n\n${'First chunk relationship. '.repeat(700)}`,
+		`${'Second chunk relationship. '.repeat(700)}`,
+	].join('\n\n');
 }
 
 beforeAll(async () => {
@@ -670,6 +750,59 @@ describe('Spec 102: sensitivity tagging and auto-detection', () => {
 		expect(
 			db.runSql(`SELECT sensitivity_level FROM knowledge_assertions WHERE story_id = ${sqlLiteral(story.id)} LIMIT 1;`),
 		).toBe('confidential');
+	});
+
+	it.skipIf(!pgAvailable)('QA-05b: pre-chunk duplicate relationships merge most restrictive sensitivity', async () => {
+		const { story } = await createSegmentedStory('spec102-qa05b');
+		const runtimeConfig = enrichConfig(true);
+		const result = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: false },
+			{
+				...runtimeConfig,
+				enrichment: {
+					...runtimeConfig.enrichment,
+					max_story_tokens: 1,
+				},
+			},
+			fakeServices(
+				story.gcsMarkdownUri,
+				[
+					duplicateRelationshipResponse('internal', {
+						reason: 'internal_relationship',
+						confidence: 0.51,
+						piiTypes: ['location_private'],
+					}),
+					duplicateRelationshipResponse('confidential', {
+						reason: 'confidential_relationship',
+						confidence: 0.95,
+						piiTypes: ['legal'],
+					}),
+				],
+				{ markdown: longPrechunkMarkdown(), tokenCount: 20_001 },
+			),
+			pool,
+			logger,
+		);
+
+		expect(result.status).toBe('success');
+		expect(result.data?.chunksUsed).toBe(2);
+		expect(result.data?.relationshipsCreated).toBe(1);
+		expect(
+			db.runSql(`SELECT sensitivity_level FROM entity_edges WHERE story_id = ${sqlLiteral(story.id)} LIMIT 1;`),
+		).toBe('confidential');
+		expect(
+			Number(
+				db.runSql(
+					[
+						'SELECT COUNT(*)',
+						'FROM entity_edges',
+						`WHERE story_id = ${sqlLiteral(story.id)}`,
+						"  AND sensitivity_metadata->'pii_types' ? 'legal'",
+						"  AND sensitivity_metadata->'pii_types' ? 'location_private';",
+					].join('\n'),
+				),
+			),
+		).toBe(1);
 	});
 
 	it.skipIf(!pgAvailable)('QA-06: upward propagation updates story and source', async () => {

--- a/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
+++ b/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
@@ -1,0 +1,810 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import pg from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, MULDER_TEST_TABLES, truncateExistingTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const PIPELINE_DIR = resolve(ROOT, 'packages/pipeline');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const PIPELINE_DIST = resolve(PIPELINE_DIR, 'dist/index.js');
+const CLI_DIST = resolve(CLI_DIR, 'dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const SENSITIVITY_TABLES = [
+	'sources',
+	'stories',
+	'entities',
+	'entity_aliases',
+	'story_entities',
+	'chunks',
+	'entity_edges',
+	'knowledge_assertions',
+] as const;
+
+const EXPECTED_LEVELS = ['public', 'internal', 'restricted', 'confidential'];
+const EXPECTED_PII_TYPES = [
+	'person_name',
+	'contact_info',
+	'medical_data',
+	'location_private',
+	'location_sighting',
+	'financial',
+	'unpublished_research',
+	'legal',
+];
+
+const PG_CONFIG = {
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
+};
+
+const pgAvailable = db.isPgAvailable();
+let tempDir: string | null = null;
+let pool: pg.Pool;
+let coreModule: typeof import('@mulder/core');
+let pipelineModule: typeof import('@mulder/pipeline');
+let config: import('@mulder/core').MulderConfig;
+let logger: import('@mulder/core').Logger;
+
+type SensitivityLevel = import('@mulder/core').SensitivityLevel;
+type PIIType = import('@mulder/core').PIIType;
+type ExtractionResponse = import('@mulder/pipeline').ExtractionResponse;
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		encoding: 'utf-8',
+		timeout: 180_000,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(`Build failed in ${packageDir}:\n${result.stdout}\n${result.stderr}`);
+	}
+}
+
+function sqlLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function runCli(
+	args: string[],
+	opts?: { configPath?: string; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI_DIST, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: opts?.timeout ?? 120_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			MULDER_CONFIG: opts?.configPath ?? EXAMPLE_CONFIG,
+			MULDER_LOG_LEVEL: 'silent',
+			PGHOST: db.TEST_PG_HOST,
+			PGPORT: String(db.TEST_PG_PORT),
+			PGUSER: db.TEST_PG_USER,
+			PGPASSWORD: db.TEST_PG_PASSWORD,
+			PGDATABASE: db.TEST_PG_DATABASE,
+		},
+	});
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function combinedOutput(result: { stdout: string; stderr: string }): string {
+	return `${result.stdout}\n${result.stderr}`;
+}
+
+function writeMinimalConfigWithoutAccessControl(): string {
+	if (!tempDir) {
+		tempDir = mkdtempSync(join(tmpdir(), 'mulder-spec102-'));
+	}
+	const configPath = join(tempDir, `minimal-${randomUUID()}.yaml`);
+	writeFileSync(
+		configPath,
+		[
+			'project:',
+			'  name: "spec102"',
+			'  description: "Spec 102 minimal config"',
+			'  supported_locales: ["en"]',
+			'gcp:',
+			'  project_id: "test-project"',
+			'  region: "europe-west1"',
+			'  cloud_sql:',
+			'    instance_name: "mulder-db"',
+			'    database: "mulder"',
+			'    tier: "db-custom-2-8192"',
+			'  storage:',
+			'    bucket: "mulder-test"',
+			'  document_ai:',
+			'    processor_id: "processor"',
+			'    location: "eu"',
+			'ontology:',
+			'  entity_types:',
+			'    - name: "person"',
+			'      description: "Person"',
+			'      attributes: []',
+			'    - name: "event"',
+			'      description: "Event"',
+			'      attributes: []',
+			'  relationships:',
+			'    - name: "PARTICIPATED_IN"',
+			'      source: "person"',
+			'      target: "event"',
+			'',
+		].join('\n'),
+		'utf-8',
+	);
+	return configPath;
+}
+
+function cleanTables(): void {
+	truncateExistingTables(['knowledge_assertions', ...MULDER_TEST_TABLES]);
+}
+
+function sensitivityMetadata(
+	level: SensitivityLevel,
+	options?: { reason?: string; assignedBy?: import('@mulder/core').SensitivityAssignmentSource; piiTypes?: PIIType[] },
+) {
+	return coreModule.defaultSensitivityMetadata(level, {
+		reason: options?.reason ?? `${level}_fixture`,
+		assignedBy: options?.assignedBy ?? 'human',
+		assignedAt: '2026-05-05T00:00:00.000Z',
+		piiTypes: options?.piiTypes ?? [],
+		declassifyDate: null,
+	});
+}
+
+async function createSegmentedStory(label = 'spec102') {
+	const source = await coreModule.createSource(pool, {
+		filename: `${label}-${randomUUID()}.md`,
+		storagePath: `raw/${label}-${randomUUID()}.md`,
+		fileHash: `${label}-${randomUUID()}`,
+		sourceType: 'text',
+		formatMetadata: { media_type: 'text/markdown' },
+		pageCount: 1,
+		hasNativeText: true,
+		nativeTextRatio: 1,
+	});
+	await coreModule.updateSourceStatus(pool, source.id, 'segmented');
+	const story = await coreModule.createStory(pool, {
+		sourceId: source.id,
+		title: 'Spec 102 Story',
+		gcsMarkdownUri: `segments/${source.id}/story.md`,
+		gcsMetadataUri: `segments/${source.id}/story.meta.json`,
+		extractionConfidence: 0.93,
+	});
+	const storageRoot = process.env.MULDER_TEST_STORAGE_ROOT
+		? resolve(process.env.MULDER_TEST_STORAGE_ROOT)
+		: resolve(ROOT, '.local/storage');
+	const localMarkdownPath = resolve(storageRoot, story.gcsMarkdownUri);
+	mkdirSync(dirname(localMarkdownPath), { recursive: true });
+	writeFileSync(localMarkdownPath, '# Spec 102 Story\n\nA named person attended a private event.', 'utf-8');
+	await coreModule.updateStoryStatus(pool, story.id, 'segmented');
+	return { source, story };
+}
+
+function confidenceMetadata(): import('@mulder/core').ConfidenceMetadata {
+	return {
+		witnessCount: 1,
+		measurementBased: false,
+		contemporaneous: true,
+		corroborated: false,
+		peerReviewed: false,
+		authorIsInterpreter: false,
+	};
+}
+
+function fakeServices(storyUri: string, response: ExtractionResponse): import('@mulder/core').Services {
+	return {
+		storage: {
+			upload: async () => 'gs://test/spec102',
+			download: async (path: string) => {
+				if (path !== storyUri) {
+					throw new Error(`unexpected storage download: ${path}`);
+				}
+				return Buffer.from('# Spec 102 Story\n\nA named person attended a private event.', 'utf-8');
+			},
+			delete: async () => undefined,
+			exists: async () => true,
+			getUri: (path: string) => `gs://test/${path}`,
+			list: async () => ({ paths: [] }),
+		},
+		firestore: {
+			setDocument: async () => undefined,
+			getDocument: async () => null,
+			updateDocument: async () => undefined,
+			deleteDocument: async () => undefined,
+			queryCollection: async () => [],
+		},
+		documentAi: {
+			processDocument: async () => {
+				throw new Error('documentAi should not be called by Spec 102 enrich tests');
+			},
+		},
+		llm: {
+			countTokens: async () => 32,
+			generateText: async () => {
+				throw new Error('generateText should not be called by Spec 102 enrich tests');
+			},
+			generateGrounded: async () => {
+				throw new Error('generateGrounded should not be called by Spec 102 enrich tests');
+			},
+			generateStructured: async () => response,
+		},
+		embeddings: {
+			embed: async () => {
+				throw new Error('embeddings should not be called by Spec 102 enrich tests');
+			},
+			embedBatch: async () => {
+				throw new Error('embeddings should not be called by Spec 102 enrich tests');
+			},
+		},
+		officeDocuments: {
+			extractDocx: async () => {
+				throw new Error('office extraction should not be called by Spec 102 enrich tests');
+			},
+		},
+		spreadsheets: {
+			extractSpreadsheet: async () => {
+				throw new Error('spreadsheet extraction should not be called by Spec 102 enrich tests');
+			},
+		},
+		emailExtractors: {
+			extractEmail: async () => {
+				throw new Error('email extraction should not be called by Spec 102 enrich tests');
+			},
+		},
+		urlFetchers: {
+			fetchUrl: async () => {
+				throw new Error('url fetch should not be called by Spec 102 enrich tests');
+			},
+		},
+		urlRenderers: {
+			renderUrl: async () => {
+				throw new Error('url render should not be called by Spec 102 enrich tests');
+			},
+		},
+		urlExtractors: {
+			extractUrl: async () => {
+				throw new Error('url extraction should not be called by Spec 102 enrich tests');
+			},
+		},
+	} as unknown as import('@mulder/core').Services;
+}
+
+function enrichConfig(autoDetection: boolean): import('@mulder/core').MulderConfig {
+	return {
+		...config,
+		access_control: {
+			...config.access_control,
+			sensitivity: {
+				...config.access_control.sensitivity,
+				auto_detection: autoDetection,
+				default_level: 'internal',
+				propagation: 'upward',
+			},
+		},
+		enrichment: {
+			...config.enrichment,
+			assertion_classification: {
+				...config.enrichment.assertion_classification,
+				enabled: true,
+			},
+		},
+		entity_resolution: {
+			...config.entity_resolution,
+			strategies: config.entity_resolution.strategies.map((strategy) => ({ ...strategy, enabled: false })),
+		},
+	};
+}
+
+function extractionResponse(levels: {
+	entity: SensitivityLevel;
+	relationship: SensitivityLevel;
+	assertion: SensitivityLevel;
+	entityName?: string;
+	eventName?: string;
+}): ExtractionResponse {
+	const entityName = levels.entityName ?? 'Spec Sensitive Person';
+	const eventName = levels.eventName ?? 'Spec Private Event';
+	return {
+		entities: [
+			{
+				name: entityName,
+				type: 'person',
+				confidence: 0.91,
+				attributes: {},
+				mentions: [entityName],
+				sensitivity: {
+					level: levels.entity,
+					reason: `${levels.entity}_entity`,
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: levels.entity === 'internal' ? [] : ['person_name'],
+					declassify_date: null,
+				},
+			},
+			{
+				name: eventName,
+				type: 'event',
+				confidence: 0.88,
+				attributes: {},
+				mentions: [eventName],
+				sensitivity: {
+					level: 'internal',
+					reason: 'internal_event',
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: [],
+					declassify_date: null,
+				},
+			},
+		],
+		relationships: [
+			{
+				source_entity: entityName,
+				target_entity: eventName,
+				relationship_type: 'PARTICIPATED_IN',
+				confidence: 0.82,
+				attributes: {},
+				sensitivity: {
+					level: levels.relationship,
+					reason: `${levels.relationship}_relationship`,
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: [],
+					declassify_date: null,
+				},
+			},
+		],
+		assertions: [
+			{
+				content: `${entityName} attended ${eventName}.`,
+				assertion_type: 'observation',
+				confidence_metadata: {
+					witness_count: 1,
+					measurement_based: false,
+					contemporaneous: true,
+					corroborated: false,
+					peer_reviewed: false,
+					author_is_interpreter: false,
+				},
+				classification_provenance: 'llm_auto',
+				entity_names: [entityName, eventName],
+				sensitivity: {
+					level: levels.assertion,
+					reason: `${levels.assertion}_assertion`,
+					assigned_by: 'llm_auto',
+					assigned_at: '2026-05-05T00:00:00.000Z',
+					pii_types: levels.assertion === 'internal' ? [] : ['medical_data'],
+					declassify_date: null,
+				},
+			},
+		],
+	};
+}
+
+function extractionResponseWithoutSensitivity(): ExtractionResponse {
+	return {
+		entities: [
+			{
+				name: 'Spec Default Person',
+				type: 'person',
+				confidence: 0.91,
+				attributes: {},
+				mentions: ['Spec Default Person'],
+			},
+		],
+		relationships: [],
+		assertions: [
+			{
+				content: 'A person attended an event.',
+				assertion_type: 'observation',
+				confidence_metadata: {
+					witness_count: 1,
+					measurement_based: false,
+					contemporaneous: true,
+					corroborated: false,
+					peer_reviewed: false,
+					author_is_interpreter: false,
+				},
+				classification_provenance: 'llm_auto',
+				entity_names: ['Spec Default Person'],
+			},
+		],
+	};
+}
+
+beforeAll(async () => {
+	buildPackage(CORE_DIR);
+	buildPackage(PIPELINE_DIR);
+	buildPackage(CLI_DIR);
+
+	coreModule = await import(pathToFileURL(CORE_DIST).href);
+	pipelineModule = await import(pathToFileURL(PIPELINE_DIST).href);
+	config = coreModule.loadConfig(EXAMPLE_CONFIG) as import('@mulder/core').MulderConfig;
+	logger = coreModule.createLogger({ level: 'silent' });
+
+	if (!pgAvailable) return;
+	ensureSchema();
+	pool = new pg.Pool(PG_CONFIG);
+});
+
+beforeEach(() => {
+	if (!pgAvailable) return;
+	cleanTables();
+});
+
+afterAll(async () => {
+	await pool?.end();
+	if (tempDir) {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe('Spec 102: sensitivity tagging and auto-detection', () => {
+	it.skipIf(!pgAvailable)('QA-01: migration adds constrained sensitivity fields', async () => {
+		for (const table of SENSITIVITY_TABLES) {
+			const columns = db.runSql(
+				[
+					"SELECT column_name || ':' || data_type || ':' || is_nullable || ':' || COALESCE(column_default, '')",
+					'FROM information_schema.columns',
+					`WHERE table_schema = 'public' AND table_name = ${sqlLiteral(table)}`,
+					"  AND column_name IN ('sensitivity_level', 'sensitivity_metadata')",
+					'ORDER BY column_name;',
+				].join('\n'),
+			);
+			expect(columns, table).toContain("sensitivity_level:text:NO:'internal'::text");
+			expect(columns, table).toContain('sensitivity_metadata:jsonb:NO:');
+
+			const checks = db.runSql(
+				[
+					"SELECT string_agg(pg_get_constraintdef(oid), E'\\n' ORDER BY conname)",
+					'FROM pg_constraint',
+					`WHERE conrelid = ${sqlLiteral(table)}::regclass AND contype = 'c';`,
+				].join('\n'),
+			);
+			for (const level of EXPECTED_LEVELS) {
+				expect(checks, table).toContain(level);
+			}
+			for (const key of ['level', 'reason', 'assigned_by', 'assigned_at', 'pii_types', 'declassify_date']) {
+				expect(checks, table).toContain(key);
+			}
+			expect(checks, table).toContain('jsonb_typeof');
+		}
+
+		const source = await coreModule.createSource(pool, {
+			filename: `spec102-default-${randomUUID()}.txt`,
+			storagePath: `raw/spec102-default-${randomUUID()}.txt`,
+			fileHash: `spec102-default-${randomUUID()}`,
+			sourceType: 'text',
+			formatMetadata: { media_type: 'text/plain' },
+		});
+		expect(source.sensitivityLevel).toBe('internal');
+		expect(source.sensitivityMetadata).toMatchObject({
+			level: 'internal',
+			reason: 'default_policy',
+			assignedBy: 'policy_rule',
+			piiTypes: [],
+			declassifyDate: null,
+		});
+	});
+
+	it('QA-02: config exposes A5 tagging defaults', () => {
+		const minimalConfig = coreModule.loadConfig(
+			writeMinimalConfigWithoutAccessControl(),
+		) as import('@mulder/core').MulderConfig;
+		expect(minimalConfig.access_control.enabled).toBe(true);
+		expect(minimalConfig.access_control.sensitivity).toEqual({
+			levels: EXPECTED_LEVELS,
+			default_level: 'internal',
+			auto_detection: true,
+			propagation: 'upward',
+			pii_types: EXPECTED_PII_TYPES,
+		});
+	});
+
+	it('QA-03: shared helpers choose the most restrictive level', () => {
+		expect(coreModule.mostRestrictiveSensitivityLevel(['public', 'internal', 'restricted', 'confidential'])).toBe(
+			'confidential',
+		);
+		expect(coreModule.mostRestrictiveSensitivityLevel(['public', 'internal', 'restricted'])).toBe('restricted');
+		expect(coreModule.mostRestrictiveSensitivityLevel(['public', 'internal'])).toBe('internal');
+		expect(coreModule.mostRestrictiveSensitivityLevel(['public'])).toBe('public');
+
+		const merged = coreModule.mergeSensitivityMetadata([
+			sensitivityMetadata('internal', { piiTypes: ['person_name'] }),
+			sensitivityMetadata('restricted', { piiTypes: ['person_name', 'medical_data'] }),
+			sensitivityMetadata('confidential', { piiTypes: ['medical_data', 'financial'] }),
+		]);
+		expect(merged.level).toBe('confidential');
+		expect(merged.piiTypes.sort()).toEqual(['financial', 'medical_data', 'person_name'].sort());
+	});
+
+	it.skipIf(!pgAvailable)('QA-04: repository reads and writes round-trip sensitivity', async () => {
+		const sourceMetadata = sensitivityMetadata('restricted', { piiTypes: ['contact_info'] });
+		const source = await coreModule.createSource(pool, {
+			filename: `spec102-repo-${randomUUID()}.txt`,
+			storagePath: `raw/spec102-repo-${randomUUID()}.txt`,
+			fileHash: `spec102-repo-${randomUUID()}`,
+			sourceType: 'text',
+			formatMetadata: { media_type: 'text/plain' },
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sourceMetadata,
+		});
+		const story = await coreModule.createStory(pool, {
+			sourceId: source.id,
+			title: 'Spec 102 Repository Story',
+			gcsMarkdownUri: `segments/${source.id}/repo.md`,
+			gcsMetadataUri: `segments/${source.id}/repo.meta.json`,
+			sensitivityLevel: 'confidential',
+			sensitivityMetadata: sensitivityMetadata('confidential', { piiTypes: ['medical_data'] }),
+		});
+		const entity = await coreModule.createEntity(pool, {
+			name: 'Repository Person',
+			type: 'person',
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted', { piiTypes: ['person_name'] }),
+		});
+		const alias = await coreModule.createEntityAlias(pool, {
+			entityId: entity.id,
+			alias: 'Repo Alias',
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
+		const storyEntity = await coreModule.linkStoryEntity(pool, {
+			storyId: story.id,
+			entityId: entity.id,
+			confidence: 0.9,
+			mentionCount: 1,
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted', { piiTypes: ['person_name'] }),
+		});
+		const target = await coreModule.createEntity(pool, {
+			name: 'Repository Event',
+			type: 'event',
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
+		const edge = await coreModule.upsertEdge(pool, {
+			sourceEntityId: entity.id,
+			targetEntityId: target.id,
+			relationship: 'PARTICIPATED_IN',
+			storyId: story.id,
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted', { piiTypes: ['location_private'] }),
+		});
+		const chunk = await coreModule.createChunk(pool, {
+			storyId: story.id,
+			content: 'Repository chunk',
+			chunkIndex: 0,
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
+		const assertion = await coreModule.upsertKnowledgeAssertion(pool, {
+			sourceId: source.id,
+			storyId: story.id,
+			assertionType: 'observation',
+			content: 'Repository assertion',
+			confidenceMetadata: confidenceMetadata(),
+			sensitivityLevel: 'confidential',
+			sensitivityMetadata: sensitivityMetadata('confidential', { piiTypes: ['medical_data'] }),
+		});
+
+		const foundSource = await coreModule.findSourceById(pool, source.id);
+		const foundStory = await coreModule.findStoryById(pool, story.id);
+		const foundEntity = await coreModule.findEntityById(pool, entity.id);
+		const [foundAlias] = await coreModule.findAliasesByEntityId(pool, entity.id);
+		const [foundEdge] = await coreModule.findEdgesByStoryId(pool, story.id);
+		const foundChunk = await coreModule.findChunkById(pool, chunk.id);
+		const [foundAssertion] = await coreModule.listKnowledgeAssertionsForStory(pool, story.id);
+
+		expect(foundSource?.sensitivityLevel).toBe('restricted');
+		expect(foundSource?.sensitivityMetadata.piiTypes).toEqual(['contact_info']);
+		expect(foundStory?.sensitivityLevel).toBe('confidential');
+		expect(foundEntity?.sensitivityLevel).toBe('restricted');
+		expect(foundAlias.sensitivityLevel).toBe(alias.sensitivityLevel);
+		expect(storyEntity.sensitivityLevel).toBe('restricted');
+		expect(foundEdge.sensitivityLevel).toBe(edge.sensitivityLevel);
+		expect(foundChunk?.sensitivityLevel).toBe('internal');
+		expect(foundAssertion.id).toBe(assertion.id);
+		expect(foundAssertion.sensitivityLevel).toBe('confidential');
+	});
+
+	it.skipIf(!pgAvailable)('QA-05: Enrich auto-detection writes child artifact sensitivity', async () => {
+		const { story } = await createSegmentedStory('spec102-qa05');
+		const result = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: false },
+			enrichConfig(true),
+			fakeServices(
+				story.gcsMarkdownUri,
+				extractionResponse({ entity: 'restricted', relationship: 'internal', assertion: 'confidential' }),
+			),
+			pool,
+			logger,
+		);
+
+		expect(result.status).toBe('success');
+		expect(
+			db.runSql(
+				['SELECT sensitivity_level', 'FROM entities', "WHERE name = 'Spec Sensitive Person'", 'LIMIT 1;'].join('\n'),
+			),
+		).toBe('restricted');
+		expect(
+			db.runSql(
+				[
+					'SELECT se.sensitivity_level',
+					'FROM story_entities se',
+					'JOIN entities e ON e.id = se.entity_id',
+					`WHERE se.story_id = ${sqlLiteral(story.id)} AND e.name = 'Spec Sensitive Person'`,
+					'LIMIT 1;',
+				].join('\n'),
+			),
+		).toBe('restricted');
+		expect(
+			db.runSql(`SELECT sensitivity_level FROM entity_edges WHERE story_id = ${sqlLiteral(story.id)} LIMIT 1;`),
+		).toBe('internal');
+		expect(
+			db.runSql(`SELECT sensitivity_level FROM knowledge_assertions WHERE story_id = ${sqlLiteral(story.id)} LIMIT 1;`),
+		).toBe('confidential');
+	});
+
+	it.skipIf(!pgAvailable)('QA-06: upward propagation updates story and source', async () => {
+		const { source, story } = await createSegmentedStory('spec102-qa06');
+		const result = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: false },
+			enrichConfig(true),
+			fakeServices(
+				story.gcsMarkdownUri,
+				extractionResponse({ entity: 'restricted', relationship: 'internal', assertion: 'confidential' }),
+			),
+			pool,
+			logger,
+		);
+		expect(result.status).toBe('success');
+
+		const foundStory = await coreModule.findStoryById(pool, story.id);
+		const foundSource = await coreModule.findSourceById(pool, source.id);
+		expect(foundStory?.sensitivityLevel).toBe('confidential');
+		expect(foundSource?.sensitivityLevel).toBe('confidential');
+		expect(foundStory?.sensitivityMetadata.assignedBy).toBe('policy_rule');
+		expect(foundSource?.sensitivityMetadata.assignedBy).toBe('policy_rule');
+	});
+
+	it.skipIf(!pgAvailable)('QA-07: disabled auto-detection preserves existing Enrich compatibility', async () => {
+		const runtime = pipelineModule.getExtractionResponseSchema(config.ontology, {
+			assertionClassificationEnabled: true,
+			sensitivityAutoDetectionEnabled: false,
+		});
+		expect(runtime.safeParse(extractionResponseWithoutSensitivity()).success).toBe(true);
+
+		const { story } = await createSegmentedStory('spec102-qa07');
+		const result = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: false },
+			enrichConfig(false),
+			fakeServices(story.gcsMarkdownUri, extractionResponseWithoutSensitivity()),
+			pool,
+			logger,
+		);
+		expect(result.status).toBe('success');
+		expect(
+			db.runSql(
+				['SELECT sensitivity_level', 'FROM entities', "WHERE name = 'Spec Default Person'", 'LIMIT 1;'].join('\n'),
+			),
+		).toBe('internal');
+		expect(
+			db.runSql(`SELECT sensitivity_level FROM knowledge_assertions WHERE story_id = ${sqlLiteral(story.id)} LIMIT 1;`),
+		).toBe('internal');
+	});
+
+	it.skipIf(!pgAvailable)('QA-08: force reruns do not leave stale higher sensitivity', async () => {
+		const { source, story } = await createSegmentedStory('spec102-qa08');
+		const first = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: false },
+			enrichConfig(true),
+			fakeServices(
+				story.gcsMarkdownUri,
+				extractionResponse({ entity: 'restricted', relationship: 'internal', assertion: 'confidential' }),
+			),
+			pool,
+			logger,
+		);
+		expect(first.status).toBe('success');
+
+		const second = await pipelineModule.executeEnrich(
+			{ storyId: story.id, force: true },
+			enrichConfig(true),
+			fakeServices(
+				story.gcsMarkdownUri,
+				extractionResponse({ entity: 'internal', relationship: 'internal', assertion: 'internal' }),
+			),
+			pool,
+			logger,
+		);
+		expect(second.status).toBe('success');
+
+		const staleActiveArtifacts = Number(
+			db.runSql(
+				[
+					'SELECT COUNT(*)',
+					'FROM (',
+					`  SELECT se.sensitivity_level FROM story_entities se WHERE se.story_id = ${sqlLiteral(story.id)}`,
+					'  UNION ALL',
+					`  SELECT ee.sensitivity_level FROM entity_edges ee WHERE ee.story_id = ${sqlLiteral(story.id)}`,
+					'  UNION ALL',
+					`  SELECT ka.sensitivity_level FROM knowledge_assertions ka WHERE ka.story_id = ${sqlLiteral(story.id)}`,
+					') artifacts',
+					"WHERE sensitivity_level = 'confidential';",
+				].join('\n'),
+			),
+		);
+		expect(staleActiveArtifacts).toBe(0);
+		expect((await coreModule.findStoryById(pool, story.id))?.sensitivityLevel).toBe('internal');
+		expect((await coreModule.findSourceById(pool, source.id))?.sensitivityLevel).toBe('internal');
+	});
+
+	it('CLI-01: mulder config validate accepts minimal config without access_control', () => {
+		const result = runCli(['config', 'validate', writeMinimalConfigWithoutAccessControl()]);
+		expect(result.exitCode, combinedOutput(result)).toBe(0);
+	});
+
+	it('CLI-02: mulder config show includes resolved sensitivity defaults', () => {
+		const result = runCli(['config', 'show', writeMinimalConfigWithoutAccessControl(), '--format', 'json']);
+		expect(result.exitCode, combinedOutput(result)).toBe(0);
+		const shown = JSON.parse(result.stdout) as import('@mulder/core').MulderConfig;
+		expect(shown.access_control.sensitivity).toEqual({
+			levels: EXPECTED_LEVELS,
+			default_level: 'internal',
+			auto_detection: true,
+			propagation: 'upward',
+			pii_types: EXPECTED_PII_TYPES,
+		});
+	});
+
+	it.skipIf(!pgAvailable)('CLI-03: mulder enrich <source-id> writes sensitivity metadata', async () => {
+		const { source } = await createSegmentedStory('spec102-cli03');
+		const result = runCli(['enrich', source.id], { timeout: 120_000 });
+		expect(result.exitCode, combinedOutput(result)).toBe(0);
+		expect(
+			Number(
+				db.runSql(
+					[
+						'SELECT COUNT(*)',
+						'FROM story_entities se',
+						'JOIN stories s ON s.id = se.story_id',
+						`WHERE s.source_id = ${sqlLiteral(source.id)}`,
+						'  AND se.sensitivity_level IS NOT NULL',
+						"  AND se.sensitivity_metadata ? 'level';",
+					].join('\n'),
+				),
+			),
+		).toBeGreaterThanOrEqual(1);
+	});
+
+	it.skipIf(!pgAvailable)('CLI-04: mulder enrich --force <source-id> refreshes propagated sensitivity', async () => {
+		const { source } = await createSegmentedStory('spec102-cli04');
+		const first = runCli(['enrich', source.id], { timeout: 120_000 });
+		expect(first.exitCode, combinedOutput(first)).toBe(0);
+		const second = runCli(['enrich', '--force', source.id], { timeout: 120_000 });
+		expect(second.exitCode, combinedOutput(second)).toBe(0);
+		const sourceSensitivity = db.runSql(
+			`SELECT sensitivity_level FROM sources WHERE id = ${sqlLiteral(source.id)} AND sensitivity_metadata ? 'level';`,
+		);
+		expect(EXPECTED_LEVELS).toContain(sourceSensitivity);
+	});
+});

--- a/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
+++ b/tests/specs/102_sensitivity_tagging_auto_detection.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import pg from 'pg';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
 import { ensureSchema, MULDER_TEST_TABLES, truncateExistingTables } from '../lib/schema.js';
 
@@ -450,7 +450,15 @@ beforeEach(() => {
 	cleanTables();
 });
 
+afterEach(() => {
+	if (!pgAvailable) return;
+	cleanTables();
+});
+
 afterAll(async () => {
+	if (pgAvailable) {
+		cleanTables();
+	}
 	await pool?.end();
 	if (tempDir) {
 		rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Summary
- Add sensitivity-level migration and shared normalization helpers.
- Add access_control.sensitivity defaults and include sensitivity config in Enrich reprocess hashing.
- Thread sensitivity through artifact repositories and Enrich structured output, persistence, and upward propagation.
- Retry fix: correct most-restrictive ranking, make dev Enrich fixtures satisfy sensitivity-required schemas, and preserve Source fixture compatibility while repository reads return populated sensitivity.

Spec: docs/specs/102_sensitivity_tagging_auto_detection.spec.md
Roadmap: M10-K5

Verification
- pnpm exec vitest run tests/specs/102_sensitivity_tagging_auto_detection.test.ts
- pnpm exec vitest run tests/specs/29_enrich_step.test.ts tests/specs/34_embed_step.test.ts tests/specs/34_qa_status_state_machine.test.ts
- pnpm --filter @mulder/tests typecheck
- pnpm turbo run build --filter='...[HEAD]'
- npx biome check .

Closes #271