### PR TITLE
[Eval] Golden quality and assertion suites — M10-K9

### DIFF
--- a/apps/cli/src/lib/eval.ts
+++ b/apps/cli/src/lib/eval.ts
@@ -9,22 +9,28 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import {
+	type AssertionClassificationEvalResult,
 	type EntityEvalResult,
 	EVAL_ERROR_CODES,
 	type ExtractionEvalResult,
 	MulderEvalError,
+	type QualityRoutingEvalResult,
+	runAssertionClassificationEval,
 	runEntityEval,
 	runExtractionEval,
+	runQualityRoutingEval,
 	runSegmentationEval,
 	type SegmentationEvalResult,
 } from '@mulder/eval';
 
-export const VALID_EVAL_STEPS = ['extract', 'segment', 'enrich'] as const;
+export const VALID_EVAL_STEPS = ['extract', 'segment', 'enrich', 'quality', 'assertions'] as const;
 
 const STEP_TO_SUITE = {
 	extract: 'extraction',
 	segment: 'segmentation',
 	enrich: 'entities',
+	quality: 'qualityRouting',
+	assertions: 'assertions',
 } as const;
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
@@ -39,6 +45,8 @@ type EvalResults = Partial<{
 	extraction: ExtractionEvalResult;
 	segmentation: SegmentationEvalResult;
 	entities: EntityEvalResult;
+	qualityRouting: QualityRoutingEvalResult;
+	assertions: AssertionClassificationEvalResult;
 }>;
 
 interface EntityTypeComparisonMetrics {
@@ -81,6 +89,13 @@ type EntityComparison = {
 	};
 };
 
+type FixtureSuiteComparison = {
+	summary: {
+		passRate: EvalMetricComparison;
+		failedCases: EvalMetricComparison;
+	};
+};
+
 export interface EvalCommandOptions {
 	step?: string;
 	compare?: string;
@@ -101,6 +116,8 @@ export interface EvalComparisonResult {
 		extraction: ExtractionComparison;
 		segmentation: SegmentationComparison;
 		entities: EntityComparison;
+		qualityRouting: FixtureSuiteComparison;
+		assertions: FixtureSuiteComparison;
 	}>;
 }
 
@@ -137,7 +154,7 @@ function normalizeStep(step?: string): EvalRunSelection {
 	assertValidStep(step);
 
 	if (step === undefined) {
-		return { step: 'all', suites: ['extraction', 'segmentation', 'entities'] };
+		return { step: 'all', suites: ['extraction', 'segmentation', 'entities', 'qualityRouting', 'assertions'] };
 	}
 
 	return {
@@ -389,6 +406,50 @@ function buildComparison(
 				};
 				break;
 			}
+			case 'qualityRouting': {
+				const current = results.qualityRouting;
+				if (!current) {
+					continue;
+				}
+
+				comparison.suites.qualityRouting = {
+					summary: {
+						passRate: compareMetric(
+							current.summary.passRate,
+							readNumericPath(baselineSuite, ['summary', 'passRate']),
+							true,
+						),
+						failedCases: compareMetric(
+							current.summary.failedCases,
+							readNumericPath(baselineSuite, ['summary', 'failedCases']),
+							false,
+						),
+					},
+				};
+				break;
+			}
+			case 'assertions': {
+				const current = results.assertions;
+				if (!current) {
+					continue;
+				}
+
+				comparison.suites.assertions = {
+					summary: {
+						passRate: compareMetric(
+							current.summary.passRate,
+							readNumericPath(baselineSuite, ['summary', 'passRate']),
+							true,
+						),
+						failedCases: compareMetric(
+							current.summary.failedCases,
+							readNumericPath(baselineSuite, ['summary', 'failedCases']),
+							false,
+						),
+					},
+				};
+				break;
+			}
 		}
 	}
 
@@ -397,6 +458,11 @@ function buildComparison(
 
 function renderComparisonLine(label: string, metric: EvalMetricComparison): string {
 	return `  ${label.padEnd(24)} ${formatPercent(metric.current)} (baseline ${formatPercent(metric.baseline)}, delta ${formatDelta(metric.delta)}) ${metric.status}`;
+}
+
+function renderNumberComparisonLine(label: string, metric: EvalMetricComparison): string {
+	const sign = metric.delta > 0 ? '+' : '';
+	return `  ${label.padEnd(24)} ${metric.current} (baseline ${metric.baseline}, delta ${sign}${metric.delta}) ${metric.status}`;
 }
 
 function renderEntityCurrentRows(
@@ -499,6 +565,26 @@ function renderEntityReport(result: EntityEvalResult, comparison?: EntityCompari
 	return lines;
 }
 
+function renderFixtureSuiteReport(
+	title: string,
+	result: QualityRoutingEvalResult | AssertionClassificationEvalResult,
+	comparison?: FixtureSuiteComparison,
+): string[] {
+	const lines: string[] = [
+		title,
+		`  Cases: ${result.summary.totalCases}`,
+		`  Passed: ${result.summary.passedCases}  Failed: ${result.summary.failedCases}`,
+		`  Pass Rate: ${formatPercent(result.summary.passRate)}`,
+	];
+
+	if (comparison?.summary) {
+		lines.push(renderComparisonLine('Pass Rate', comparison.summary.passRate));
+		lines.push(renderNumberComparisonLine('Failed Cases', comparison.summary.failedCases));
+	}
+
+	return lines;
+}
+
 function updateBaselineSections(baselineRoot: Record<string, unknown>, results: EvalResults): string[] {
 	const updatedSuites: string[] = [];
 	if (results.extraction) {
@@ -512,6 +598,14 @@ function updateBaselineSections(baselineRoot: Record<string, unknown>, results: 
 	if (results.entities) {
 		baselineRoot.entities = results.entities;
 		updatedSuites.push('entities');
+	}
+	if (results.qualityRouting) {
+		baselineRoot.qualityRouting = results.qualityRouting;
+		updatedSuites.push('qualityRouting');
+	}
+	if (results.assertions) {
+		baselineRoot.assertions = results.assertions;
+		updatedSuites.push('assertions');
 	}
 	writeBaselineRoot(baselineRoot);
 	return updatedSuites;
@@ -555,6 +649,18 @@ export function runEvalCommand(options: EvalCommandOptions): EvalCommandResult {
 			case 'entities':
 				results.entities = runEntityEval(resolve(GOLDEN_ROOT, 'entities'), resolve(REPO_ROOT, 'fixtures/entities'));
 				break;
+			case 'qualityRouting':
+				results.qualityRouting = runQualityRoutingEval(
+					resolve(GOLDEN_ROOT, 'quality-routing'),
+					resolve(REPO_ROOT, 'fixtures/quality-routing'),
+				);
+				break;
+			case 'assertions':
+				results.assertions = runAssertionClassificationEval(
+					resolve(GOLDEN_ROOT, 'assertions'),
+					resolve(REPO_ROOT, 'fixtures/assertions'),
+				);
+				break;
 		}
 	}
 
@@ -597,6 +703,26 @@ export function renderEvalCommand(result: EvalCommandResult): string {
 
 	if (result.results.entities) {
 		appendSection(renderEntityReportSection(result.results.entities, result.comparison?.suites.entities));
+	}
+
+	if (result.results.qualityRouting) {
+		appendSection(
+			renderFixtureSuiteReport(
+				'Quality Routing',
+				result.results.qualityRouting,
+				result.comparison?.suites.qualityRouting,
+			),
+		);
+	}
+
+	if (result.results.assertions) {
+		appendSection(
+			renderFixtureSuiteReport(
+				'Assertion Classification',
+				result.results.assertions,
+				result.comparison?.suites.assertions,
+			),
+		);
 	}
 
 	if (result.baselineUpdated) {

--- a/apps/cli/src/lib/eval.ts
+++ b/apps/cli/src/lib/eval.ts
@@ -35,7 +35,9 @@ const STEP_TO_SUITE = {
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
 const GOLDEN_ROOT = resolve(REPO_ROOT, 'eval/golden');
-const BASELINE_PATH = resolve(REPO_ROOT, 'eval/metrics/baseline.json');
+const BASELINE_PATH = process.env.MULDER_EVAL_BASELINE_PATH
+	? resolve(process.env.MULDER_EVAL_BASELINE_PATH)
+	: resolve(REPO_ROOT, 'eval/metrics/baseline.json');
 
 type EvalStep = (typeof VALID_EVAL_STEPS)[number];
 type EvalSuite = (typeof STEP_TO_SUITE)[EvalStep];

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -295,7 +295,7 @@ Must complete before first real archive data ingest. Without these foundations, 
 | 🟢 | K6 | Source rollback — soft-delete + cascading purge | §A6 |
 | 🟢 | K7 | Ingest provenance data model — AcquisitionContext, ArchiveLocation, Archive, CustodyChain | §A2.3 |
 | 🟢 | K8 | Collection management — create, tag, defaults | §A2.3 |
-| ⚪ | K9 | Golden tests — quality routing + assertion classification | §A3, §A4 |
+| 🟡 | K9 | Golden tests — quality routing + assertion classification | §A3, §A4 |
 
 **Also read for all M10 steps:** §A1 (architecture principle), §A2 (storage design)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -295,7 +295,7 @@ Must complete before first real archive data ingest. Without these foundations, 
 | 🟢 | K6 | Source rollback — soft-delete + cascading purge | §A6 |
 | 🟢 | K7 | Ingest provenance data model — AcquisitionContext, ArchiveLocation, Archive, CustodyChain | §A2.3 |
 | 🟢 | K8 | Collection management — create, tag, defaults | §A2.3 |
-| 🟡 | K9 | Golden tests — quality routing + assertion classification | §A3, §A4 |
+| 🟢 | K9 | Golden tests — quality routing + assertion classification | §A3, §A4 |
 
 **Also read for all M10 steps:** §A1 (architecture principle), §A2 (storage design)
 

--- a/docs/specs/106_golden_tests_quality_routing_assertion_classification.spec.md
+++ b/docs/specs/106_golden_tests_quality_routing_assertion_classification.spec.md
@@ -1,0 +1,178 @@
+---
+spec: 106
+title: "Golden Tests For Quality Routing And Assertion Classification"
+roadmap_step: "M10-K9"
+functional_spec: "§A3, §A4, §A1, §A2"
+scope: "phased"
+issue: "https://github.com/mulkatz/mulder/issues/279"
+created: 2026-05-06
+---
+
+# Spec 106: Golden Tests For Quality Routing And Assertion Classification
+
+## 1. Objective
+
+Complete M10-K9 by adding deterministic, fixture-backed golden tests for the two M10 trust surfaces that feed later archive ingest: document quality routing from §A4 and assertion classification from §A3.
+
+K3 made quality a persisted pipeline step and K4 made assertions first-class Enrich output. K9 turns those behaviors into an operational regression suite: future changes to quality rules, prompts, schema generation, or eval tooling must have checked-in goldens that prove routing and epistemic classification still match the contract before real archive batches are ingested.
+
+The suite must stay cost-free and domain-agnostic. It must not call Gemini, Document AI, GCP storage, or PostgreSQL by default. Golden annotations and fixtures are generic examples, not domain policy.
+
+## 2. Boundaries
+
+**Roadmap step:** M10-K9 - Golden tests: quality routing + assertion classification.
+
+**Base branch:** `milestone/10`. This spec is delivered to the M10 integration branch, not directly to `main`.
+
+**Target branch:** `feat/279-golden-tests-quality-assertions`.
+
+**Primary files:**
+
+- `eval/golden/quality-routing/*.json`
+- `eval/golden/assertions/*.json`
+- `fixtures/quality-routing/*.json`
+- `fixtures/assertions/*.json`
+- `eval/golden/README.md`
+- `packages/eval/src/quality-routing-runner.ts`
+- `packages/eval/src/assertion-runner.ts`
+- `packages/eval/src/types.ts`
+- `packages/eval/src/index.ts`
+- `apps/cli/src/lib/eval.ts`
+- `tests/specs/106_golden_tests_quality_routing_assertion_classification.test.ts`
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Add a quality-routing golden set with explicit cases for `high`, `medium`, `low`, and `unusable` quality decisions.
+- Represent expected routing with `overall_quality`, `processable`, `recommended_path`, extraction gate outcome, quality metadata propagation, and the generic signals that justify the decision.
+- Add an assertion-classification golden set with at least one `observation`, `interpretation`, and `hypothesis` case.
+- Represent expected assertion output with content, assertion type, classification provenance, required confidence metadata, optional entity names, and optional source-quality metadata.
+- Add deterministic actual fixtures that can be scored without database writes or live model output.
+- Add public `@mulder/eval` loaders/runners that validate goldens, compare fixtures, and return aggregate pass/coverage metrics.
+- Extend `mulder eval` with fixture-backed suite selection for quality routing and assertion classification.
+- Preserve the existing `mulder eval` behavior for `extract`, `segment`, and `enrich`.
+- Add black-box Vitest coverage for golden validation, fixture matching, CLI selection, baseline comparison compatibility, and no-cloud execution.
+
+**Out of scope:**
+
+- New quality-assessment production rules beyond Spec 100.
+- New assertion-extraction prompt behavior beyond Spec 101.
+- Human review workflows, confidence calibration UX, contradiction handling, credibility scoring, graph schema changes, or agent use of assertions.
+- Live LLM, Document AI, OCR, GCS, or PostgreSQL-backed eval execution.
+- Domain-specific classification labels or domain-specific quality categories.
+- Rewriting historical eval baselines unless the current runner output intentionally adds new top-level suite sections.
+
+## 3. Dependencies
+
+- M10-K3 / Spec 100: document quality assessments, route names, and extract skip behavior exist.
+- M10-K4 / Spec 101: `knowledge_assertions`, assertion labels, confidence metadata, and Enrich assertion persistence exist.
+- M10-K8 / Spec 105: collection/provenance fixtures are available if needed, but K9 must not depend on collection-specific semantics.
+- M8-I1 / Spec 77: `@mulder/eval` and `mulder eval` provide the checked-in fixture eval pattern.
+
+K9 completes the M10 pre-archive quality gate. It does not block another M10 step; it blocks real archive ingest by providing a local regression suite for M10 quality and assertion behavior.
+
+## 4. Blueprint
+
+1. Add golden annotation formats:
+   - `eval/golden/quality-routing/*.json` with one JSON file per deterministic quality case.
+   - `eval/golden/assertions/*.json` with one JSON file per deterministic assertion case.
+   - Update `eval/golden/README.md` with both schemas and rules for adding cases.
+
+2. Add actual fixtures:
+   - `fixtures/quality-routing/*.json` should mirror observable quality-assessment output, not internal function calls.
+   - `fixtures/assertions/*.json` should mirror extracted assertion output plus optional persisted metadata.
+   - Fixtures may intentionally include extra or mismatched fields only when tests assert that the runner reports the mismatch.
+
+3. Add eval package support:
+   - Extend `packages/eval/src/types.ts` with quality-routing and assertion-classification golden/result types.
+   - Add `loadQualityRoutingGoldenSet`, `loadActualQualityRoutingCases`, and `runQualityRoutingEval`.
+   - Add `loadAssertionGoldenSet`, `loadActualAssertionCases`, and `runAssertionClassificationEval`.
+   - Export the new runners and public types from `packages/eval/src/index.ts`.
+   - Runner output must include total cases, passed cases, failed cases, coverage by quality/assertion type, and per-case mismatch details.
+
+4. Extend `mulder eval`:
+   - Add `quality` and `assertions` as valid `--step` values.
+   - Keep `enrich` mapped to the existing entity extraction suite for backward compatibility.
+   - Omitted `--step` should run all fixture-backed suites: extraction, segmentation, entities, quality routing, and assertions.
+   - Baseline comparison/update must preserve unrelated top-level sections and support the new suite keys when they exist in `eval/metrics/baseline.json`.
+   - Human output should add compact quality-routing and assertion-classification sections.
+
+5. Add black-box spec tests:
+   - Validate both golden directories and fixture directories exist and contain the minimum coverage.
+   - Verify runner outputs are deterministic and all checked-in fixture cases pass.
+   - Verify intentionally malformed temp goldens fail validation with eval errors.
+   - Verify `mulder eval --step quality --json` returns only the quality-routing suite.
+   - Verify `mulder eval --step assertions --json` returns only the assertion-classification suite.
+   - Verify `mulder eval --json` includes the two new suites while preserving the existing suites.
+   - Verify the command succeeds with cloud and database environment variables absent.
+
+6. Update roadmap state only after gates:
+   - Keep K9 marked in progress while implementation is open.
+   - Mark K9 complete only after scoped tests, affected checks, review, PR CI, and merge to `milestone/10`.
+
+## 5. QA Contract
+
+1. **QA-01: Quality-routing goldens exist and cover §A4 routes**
+   - Given the repository checkout
+   - When `eval/golden/quality-routing/` is inspected
+   - Then it contains deterministic cases for `high`, `medium`, `low`, and `unusable`, including `standard`, `enhanced_ocr`, `visual_extraction`, and `skip` route expectations.
+
+2. **QA-02: Assertion goldens exist and cover §A3 labels**
+   - Given the repository checkout
+   - When `eval/golden/assertions/` is inspected
+   - Then it contains deterministic cases for `observation`, `interpretation`, and `hypothesis`, and every case has complete confidence metadata.
+
+3. **QA-03: Quality runner validates and scores fixtures**
+   - Given quality-routing goldens and matching fixtures
+   - When the public eval runner is called
+   - Then all checked-in cases pass, coverage includes every expected quality value, and the result exposes per-case route/processability checks.
+
+4. **QA-04: Assertion runner validates and scores fixtures**
+   - Given assertion-classification goldens and matching fixtures
+   - When the public eval runner is called
+   - Then all checked-in cases pass, coverage includes every assertion type, and the result exposes confidence-metadata checks.
+
+5. **QA-05: Runners report mismatches without live services**
+   - Given a temporary actual fixture that changes one expected route or assertion type
+   - When the matching eval runner is called
+   - Then the result is deterministic, marks that case failed, and reports the mismatched field without network or database access.
+
+6. **QA-06: Eval CLI can run quality and assertions suites**
+   - Given a built CLI
+   - When `mulder eval --step quality --json` and `mulder eval --step assertions --json` run
+   - Then each exits 0 and emits only its selected suite.
+
+7. **QA-07: Full eval includes the new suites**
+   - Given a built CLI
+   - When `mulder eval --json` runs
+   - Then results include extraction, segmentation, entities, quality routing, and assertions.
+
+8. **QA-08: Existing eval behavior remains compatible**
+   - Given existing Spec 77 commands
+   - When `mulder eval --step extract|segment|enrich` and `--compare baseline` run
+   - Then existing suite keys and comparison semantics still work.
+
+9. **QA-09: Suite is cost-free**
+   - Given cloud and database environment variables are absent
+   - When both new CLI suites run
+   - Then they succeed without initializing GCP, Gemini, Document AI, GCS, or PostgreSQL clients.
+
+10. **QA-10: K3/K4 regressions stay guarded**
+    - Given the K9 branch
+    - When scoped M10-K3 and M10-K4 tests are run alongside K9 scoped tests
+    - Then existing quality-routing and assertion-classification behavior remains green.
+
+## 5b. CLI Test Matrix
+
+| Command | Fixture | Expected |
+| --- | --- | --- |
+| `mulder eval --step quality --json` | Checked-in quality-routing goldens/fixtures | Exit 0; JSON contains only `results.qualityRouting`. |
+| `mulder eval --step assertions --json` | Checked-in assertion goldens/fixtures | Exit 0; JSON contains only `results.assertions`. |
+| `mulder eval --json` | All checked-in fixture-backed suites | Exit 0; JSON includes extraction, segmentation, entities, qualityRouting, and assertions. |
+| `mulder eval --step quality --compare baseline --json` | Baseline with `qualityRouting` section | Exit 0; comparison covers quality pass rate and failed case count. |
+| `mulder eval --step assertions --compare baseline --json` | Baseline with `assertions` section | Exit 0; comparison covers assertion pass rate and failed case count. |
+| `mulder eval --step bogus` | N/A | Exit non-zero; valid steps include `quality` and `assertions`. |
+
+## 6. Cost Considerations
+
+K9 must be cost-free. It reads checked-in JSON goldens and fixtures only. It must not instantiate production services, open database pools, make network calls, or call paid AI APIs. Baseline comparison and runner metrics must be simple in-memory operations over the small fixture set.

--- a/eval/golden/README.md
+++ b/eval/golden/README.md
@@ -7,10 +7,86 @@ Ground-truth annotations for evaluating pipeline quality. Each JSON file in a su
 - `extraction/` — Ground truth for extraction step (CER/WER metrics)
 - `segmentation/` — Ground truth for segment boundaries (Boundary Accuracy, Segment Count)
 - `entities/` — Ground truth for entity extraction (Precision/Recall/F1 per type)
+- `quality-routing/` — Ground truth for document quality routing and extraction gate behavior
+- `assertions/` — Ground truth for assertion classification labels and confidence metadata
 - `retrieval/` — Ground truth for hybrid retrieval (Precision@k, Recall@k, MRR, nDCG@10)
 - `multi-format/` — Deterministic M9 black-box manifest for source type, route, story, skip, and duplicate contracts
 
 ## Annotation Formats
+
+### Quality Routing (`quality-routing/*.json`)
+
+```json
+{
+  "caseId": "string — stable case identifier",
+  "sourceSlug": "string — matches fixtures/quality-routing/{slug or case}.json",
+  "difficulty": "simple | moderate | complex",
+  "expected": {
+    "overallQuality": "high | medium | low | unusable",
+    "processable": "boolean",
+    "recommendedPath": "standard | enhanced_ocr | visual_extraction | handwriting_recognition | manual_transcription_required | skip",
+    "extractionGateOutcome": "allow | skip",
+    "qualityMetadata": {
+      "source_document_quality": "high | medium | low",
+      "extraction_path": "same value as recommendedPath",
+      "extraction_confidence": "number from 0.0 to 1.0"
+    },
+    "signals": {
+      "signal_name": "generic expected signal value"
+    }
+  },
+  "annotation": {
+    "author": "string",
+    "date": "string — ISO date",
+    "notes": "string (optional)"
+  }
+}
+```
+
+Rules:
+
+1. Cover all quality values (`high`, `medium`, `low`, `unusable`) in the checked-in set.
+2. Keep signals generic and observable; do not encode domain policy or production internals.
+3. Fixtures in `fixtures/quality-routing/` mirror the quality assessment, extraction gate outcome, and propagated metadata.
+4. Mismatches are reported by field path; runners do not call live OCR, LLM, storage, or database services.
+
+### Assertion Classification (`assertions/*.json`)
+
+```json
+{
+  "caseId": "string — stable case identifier",
+  "segmentId": "string — stable segment identifier",
+  "sourceSlug": "string — source document slug for context",
+  "difficulty": "simple | moderate | complex",
+  "expected": {
+    "content": "string — assertion text",
+    "assertionType": "observation | interpretation | hypothesis",
+    "classificationProvenance": "llm_auto | human_reviewed | author_explicit",
+    "confidenceMetadata": {
+      "witness_count": "number or null",
+      "measurement_based": "boolean",
+      "contemporaneous": "boolean",
+      "corroborated": "boolean",
+      "peer_reviewed": "boolean",
+      "author_is_interpreter": "boolean"
+    },
+    "entityNames": ["string (optional)"],
+    "qualityMetadata": "object (optional)"
+  },
+  "annotation": {
+    "author": "string",
+    "date": "string — ISO date",
+    "notes": "string (optional)"
+  }
+}
+```
+
+Rules:
+
+1. Cover all assertion types (`observation`, `interpretation`, `hypothesis`) in the checked-in set.
+2. Every golden case must include complete confidence metadata.
+3. Fixtures in `fixtures/assertions/` mirror extracted assertion output plus optional persisted metadata.
+4. Classification examples must stay domain-agnostic; use generic document, review, or process examples.
 
 ### Multi-Format (`multi-format/manifest.json`)
 

--- a/eval/golden/assertions/hypothesis-testable-pattern.json
+++ b/eval/golden/assertions/hypothesis-testable-pattern.json
@@ -1,0 +1,30 @@
+{
+	"caseId": "assertion-hypothesis-testable-pattern",
+	"segmentId": "assertion-seg-003",
+	"sourceSlug": "analysis-note",
+	"difficulty": "complex",
+	"expected": {
+		"content": "If the proposed review schedule is effective, error rates should decline after the next reporting cycle.",
+		"assertionType": "hypothesis",
+		"classificationProvenance": "author_explicit",
+		"confidenceMetadata": {
+			"witness_count": null,
+			"measurement_based": false,
+			"contemporaneous": false,
+			"corroborated": false,
+			"peer_reviewed": false,
+			"author_is_interpreter": true
+		},
+		"entityNames": ["review schedule", "reporting cycle"],
+		"qualityMetadata": {
+			"source_document_quality": "medium",
+			"extraction_path": "enhanced_ocr",
+			"extraction_confidence": 0.7
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Explicit testable prediction should be classified as a hypothesis."
+	}
+}

--- a/eval/golden/assertions/interpretation-correlation.json
+++ b/eval/golden/assertions/interpretation-correlation.json
@@ -1,0 +1,30 @@
+{
+	"caseId": "assertion-interpretation-correlation",
+	"segmentId": "assertion-seg-002",
+	"sourceSlug": "summary-memo",
+	"difficulty": "moderate",
+	"expected": {
+		"content": "The repeated delays suggest the review process depends on external approval.",
+		"assertionType": "interpretation",
+		"classificationProvenance": "llm_auto",
+		"confidenceMetadata": {
+			"witness_count": null,
+			"measurement_based": false,
+			"contemporaneous": true,
+			"corroborated": false,
+			"peer_reviewed": false,
+			"author_is_interpreter": true
+		},
+		"entityNames": ["review process", "external approval"],
+		"qualityMetadata": {
+			"source_document_quality": "high",
+			"extraction_path": "standard",
+			"extraction_confidence": 0.95
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "A causal reading of observations should not be promoted to observation."
+	}
+}

--- a/eval/golden/assertions/observation-measured-count.json
+++ b/eval/golden/assertions/observation-measured-count.json
@@ -1,0 +1,30 @@
+{
+	"caseId": "assertion-observation-measured-count",
+	"segmentId": "assertion-seg-001",
+	"sourceSlug": "inspection-log",
+	"difficulty": "simple",
+	"expected": {
+		"content": "The inspection log recorded 42 sealed boxes at 09:30 on 2026-04-01.",
+		"assertionType": "observation",
+		"classificationProvenance": "human_reviewed",
+		"confidenceMetadata": {
+			"witness_count": 2,
+			"measurement_based": true,
+			"contemporaneous": true,
+			"corroborated": true,
+			"peer_reviewed": false,
+			"author_is_interpreter": false
+		},
+		"entityNames": ["inspection log", "sealed boxes"],
+		"qualityMetadata": {
+			"source_document_quality": "high",
+			"extraction_path": "standard",
+			"extraction_confidence": 0.95
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Measured contemporary record should be classified as observation."
+	}
+}

--- a/eval/golden/quality-routing/high-standard.json
+++ b/eval/golden/quality-routing/high-standard.json
@@ -1,0 +1,26 @@
+{
+	"caseId": "quality-high-standard",
+	"sourceSlug": "typed-clean-report",
+	"difficulty": "simple",
+	"expected": {
+		"overallQuality": "high",
+		"processable": true,
+		"recommendedPath": "standard",
+		"extractionGateOutcome": "allow",
+		"qualityMetadata": {
+			"source_document_quality": "high",
+			"extraction_path": "standard",
+			"extraction_confidence": 0.95
+		},
+		"signals": {
+			"text_readability": "clear",
+			"image_quality": "clean",
+			"content_completeness": "complete"
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Clean machine text should remain on the standard extraction path."
+	}
+}

--- a/eval/golden/quality-routing/low-visual-extraction.json
+++ b/eval/golden/quality-routing/low-visual-extraction.json
@@ -1,0 +1,26 @@
+{
+	"caseId": "quality-low-visual-extraction",
+	"sourceSlug": "photo-of-table",
+	"difficulty": "complex",
+	"expected": {
+		"overallQuality": "low",
+		"processable": true,
+		"recommendedPath": "visual_extraction",
+		"extractionGateOutcome": "allow",
+		"qualityMetadata": {
+			"source_document_quality": "low",
+			"extraction_path": "visual_extraction",
+			"extraction_confidence": 0.4
+		},
+		"signals": {
+			"text_readability": "visual_only",
+			"image_quality": "skewed",
+			"content_completeness": "partial"
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Low quality but processable visual documents should not be skipped."
+	}
+}

--- a/eval/golden/quality-routing/medium-enhanced-ocr.json
+++ b/eval/golden/quality-routing/medium-enhanced-ocr.json
@@ -1,0 +1,26 @@
+{
+	"caseId": "quality-medium-enhanced-ocr",
+	"sourceSlug": "faded-scan-report",
+	"difficulty": "moderate",
+	"expected": {
+		"overallQuality": "medium",
+		"processable": true,
+		"recommendedPath": "enhanced_ocr",
+		"extractionGateOutcome": "allow",
+		"qualityMetadata": {
+			"source_document_quality": "medium",
+			"extraction_path": "enhanced_ocr",
+			"extraction_confidence": 0.7
+		},
+		"signals": {
+			"text_readability": "partially_degraded",
+			"image_quality": "faded",
+			"content_completeness": "complete"
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Readable degraded scans should route through enhanced OCR."
+	}
+}

--- a/eval/golden/quality-routing/unusable-skip.json
+++ b/eval/golden/quality-routing/unusable-skip.json
@@ -1,0 +1,26 @@
+{
+	"caseId": "quality-unusable-skip",
+	"sourceSlug": "truncated-illegible-page",
+	"difficulty": "complex",
+	"expected": {
+		"overallQuality": "unusable",
+		"processable": false,
+		"recommendedPath": "skip",
+		"extractionGateOutcome": "skip",
+		"qualityMetadata": {
+			"source_document_quality": "low",
+			"extraction_path": "skip",
+			"extraction_confidence": 0
+		},
+		"signals": {
+			"text_readability": "illegible",
+			"image_quality": "severely_degraded",
+			"content_completeness": "truncated"
+		}
+	},
+	"annotation": {
+		"author": "Mulder QA",
+		"date": "2026-05-06",
+		"notes": "Unusable documents should be recorded and skipped before extraction."
+	}
+}

--- a/eval/metrics/baseline.json
+++ b/eval/metrics/baseline.json
@@ -369,5 +369,179 @@
 				}
 			}
 		}
+	},
+	"qualityRouting": {
+		"timestamp": "1970-01-01T00:00:00.000Z",
+		"cases": [
+			{
+				"caseId": "quality-high-standard",
+				"sourceSlug": "typed-clean-report",
+				"difficulty": "simple",
+				"overallQuality": "high",
+				"recommendedPath": "standard",
+				"processable": true,
+				"passed": true,
+				"checks": {
+					"overallQuality": true,
+					"processable": true,
+					"recommendedPath": true,
+					"extractionGateOutcome": true,
+					"qualityMetadata": true,
+					"signals": true
+				},
+				"mismatches": []
+			},
+			{
+				"caseId": "quality-low-visual-extraction",
+				"sourceSlug": "photo-of-table",
+				"difficulty": "complex",
+				"overallQuality": "low",
+				"recommendedPath": "visual_extraction",
+				"processable": true,
+				"passed": true,
+				"checks": {
+					"overallQuality": true,
+					"processable": true,
+					"recommendedPath": true,
+					"extractionGateOutcome": true,
+					"qualityMetadata": true,
+					"signals": true
+				},
+				"mismatches": []
+			},
+			{
+				"caseId": "quality-medium-enhanced-ocr",
+				"sourceSlug": "faded-scan-report",
+				"difficulty": "moderate",
+				"overallQuality": "medium",
+				"recommendedPath": "enhanced_ocr",
+				"processable": true,
+				"passed": true,
+				"checks": {
+					"overallQuality": true,
+					"processable": true,
+					"recommendedPath": true,
+					"extractionGateOutcome": true,
+					"qualityMetadata": true,
+					"signals": true
+				},
+				"mismatches": []
+			},
+			{
+				"caseId": "quality-unusable-skip",
+				"sourceSlug": "truncated-illegible-page",
+				"difficulty": "complex",
+				"overallQuality": "unusable",
+				"recommendedPath": "skip",
+				"processable": false,
+				"passed": true,
+				"checks": {
+					"overallQuality": true,
+					"processable": true,
+					"recommendedPath": true,
+					"extractionGateOutcome": true,
+					"qualityMetadata": true,
+					"signals": true
+				},
+				"mismatches": []
+			}
+		],
+		"summary": {
+			"totalCases": 4,
+			"passedCases": 4,
+			"failedCases": 0,
+			"passRate": 1,
+			"coverage": {
+				"byQuality": {
+					"high": 1,
+					"medium": 1,
+					"low": 1,
+					"unusable": 1
+				},
+				"byRoute": {
+					"standard": 1,
+					"visual_extraction": 1,
+					"enhanced_ocr": 1,
+					"skip": 1
+				}
+			}
+		}
+	},
+	"assertions": {
+		"timestamp": "1970-01-01T00:00:00.000Z",
+		"cases": [
+			{
+				"caseId": "assertion-hypothesis-testable-pattern",
+				"segmentId": "assertion-seg-003",
+				"sourceSlug": "analysis-note",
+				"difficulty": "complex",
+				"assertionType": "hypothesis",
+				"classificationProvenance": "author_explicit",
+				"passed": true,
+				"checks": {
+					"content": true,
+					"assertionType": true,
+					"classificationProvenance": true,
+					"confidenceMetadata": true,
+					"entityNames": true,
+					"qualityMetadata": true
+				},
+				"mismatches": []
+			},
+			{
+				"caseId": "assertion-interpretation-correlation",
+				"segmentId": "assertion-seg-002",
+				"sourceSlug": "summary-memo",
+				"difficulty": "moderate",
+				"assertionType": "interpretation",
+				"classificationProvenance": "llm_auto",
+				"passed": true,
+				"checks": {
+					"content": true,
+					"assertionType": true,
+					"classificationProvenance": true,
+					"confidenceMetadata": true,
+					"entityNames": true,
+					"qualityMetadata": true
+				},
+				"mismatches": []
+			},
+			{
+				"caseId": "assertion-observation-measured-count",
+				"segmentId": "assertion-seg-001",
+				"sourceSlug": "inspection-log",
+				"difficulty": "simple",
+				"assertionType": "observation",
+				"classificationProvenance": "human_reviewed",
+				"passed": true,
+				"checks": {
+					"content": true,
+					"assertionType": true,
+					"classificationProvenance": true,
+					"confidenceMetadata": true,
+					"entityNames": true,
+					"qualityMetadata": true
+				},
+				"mismatches": []
+			}
+		],
+		"summary": {
+			"totalCases": 3,
+			"passedCases": 3,
+			"failedCases": 0,
+			"passRate": 1,
+			"coverage": {
+				"byAssertionType": {
+					"observation": 1,
+					"interpretation": 1,
+					"hypothesis": 1
+				},
+				"byProvenance": {
+					"author_explicit": 1,
+					"llm_auto": 1,
+					"human_reviewed": 1
+				}
+			}
+		}
 	}
 }

--- a/fixtures/assertions/hypothesis-testable-pattern.json
+++ b/fixtures/assertions/hypothesis-testable-pattern.json
@@ -1,0 +1,24 @@
+{
+	"caseId": "assertion-hypothesis-testable-pattern",
+	"segmentId": "assertion-seg-003",
+	"sourceSlug": "analysis-note",
+	"assertion": {
+		"content": "If the proposed review schedule is effective, error rates should decline after the next reporting cycle.",
+		"assertion_type": "hypothesis",
+		"classification_provenance": "author_explicit",
+		"confidence_metadata": {
+			"witness_count": null,
+			"measurement_based": false,
+			"contemporaneous": false,
+			"corroborated": false,
+			"peer_reviewed": false,
+			"author_is_interpreter": true
+		},
+		"entity_names": ["review schedule", "reporting cycle"],
+		"quality_metadata": {
+			"source_document_quality": "medium",
+			"extraction_path": "enhanced_ocr",
+			"extraction_confidence": 0.7
+		}
+	}
+}

--- a/fixtures/assertions/interpretation-correlation.json
+++ b/fixtures/assertions/interpretation-correlation.json
@@ -1,0 +1,24 @@
+{
+	"caseId": "assertion-interpretation-correlation",
+	"segmentId": "assertion-seg-002",
+	"sourceSlug": "summary-memo",
+	"assertion": {
+		"content": "The repeated delays suggest the review process depends on external approval.",
+		"assertion_type": "interpretation",
+		"classification_provenance": "llm_auto",
+		"confidence_metadata": {
+			"witness_count": null,
+			"measurement_based": false,
+			"contemporaneous": true,
+			"corroborated": false,
+			"peer_reviewed": false,
+			"author_is_interpreter": true
+		},
+		"entity_names": ["review process", "external approval"],
+		"quality_metadata": {
+			"source_document_quality": "high",
+			"extraction_path": "standard",
+			"extraction_confidence": 0.95
+		}
+	}
+}

--- a/fixtures/assertions/observation-measured-count.json
+++ b/fixtures/assertions/observation-measured-count.json
@@ -1,0 +1,24 @@
+{
+	"caseId": "assertion-observation-measured-count",
+	"segmentId": "assertion-seg-001",
+	"sourceSlug": "inspection-log",
+	"assertion": {
+		"content": "The inspection log recorded 42 sealed boxes at 09:30 on 2026-04-01.",
+		"assertion_type": "observation",
+		"classification_provenance": "human_reviewed",
+		"confidence_metadata": {
+			"witness_count": 2,
+			"measurement_based": true,
+			"contemporaneous": true,
+			"corroborated": true,
+			"peer_reviewed": false,
+			"author_is_interpreter": false
+		},
+		"entity_names": ["inspection log", "sealed boxes"],
+		"quality_metadata": {
+			"source_document_quality": "high",
+			"extraction_path": "standard",
+			"extraction_confidence": 0.95
+		}
+	}
+}

--- a/fixtures/quality-routing/high-standard.json
+++ b/fixtures/quality-routing/high-standard.json
@@ -1,0 +1,51 @@
+{
+	"caseId": "quality-high-standard",
+	"sourceSlug": "typed-clean-report",
+	"assessment": {
+		"assessmentMethod": "automated",
+		"overallQuality": "high",
+		"processable": true,
+		"recommendedPath": "standard",
+		"dimensions": {
+			"textReadability": {
+				"score": 0.96,
+				"method": "ocr_confidence",
+				"details": "Machine text is clear with stable line order."
+			},
+			"imageQuality": {
+				"score": 0.94,
+				"issues": []
+			},
+			"languageDetection": {
+				"primaryLanguage": "en",
+				"confidence": 0.99,
+				"mixedLanguages": false
+			},
+			"documentStructure": {
+				"type": "printed_text",
+				"hasAnnotations": false,
+				"hasMarginalia": false,
+				"multiColumn": false
+			},
+			"contentCompleteness": {
+				"pagesTotal": 2,
+				"pagesReadable": 2,
+				"missingPagesSuspected": false,
+				"truncated": false
+			}
+		},
+		"signals": {
+			"text_readability": "clear",
+			"image_quality": "clean",
+			"content_completeness": "complete"
+		}
+	},
+	"extractionGate": {
+		"outcome": "allow"
+	},
+	"qualityMetadata": {
+		"source_document_quality": "high",
+		"extraction_path": "standard",
+		"extraction_confidence": 0.95
+	}
+}

--- a/fixtures/quality-routing/low-visual-extraction.json
+++ b/fixtures/quality-routing/low-visual-extraction.json
@@ -1,0 +1,51 @@
+{
+	"caseId": "quality-low-visual-extraction",
+	"sourceSlug": "photo-of-table",
+	"assessment": {
+		"assessmentMethod": "automated",
+		"overallQuality": "low",
+		"processable": true,
+		"recommendedPath": "visual_extraction",
+		"dimensions": {
+			"textReadability": {
+				"score": 0.41,
+				"method": "llm_visual",
+				"details": "Text is hard for OCR but visible in the source image."
+			},
+			"imageQuality": {
+				"score": 0.46,
+				"issues": ["skewed", "shadowed"]
+			},
+			"languageDetection": {
+				"primaryLanguage": "en",
+				"confidence": 0.82,
+				"mixedLanguages": false
+			},
+			"documentStructure": {
+				"type": "table",
+				"hasAnnotations": false,
+				"hasMarginalia": false,
+				"multiColumn": true
+			},
+			"contentCompleteness": {
+				"pagesTotal": 1,
+				"pagesReadable": 1,
+				"missingPagesSuspected": false,
+				"truncated": true
+			}
+		},
+		"signals": {
+			"text_readability": "visual_only",
+			"image_quality": "skewed",
+			"content_completeness": "partial"
+		}
+	},
+	"extractionGate": {
+		"outcome": "allow"
+	},
+	"qualityMetadata": {
+		"source_document_quality": "low",
+		"extraction_path": "visual_extraction",
+		"extraction_confidence": 0.4
+	}
+}

--- a/fixtures/quality-routing/medium-enhanced-ocr.json
+++ b/fixtures/quality-routing/medium-enhanced-ocr.json
@@ -1,0 +1,51 @@
+{
+	"caseId": "quality-medium-enhanced-ocr",
+	"sourceSlug": "faded-scan-report",
+	"assessment": {
+		"assessmentMethod": "automated",
+		"overallQuality": "medium",
+		"processable": true,
+		"recommendedPath": "enhanced_ocr",
+		"dimensions": {
+			"textReadability": {
+				"score": 0.72,
+				"method": "ocr_confidence",
+				"details": "Most text is readable but faded regions lower confidence."
+			},
+			"imageQuality": {
+				"score": 0.68,
+				"issues": ["faded", "low_contrast"]
+			},
+			"languageDetection": {
+				"primaryLanguage": "en",
+				"confidence": 0.94,
+				"mixedLanguages": false
+			},
+			"documentStructure": {
+				"type": "printed_text",
+				"hasAnnotations": true,
+				"hasMarginalia": false,
+				"multiColumn": false
+			},
+			"contentCompleteness": {
+				"pagesTotal": 3,
+				"pagesReadable": 3,
+				"missingPagesSuspected": false,
+				"truncated": false
+			}
+		},
+		"signals": {
+			"text_readability": "partially_degraded",
+			"image_quality": "faded",
+			"content_completeness": "complete"
+		}
+	},
+	"extractionGate": {
+		"outcome": "allow"
+	},
+	"qualityMetadata": {
+		"source_document_quality": "medium",
+		"extraction_path": "enhanced_ocr",
+		"extraction_confidence": 0.7
+	}
+}

--- a/fixtures/quality-routing/unusable-skip.json
+++ b/fixtures/quality-routing/unusable-skip.json
@@ -1,0 +1,51 @@
+{
+	"caseId": "quality-unusable-skip",
+	"sourceSlug": "truncated-illegible-page",
+	"assessment": {
+		"assessmentMethod": "automated",
+		"overallQuality": "unusable",
+		"processable": false,
+		"recommendedPath": "skip",
+		"dimensions": {
+			"textReadability": {
+				"score": 0.03,
+				"method": "llm_visual",
+				"details": "Text cannot be read reliably."
+			},
+			"imageQuality": {
+				"score": 0.08,
+				"issues": ["blurred", "low_contrast", "cropped"]
+			},
+			"languageDetection": {
+				"primaryLanguage": "und",
+				"confidence": 0.1,
+				"mixedLanguages": false
+			},
+			"documentStructure": {
+				"type": "photo_of_document",
+				"hasAnnotations": false,
+				"hasMarginalia": false,
+				"multiColumn": false
+			},
+			"contentCompleteness": {
+				"pagesTotal": 1,
+				"pagesReadable": 0,
+				"missingPagesSuspected": true,
+				"truncated": true
+			}
+		},
+		"signals": {
+			"text_readability": "illegible",
+			"image_quality": "severely_degraded",
+			"content_completeness": "truncated"
+		}
+	},
+	"extractionGate": {
+		"outcome": "skip"
+	},
+	"qualityMetadata": {
+		"source_document_quality": "low",
+		"extraction_path": "skip",
+		"extraction_confidence": 0
+	}
+}

--- a/packages/eval/src/assertion-runner.ts
+++ b/packages/eval/src/assertion-runner.ts
@@ -1,0 +1,395 @@
+/**
+ * Assertion-classification eval runner: validates golden assertion annotations,
+ * compares fixture-backed extracted assertions, and reports deterministic pass
+ * and coverage metrics without live LLM, database, or storage access.
+ *
+ * @see docs/specs/106_golden_tests_quality_routing_assertion_classification.spec.md
+ * @see docs/functional-spec-addendum.md §A3
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EVAL_ERROR_CODES, MulderEvalError } from './errors.js';
+import type {
+	ActualAssertionCase,
+	AssertionClassificationCaseResult,
+	AssertionClassificationEvalResult,
+	AssertionClassificationGolden,
+	AssertionConfidenceMetadata,
+	AssertionType,
+	ClassificationProvenance,
+	EvalMismatch,
+} from './types.js';
+
+const DETERMINISTIC_TIMESTAMP = '1970-01-01T00:00:00.000Z';
+const DIFFICULTIES = ['simple', 'moderate', 'complex'] as const;
+const ASSERTION_TYPES = ['observation', 'interpretation', 'hypothesis'] as const;
+const CLASSIFICATION_PROVENANCES = ['llm_auto', 'human_reviewed', 'author_explicit'] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const T extends readonly string[]>(value: unknown, allowed: T): value is T[number] {
+	return typeof value === 'string' && allowed.includes(value);
+}
+
+function assertPlainObject(value: unknown, filePath: string, field: string): Record<string, unknown> {
+	if (!isPlainObject(value)) {
+		throw new MulderEvalError(
+			`Assertion file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertString(value: unknown, filePath: string, field: string): string {
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new MulderEvalError(
+			`Assertion file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertBoolean(value: unknown, filePath: string, field: string): boolean {
+	if (typeof value !== 'boolean') {
+		throw new MulderEvalError(
+			`Assertion file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertStringArray(value: unknown, filePath: string, field: string): string[] {
+	if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+		throw new MulderEvalError(
+			`Assertion file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return [...value].sort((left, right) => left.localeCompare(right));
+}
+
+function validateConfidenceMetadata(value: unknown, filePath: string): AssertionConfidenceMetadata {
+	const metadata = assertPlainObject(value, filePath, 'confidenceMetadata');
+	const witnessCount = metadata.witness_count;
+	if (witnessCount !== null && (typeof witnessCount !== 'number' || Number.isNaN(witnessCount))) {
+		throw new MulderEvalError(
+			`Assertion file has invalid confidenceMetadata.witness_count: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: witnessCount } },
+		);
+	}
+
+	return {
+		witness_count: witnessCount,
+		measurement_based: assertBoolean(metadata.measurement_based, filePath, 'confidenceMetadata.measurement_based'),
+		contemporaneous: assertBoolean(metadata.contemporaneous, filePath, 'confidenceMetadata.contemporaneous'),
+		corroborated: assertBoolean(metadata.corroborated, filePath, 'confidenceMetadata.corroborated'),
+		peer_reviewed: assertBoolean(metadata.peer_reviewed, filePath, 'confidenceMetadata.peer_reviewed'),
+		author_is_interpreter: assertBoolean(
+			metadata.author_is_interpreter,
+			filePath,
+			'confidenceMetadata.author_is_interpreter',
+		),
+	};
+}
+
+function validateExpectedAssertion(value: unknown, filePath: string): AssertionClassificationGolden['expected'] {
+	const expected = assertPlainObject(value, filePath, 'expected');
+	const assertionType = expected.assertionType;
+	const classificationProvenance = expected.classificationProvenance;
+
+	if (!isOneOf(assertionType, ASSERTION_TYPES)) {
+		throw new MulderEvalError(
+			`Assertion golden has invalid expected.assertionType: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: assertionType } },
+		);
+	}
+
+	if (!isOneOf(classificationProvenance, CLASSIFICATION_PROVENANCES)) {
+		throw new MulderEvalError(
+			`Assertion golden has invalid expected.classificationProvenance: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: classificationProvenance } },
+		);
+	}
+
+	return {
+		content: assertString(expected.content, filePath, 'expected.content'),
+		assertionType,
+		classificationProvenance,
+		confidenceMetadata: validateConfidenceMetadata(expected.confidenceMetadata, filePath),
+		...(expected.entityNames === undefined
+			? {}
+			: { entityNames: assertStringArray(expected.entityNames, filePath, 'expected.entityNames') }),
+		...(expected.qualityMetadata === undefined
+			? {}
+			: { qualityMetadata: assertPlainObject(expected.qualityMetadata, filePath, 'expected.qualityMetadata') }),
+	};
+}
+
+function validateAnnotation(value: unknown, filePath: string): AssertionClassificationGolden['annotation'] {
+	const annotation = assertPlainObject(value, filePath, 'annotation');
+	return {
+		author: assertString(annotation.author, filePath, 'annotation.author'),
+		date: assertString(annotation.date, filePath, 'annotation.date'),
+		...(typeof annotation.notes === 'string' ? { notes: annotation.notes } : {}),
+	};
+}
+
+function validateAssertionGolden(data: unknown, filePath: string): AssertionClassificationGolden {
+	const obj = assertPlainObject(data, filePath, 'root');
+	const difficulty = obj.difficulty;
+	if (!isOneOf(difficulty, DIFFICULTIES)) {
+		throw new MulderEvalError(
+			`Assertion golden missing or invalid 'difficulty': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: difficulty } },
+		);
+	}
+
+	return {
+		caseId: assertString(obj.caseId, filePath, 'caseId'),
+		segmentId: assertString(obj.segmentId, filePath, 'segmentId'),
+		sourceSlug: assertString(obj.sourceSlug, filePath, 'sourceSlug'),
+		difficulty,
+		expected: validateExpectedAssertion(obj.expected, filePath),
+		annotation: validateAnnotation(obj.annotation, filePath),
+	};
+}
+
+function parseJsonFile(filePath: string, label: string): unknown {
+	try {
+		return JSON.parse(readFileSync(filePath, 'utf-8'));
+	} catch (cause) {
+		throw new MulderEvalError(`Failed to parse ${label} JSON: ${filePath}`, EVAL_ERROR_CODES.GOLDEN_INVALID, {
+			context: { filePath },
+			cause,
+		});
+	}
+}
+
+function listJsonFiles(dir: string, label: string): string[] {
+	if (!existsSync(dir)) {
+		throw new MulderEvalError(`${label} directory does not exist: ${dir}`, EVAL_ERROR_CODES.GOLDEN_DIR_EMPTY, {
+			context: { dir },
+		});
+	}
+
+	const files = readdirSync(dir).filter((file) => file.endsWith('.json'));
+	if (files.length === 0) {
+		throw new MulderEvalError(`${label} directory contains no JSON files: ${dir}`, EVAL_ERROR_CODES.GOLDEN_DIR_EMPTY, {
+			context: { dir },
+		});
+	}
+
+	return files.sort((left, right) => left.localeCompare(right));
+}
+
+export function loadAssertionGoldenSet(goldenDir: string): AssertionClassificationGolden[] {
+	return listJsonFiles(goldenDir, 'Assertion golden')
+		.map((file) => {
+			const filePath = join(goldenDir, file);
+			return validateAssertionGolden(parseJsonFile(filePath, 'assertion golden'), filePath);
+		})
+		.sort((left, right) => left.caseId.localeCompare(right.caseId));
+}
+
+function validateActualAssertionCase(data: unknown, filePath: string): ActualAssertionCase {
+	const obj = assertPlainObject(data, filePath, 'root');
+	const assertion = assertPlainObject(obj.assertion, filePath, 'assertion');
+	const assertionType = assertion.assertion_type;
+	const classificationProvenance = assertion.classification_provenance;
+
+	if (!isOneOf(assertionType, ASSERTION_TYPES)) {
+		throw new MulderEvalError(
+			`Assertion fixture has invalid assertion.assertion_type: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: assertionType } },
+		);
+	}
+
+	if (!isOneOf(classificationProvenance, CLASSIFICATION_PROVENANCES)) {
+		throw new MulderEvalError(
+			`Assertion fixture has invalid assertion.classification_provenance: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: classificationProvenance } },
+		);
+	}
+
+	return {
+		caseId: assertString(obj.caseId, filePath, 'caseId'),
+		segmentId: assertString(obj.segmentId, filePath, 'segmentId'),
+		sourceSlug: assertString(obj.sourceSlug, filePath, 'sourceSlug'),
+		assertion: {
+			content: assertString(assertion.content, filePath, 'assertion.content'),
+			assertion_type: assertionType,
+			classification_provenance: classificationProvenance,
+			confidence_metadata: validateConfidenceMetadata(assertion.confidence_metadata, filePath),
+			...(assertion.entity_names === undefined
+				? {}
+				: { entity_names: assertStringArray(assertion.entity_names, filePath, 'assertion.entity_names') }),
+			...(assertion.quality_metadata === undefined
+				? {}
+				: { quality_metadata: assertPlainObject(assertion.quality_metadata, filePath, 'assertion.quality_metadata') }),
+		},
+	};
+}
+
+export function loadActualAssertionCases(fixturesDir: string): ActualAssertionCase[] {
+	return listJsonFiles(fixturesDir, 'Assertion fixture')
+		.map((file) => {
+			const filePath = join(fixturesDir, file);
+			return validateActualAssertionCase(parseJsonFile(filePath, 'assertion fixture'), filePath);
+		})
+		.sort((left, right) => left.caseId.localeCompare(right.caseId));
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) {
+		return true;
+	}
+
+	if (Array.isArray(left) || Array.isArray(right)) {
+		if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+			return false;
+		}
+
+		return left.every((value, index) => valuesEqual(value, right[index]));
+	}
+
+	if (!isPlainObject(left) || !isPlainObject(right)) {
+		return false;
+	}
+
+	const leftKeys = Object.keys(left).sort((a, b) => a.localeCompare(b));
+	const rightKeys = Object.keys(right).sort((a, b) => a.localeCompare(b));
+	return valuesEqual(leftKeys, rightKeys) && leftKeys.every((key) => valuesEqual(left[key], right[key]));
+}
+
+function addMismatch(mismatches: EvalMismatch[], field: string, expected: unknown, actual: unknown): boolean {
+	const matches = valuesEqual(expected, actual);
+	if (!matches) {
+		mismatches.push({ field, expected, actual });
+	}
+
+	return matches;
+}
+
+function scoreAssertionCase(
+	golden: AssertionClassificationGolden,
+	actual: ActualAssertionCase,
+): AssertionClassificationCaseResult {
+	const mismatches: EvalMismatch[] = [];
+	const expected = golden.expected;
+	const assertion = actual.assertion;
+	const checks = {
+		content: addMismatch(mismatches, 'content', expected.content, assertion.content),
+		assertionType: addMismatch(mismatches, 'assertionType', expected.assertionType, assertion.assertion_type),
+		classificationProvenance: addMismatch(
+			mismatches,
+			'classificationProvenance',
+			expected.classificationProvenance,
+			assertion.classification_provenance,
+		),
+		confidenceMetadata: addMismatch(
+			mismatches,
+			'confidenceMetadata',
+			expected.confidenceMetadata,
+			assertion.confidence_metadata,
+		),
+		entityNames: addMismatch(mismatches, 'entityNames', expected.entityNames ?? [], assertion.entity_names ?? []),
+		qualityMetadata: addMismatch(
+			mismatches,
+			'qualityMetadata',
+			expected.qualityMetadata ?? {},
+			assertion.quality_metadata ?? {},
+		),
+	};
+
+	return {
+		caseId: golden.caseId,
+		segmentId: golden.segmentId,
+		sourceSlug: golden.sourceSlug,
+		difficulty: golden.difficulty,
+		assertionType: assertion.assertion_type,
+		classificationProvenance: assertion.classification_provenance,
+		passed: mismatches.length === 0,
+		checks,
+		mismatches,
+	};
+}
+
+function emptyAssertionCoverage(): Record<AssertionType, number> {
+	return {
+		observation: 0,
+		interpretation: 0,
+		hypothesis: 0,
+	};
+}
+
+export function runAssertionClassificationEval(
+	goldenDir: string,
+	fixturesDir: string,
+): AssertionClassificationEvalResult {
+	const goldens = loadAssertionGoldenSet(goldenDir);
+	const actualCases = loadActualAssertionCases(fixturesDir);
+	const actualByCaseId = new Map(actualCases.map((actual) => [actual.caseId, actual]));
+	const cases: AssertionClassificationCaseResult[] = [];
+
+	for (const golden of goldens) {
+		const actual = actualByCaseId.get(golden.caseId);
+		if (!actual) {
+			throw new MulderEvalError(
+				`Assertion fixture not found for case: ${golden.caseId}`,
+				EVAL_ERROR_CODES.FIXTURE_NOT_FOUND,
+				{
+					context: { caseId: golden.caseId, fixturesDir },
+				},
+			);
+		}
+
+		cases.push(scoreAssertionCase(golden, actual));
+	}
+
+	const byAssertionType = emptyAssertionCoverage();
+	const byProvenance: Partial<Record<ClassificationProvenance, number>> = {};
+	for (const golden of goldens) {
+		byAssertionType[golden.expected.assertionType] += 1;
+		byProvenance[golden.expected.classificationProvenance] =
+			(byProvenance[golden.expected.classificationProvenance] ?? 0) + 1;
+	}
+
+	const totalCases = cases.length;
+	const passedCases = cases.filter((result) => result.passed).length;
+	const failedCases = totalCases - passedCases;
+
+	return {
+		timestamp: DETERMINISTIC_TIMESTAMP,
+		cases,
+		summary: {
+			totalCases,
+			passedCases,
+			failedCases,
+			passRate: totalCases > 0 ? passedCases / totalCases : 0,
+			coverage: {
+				byAssertionType,
+				byProvenance,
+			},
+		},
+	};
+}

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,3 +1,8 @@
+export {
+	loadActualAssertionCases,
+	loadAssertionGoldenSet,
+	runAssertionClassificationEval,
+} from './assertion-runner.js';
 export type { PerTypeMetrics } from './entity-metrics.js';
 export { computeEntityPrecisionRecallF1, normalizeEntityName } from './entity-metrics.js';
 export { loadActualEntities, loadEntityGoldenSet, runEntityEval } from './entity-runner.js';
@@ -10,6 +15,11 @@ export {
 	levenshteinDistance,
 	normalizeWhitespace,
 } from './extraction-metrics.js';
+export {
+	loadActualQualityRoutingCases,
+	loadQualityRoutingGoldenSet,
+	runQualityRoutingEval,
+} from './quality-routing-runner.js';
 export { computeRelationshipPrecisionRecallF1 } from './relationship-metrics.js';
 export {
 	computeMRR,
@@ -28,22 +38,38 @@ export {
 export { computeBoundaryAccuracy, loadActualSegments } from './segmentation-metrics.js';
 export { loadSegmentationGoldenSet, runSegmentationEval } from './segmentation-runner.js';
 export type {
+	ActualAssertionCase,
+	ActualQualityRoutingCase,
 	ActualRetrievalHit,
 	ActualRetrievalRun,
 	ActualSegment,
+	AssertionClassificationCaseResult,
+	AssertionClassificationEvalResult,
+	AssertionClassificationGolden,
+	AssertionConfidenceMetadata,
+	AssertionType,
+	ClassificationProvenance,
 	DifficultyLevel,
 	DifficultyStats,
+	DocumentOverallQuality,
 	EntityEvalResult,
 	EntityGolden,
 	EntityMetricResult,
+	EvalMismatch,
 	ExpectedEntity,
+	ExpectedQualityMetadata,
 	ExpectedRelationship,
 	ExpectedRetrievalHit,
 	ExpectedSegment,
 	ExtractionEvalResult,
+	ExtractionGateOutcome,
 	ExtractionGolden,
 	ExtractionMetricResult,
+	ExtractionPath,
 	PRF1,
+	QualityRoutingCaseResult,
+	QualityRoutingEvalResult,
+	QualityRoutingGolden,
 	RetrievalEvalResult,
 	RetrievalGolden,
 	RetrievalMetricAtK,

--- a/packages/eval/src/quality-routing-runner.ts
+++ b/packages/eval/src/quality-routing-runner.ts
@@ -1,0 +1,416 @@
+/**
+ * Quality-routing eval runner: validates golden routing annotations, compares
+ * them against fixture-backed quality assessment output, and reports pass and
+ * coverage metrics without touching live services.
+ *
+ * @see docs/specs/106_golden_tests_quality_routing_assertion_classification.spec.md
+ * @see docs/functional-spec-addendum.md §A4
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EVAL_ERROR_CODES, MulderEvalError } from './errors.js';
+import type {
+	ActualQualityRoutingCase,
+	DocumentOverallQuality,
+	EvalMismatch,
+	ExtractionPath,
+	QualityRoutingCaseResult,
+	QualityRoutingEvalResult,
+	QualityRoutingGolden,
+} from './types.js';
+
+const DETERMINISTIC_TIMESTAMP = '1970-01-01T00:00:00.000Z';
+const DIFFICULTIES = ['simple', 'moderate', 'complex'] as const;
+const OVERALL_QUALITIES = ['high', 'medium', 'low', 'unusable'] as const;
+const EXTRACTION_PATHS = [
+	'standard',
+	'enhanced_ocr',
+	'visual_extraction',
+	'handwriting_recognition',
+	'manual_transcription_required',
+	'skip',
+] as const;
+const GATE_OUTCOMES = ['allow', 'skip'] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const T extends readonly string[]>(value: unknown, allowed: T): value is T[number] {
+	return typeof value === 'string' && allowed.includes(value);
+}
+
+function assertPlainObject(value: unknown, filePath: string, field: string): Record<string, unknown> {
+	if (!isPlainObject(value)) {
+		throw new MulderEvalError(
+			`Quality routing file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertString(value: unknown, filePath: string, field: string): string {
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new MulderEvalError(
+			`Quality routing file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertBoolean(value: unknown, filePath: string, field: string): boolean {
+	if (typeof value !== 'boolean') {
+		throw new MulderEvalError(
+			`Quality routing file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function assertNumber(value: unknown, filePath: string, field: string): number {
+	if (typeof value !== 'number' || Number.isNaN(value)) {
+		throw new MulderEvalError(
+			`Quality routing file missing or invalid '${field}': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, field } },
+		);
+	}
+
+	return value;
+}
+
+function validateQualityMetadata(
+	value: unknown,
+	filePath: string,
+): QualityRoutingGolden['expected']['qualityMetadata'] {
+	const metadata = assertPlainObject(value, filePath, 'qualityMetadata');
+	const sourceQuality = metadata.source_document_quality;
+	if (!isOneOf(sourceQuality, ['high', 'medium', 'low'] as const)) {
+		throw new MulderEvalError(
+			`Quality routing file has invalid qualityMetadata.source_document_quality: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: sourceQuality } },
+		);
+	}
+
+	const extractionPath = metadata.extraction_path;
+	if (!isOneOf(extractionPath, EXTRACTION_PATHS)) {
+		throw new MulderEvalError(
+			`Quality routing file has invalid qualityMetadata.extraction_path: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: extractionPath } },
+		);
+	}
+
+	return {
+		source_document_quality: sourceQuality,
+		extraction_path: extractionPath,
+		extraction_confidence: assertNumber(
+			metadata.extraction_confidence,
+			filePath,
+			'qualityMetadata.extraction_confidence',
+		),
+	};
+}
+
+function validateExpectedQuality(value: unknown, filePath: string): QualityRoutingGolden['expected'] {
+	const expected = assertPlainObject(value, filePath, 'expected');
+	const overallQuality = expected.overallQuality;
+	if (!isOneOf(overallQuality, OVERALL_QUALITIES)) {
+		throw new MulderEvalError(
+			`Quality routing file has invalid expected.overallQuality: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: overallQuality } },
+		);
+	}
+
+	const recommendedPath = expected.recommendedPath;
+	if (!isOneOf(recommendedPath, EXTRACTION_PATHS)) {
+		throw new MulderEvalError(
+			`Quality routing file has invalid expected.recommendedPath: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: recommendedPath } },
+		);
+	}
+
+	const extractionGateOutcome = expected.extractionGateOutcome;
+	if (!isOneOf(extractionGateOutcome, GATE_OUTCOMES)) {
+		throw new MulderEvalError(
+			`Quality routing file has invalid expected.extractionGateOutcome: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: extractionGateOutcome } },
+		);
+	}
+
+	return {
+		overallQuality,
+		processable: assertBoolean(expected.processable, filePath, 'expected.processable'),
+		recommendedPath,
+		extractionGateOutcome,
+		qualityMetadata: validateQualityMetadata(expected.qualityMetadata, filePath),
+		signals: assertPlainObject(expected.signals, filePath, 'expected.signals'),
+	};
+}
+
+function validateAnnotation(value: unknown, filePath: string): QualityRoutingGolden['annotation'] {
+	const annotation = assertPlainObject(value, filePath, 'annotation');
+	return {
+		author: assertString(annotation.author, filePath, 'annotation.author'),
+		date: assertString(annotation.date, filePath, 'annotation.date'),
+		...(typeof annotation.notes === 'string' ? { notes: annotation.notes } : {}),
+	};
+}
+
+function validateQualityRoutingGolden(data: unknown, filePath: string): QualityRoutingGolden {
+	const obj = assertPlainObject(data, filePath, 'root');
+	const difficulty = obj.difficulty;
+	if (!isOneOf(difficulty, DIFFICULTIES)) {
+		throw new MulderEvalError(
+			`Quality routing file missing or invalid 'difficulty': ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: difficulty } },
+		);
+	}
+
+	return {
+		caseId: assertString(obj.caseId, filePath, 'caseId'),
+		sourceSlug: assertString(obj.sourceSlug, filePath, 'sourceSlug'),
+		difficulty,
+		expected: validateExpectedQuality(obj.expected, filePath),
+		annotation: validateAnnotation(obj.annotation, filePath),
+	};
+}
+
+function parseJsonFile(filePath: string, label: string): unknown {
+	try {
+		return JSON.parse(readFileSync(filePath, 'utf-8'));
+	} catch (cause) {
+		throw new MulderEvalError(`Failed to parse ${label} JSON: ${filePath}`, EVAL_ERROR_CODES.GOLDEN_INVALID, {
+			context: { filePath },
+			cause,
+		});
+	}
+}
+
+function listJsonFiles(dir: string, label: string): string[] {
+	if (!existsSync(dir)) {
+		throw new MulderEvalError(`${label} directory does not exist: ${dir}`, EVAL_ERROR_CODES.GOLDEN_DIR_EMPTY, {
+			context: { dir },
+		});
+	}
+
+	const files = readdirSync(dir).filter((file) => file.endsWith('.json'));
+	if (files.length === 0) {
+		throw new MulderEvalError(`${label} directory contains no JSON files: ${dir}`, EVAL_ERROR_CODES.GOLDEN_DIR_EMPTY, {
+			context: { dir },
+		});
+	}
+
+	return files.sort((left, right) => left.localeCompare(right));
+}
+
+export function loadQualityRoutingGoldenSet(goldenDir: string): QualityRoutingGolden[] {
+	return listJsonFiles(goldenDir, 'Quality routing golden')
+		.map((file) => {
+			const filePath = join(goldenDir, file);
+			return validateQualityRoutingGolden(parseJsonFile(filePath, 'quality routing golden'), filePath);
+		})
+		.sort((left, right) => left.caseId.localeCompare(right.caseId));
+}
+
+function validateActualQualityCase(data: unknown, filePath: string): ActualQualityRoutingCase {
+	const obj = assertPlainObject(data, filePath, 'root');
+	const assessment = assertPlainObject(obj.assessment, filePath, 'assessment');
+	const extractionGate = assertPlainObject(obj.extractionGate, filePath, 'extractionGate');
+	const overallQuality = assessment.overallQuality;
+	const recommendedPath = assessment.recommendedPath;
+	const outcome = extractionGate.outcome;
+
+	if (!isOneOf(overallQuality, OVERALL_QUALITIES)) {
+		throw new MulderEvalError(
+			`Quality routing fixture has invalid assessment.overallQuality: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: overallQuality } },
+		);
+	}
+
+	if (!isOneOf(recommendedPath, EXTRACTION_PATHS)) {
+		throw new MulderEvalError(
+			`Quality routing fixture has invalid assessment.recommendedPath: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: recommendedPath } },
+		);
+	}
+
+	if (!isOneOf(outcome, GATE_OUTCOMES)) {
+		throw new MulderEvalError(
+			`Quality routing fixture has invalid extractionGate.outcome: ${filePath}`,
+			EVAL_ERROR_CODES.GOLDEN_INVALID,
+			{ context: { filePath, value: outcome } },
+		);
+	}
+
+	return {
+		caseId: assertString(obj.caseId, filePath, 'caseId'),
+		sourceSlug: assertString(obj.sourceSlug, filePath, 'sourceSlug'),
+		assessment: {
+			overallQuality,
+			processable: assertBoolean(assessment.processable, filePath, 'assessment.processable'),
+			recommendedPath,
+			signals: assertPlainObject(assessment.signals, filePath, 'assessment.signals'),
+		},
+		extractionGate: { outcome },
+		qualityMetadata: validateQualityMetadata(obj.qualityMetadata, filePath),
+	};
+}
+
+export function loadActualQualityRoutingCases(fixturesDir: string): ActualQualityRoutingCase[] {
+	return listJsonFiles(fixturesDir, 'Quality routing fixture')
+		.map((file) => {
+			const filePath = join(fixturesDir, file);
+			return validateActualQualityCase(parseJsonFile(filePath, 'quality routing fixture'), filePath);
+		})
+		.sort((left, right) => left.caseId.localeCompare(right.caseId));
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) {
+		return true;
+	}
+
+	if (Array.isArray(left) || Array.isArray(right)) {
+		if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+			return false;
+		}
+
+		return left.every((value, index) => valuesEqual(value, right[index]));
+	}
+
+	if (!isPlainObject(left) || !isPlainObject(right)) {
+		return false;
+	}
+
+	const leftKeys = Object.keys(left).sort((a, b) => a.localeCompare(b));
+	const rightKeys = Object.keys(right).sort((a, b) => a.localeCompare(b));
+	return valuesEqual(leftKeys, rightKeys) && leftKeys.every((key) => valuesEqual(left[key], right[key]));
+}
+
+function addMismatch(mismatches: EvalMismatch[], field: string, expected: unknown, actual: unknown): boolean {
+	const matches = valuesEqual(expected, actual);
+	if (!matches) {
+		mismatches.push({ field, expected, actual });
+	}
+
+	return matches;
+}
+
+function scoreQualityCase(golden: QualityRoutingGolden, actual: ActualQualityRoutingCase): QualityRoutingCaseResult {
+	const mismatches: EvalMismatch[] = [];
+	const checks = {
+		overallQuality: addMismatch(
+			mismatches,
+			'overallQuality',
+			golden.expected.overallQuality,
+			actual.assessment.overallQuality,
+		),
+		processable: addMismatch(mismatches, 'processable', golden.expected.processable, actual.assessment.processable),
+		recommendedPath: addMismatch(
+			mismatches,
+			'recommendedPath',
+			golden.expected.recommendedPath,
+			actual.assessment.recommendedPath,
+		),
+		extractionGateOutcome: addMismatch(
+			mismatches,
+			'extractionGate.outcome',
+			golden.expected.extractionGateOutcome,
+			actual.extractionGate.outcome,
+		),
+		qualityMetadata: addMismatch(
+			mismatches,
+			'qualityMetadata',
+			golden.expected.qualityMetadata,
+			actual.qualityMetadata,
+		),
+		signals: addMismatch(mismatches, 'signals', golden.expected.signals, actual.assessment.signals),
+	};
+
+	return {
+		caseId: golden.caseId,
+		sourceSlug: golden.sourceSlug,
+		difficulty: golden.difficulty,
+		overallQuality: actual.assessment.overallQuality,
+		recommendedPath: actual.assessment.recommendedPath,
+		processable: actual.assessment.processable,
+		passed: mismatches.length === 0,
+		checks,
+		mismatches,
+	};
+}
+
+function emptyQualityCoverage(): Record<DocumentOverallQuality, number> {
+	return {
+		high: 0,
+		medium: 0,
+		low: 0,
+		unusable: 0,
+	};
+}
+
+export function runQualityRoutingEval(goldenDir: string, fixturesDir: string): QualityRoutingEvalResult {
+	const goldens = loadQualityRoutingGoldenSet(goldenDir);
+	const actualCases = loadActualQualityRoutingCases(fixturesDir);
+	const actualByCaseId = new Map(actualCases.map((actual) => [actual.caseId, actual]));
+	const cases: QualityRoutingCaseResult[] = [];
+
+	for (const golden of goldens) {
+		const actual = actualByCaseId.get(golden.caseId);
+		if (!actual) {
+			throw new MulderEvalError(
+				`Quality routing fixture not found for case: ${golden.caseId}`,
+				EVAL_ERROR_CODES.FIXTURE_NOT_FOUND,
+				{
+					context: { caseId: golden.caseId, fixturesDir },
+				},
+			);
+		}
+
+		cases.push(scoreQualityCase(golden, actual));
+	}
+
+	const coverage = {
+		byQuality: emptyQualityCoverage(),
+		byRoute: {} as Partial<Record<ExtractionPath, number>>,
+	};
+
+	for (const golden of goldens) {
+		coverage.byQuality[golden.expected.overallQuality] += 1;
+		coverage.byRoute[golden.expected.recommendedPath] = (coverage.byRoute[golden.expected.recommendedPath] ?? 0) + 1;
+	}
+
+	const totalCases = cases.length;
+	const passedCases = cases.filter((result) => result.passed).length;
+	const failedCases = totalCases - passedCases;
+
+	return {
+		timestamp: DETERMINISTIC_TIMESTAMP,
+		cases,
+		summary: {
+			totalCases,
+			passedCases,
+			failedCases,
+			passRate: totalCases > 0 ? passedCases / totalCases : 0,
+			coverage,
+		},
+	};
+}

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -220,6 +220,187 @@ export interface EntityEvalResult {
 }
 
 // ────────────────────────────────────────────────────────────
+// Quality-routing golden annotations
+// ────────────────────────────────────────────────────────────
+
+export type DocumentOverallQuality = 'high' | 'medium' | 'low' | 'unusable';
+
+export type ExtractionPath =
+	| 'standard'
+	| 'enhanced_ocr'
+	| 'visual_extraction'
+	| 'handwriting_recognition'
+	| 'manual_transcription_required'
+	| 'skip';
+
+export type ExtractionGateOutcome = 'allow' | 'skip';
+
+export interface ExpectedQualityMetadata {
+	source_document_quality: 'high' | 'medium' | 'low';
+	extraction_path: ExtractionPath;
+	extraction_confidence: number;
+}
+
+export interface QualityRoutingGolden {
+	caseId: string;
+	sourceSlug: string;
+	difficulty: DifficultyLevel;
+	expected: {
+		overallQuality: DocumentOverallQuality;
+		processable: boolean;
+		recommendedPath: ExtractionPath;
+		extractionGateOutcome: ExtractionGateOutcome;
+		qualityMetadata: ExpectedQualityMetadata;
+		signals: Record<string, unknown>;
+	};
+	annotation: {
+		author: string;
+		date: string;
+		notes?: string;
+	};
+}
+
+export interface ActualQualityRoutingCase {
+	caseId: string;
+	sourceSlug: string;
+	assessment: {
+		overallQuality: DocumentOverallQuality;
+		processable: boolean;
+		recommendedPath: ExtractionPath;
+		signals: Record<string, unknown>;
+	};
+	extractionGate: {
+		outcome: ExtractionGateOutcome;
+	};
+	qualityMetadata: ExpectedQualityMetadata;
+}
+
+export interface EvalMismatch {
+	field: string;
+	expected: unknown;
+	actual: unknown;
+}
+
+export interface QualityRoutingCaseResult {
+	caseId: string;
+	sourceSlug: string;
+	difficulty: DifficultyLevel;
+	overallQuality: DocumentOverallQuality;
+	recommendedPath: ExtractionPath;
+	processable: boolean;
+	passed: boolean;
+	checks: {
+		overallQuality: boolean;
+		processable: boolean;
+		recommendedPath: boolean;
+		extractionGateOutcome: boolean;
+		qualityMetadata: boolean;
+		signals: boolean;
+	};
+	mismatches: EvalMismatch[];
+}
+
+export interface QualityRoutingEvalResult {
+	timestamp: string;
+	cases: QualityRoutingCaseResult[];
+	summary: {
+		totalCases: number;
+		passedCases: number;
+		failedCases: number;
+		passRate: number;
+		coverage: {
+			byQuality: Record<DocumentOverallQuality, number>;
+			byRoute: Partial<Record<ExtractionPath, number>>;
+		};
+	};
+}
+
+// ────────────────────────────────────────────────────────────
+// Assertion-classification golden annotations
+// ────────────────────────────────────────────────────────────
+
+export type AssertionType = 'observation' | 'interpretation' | 'hypothesis';
+
+export type ClassificationProvenance = 'llm_auto' | 'human_reviewed' | 'author_explicit';
+
+export interface AssertionConfidenceMetadata {
+	witness_count: number | null;
+	measurement_based: boolean;
+	contemporaneous: boolean;
+	corroborated: boolean;
+	peer_reviewed: boolean;
+	author_is_interpreter: boolean;
+}
+
+export interface AssertionClassificationGolden {
+	caseId: string;
+	segmentId: string;
+	sourceSlug: string;
+	difficulty: DifficultyLevel;
+	expected: {
+		content: string;
+		assertionType: AssertionType;
+		classificationProvenance: ClassificationProvenance;
+		confidenceMetadata: AssertionConfidenceMetadata;
+		entityNames?: string[];
+		qualityMetadata?: Record<string, unknown>;
+	};
+	annotation: {
+		author: string;
+		date: string;
+		notes?: string;
+	};
+}
+
+export interface ActualAssertionCase {
+	caseId: string;
+	segmentId: string;
+	sourceSlug: string;
+	assertion: {
+		content: string;
+		assertion_type: AssertionType;
+		classification_provenance: ClassificationProvenance;
+		confidence_metadata: AssertionConfidenceMetadata;
+		entity_names?: string[];
+		quality_metadata?: Record<string, unknown>;
+	};
+}
+
+export interface AssertionClassificationCaseResult {
+	caseId: string;
+	segmentId: string;
+	sourceSlug: string;
+	difficulty: DifficultyLevel;
+	assertionType: AssertionType;
+	classificationProvenance: ClassificationProvenance;
+	passed: boolean;
+	checks: {
+		content: boolean;
+		assertionType: boolean;
+		classificationProvenance: boolean;
+		confidenceMetadata: boolean;
+		entityNames: boolean;
+		qualityMetadata: boolean;
+	};
+	mismatches: EvalMismatch[];
+}
+
+export interface AssertionClassificationEvalResult {
+	timestamp: string;
+	cases: AssertionClassificationCaseResult[];
+	summary: {
+		totalCases: number;
+		passedCases: number;
+		failedCases: number;
+		passRate: number;
+		coverage: {
+			byAssertionType: Record<AssertionType, number>;
+			byProvenance: Partial<Record<ClassificationProvenance, number>>;
+		};
+	};
+}
+
+// ────────────────────────────────────────────────────────────
 // Retrieval golden annotations (Phase 3, D5)
 // ────────────────────────────────────────────────────────────
 

--- a/tests/specs/106_golden_tests_quality_routing_assertion_classification.test.ts
+++ b/tests/specs/106_golden_tests_quality_routing_assertion_classification.test.ts
@@ -1,0 +1,284 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const EVAL_DIST = resolve(ROOT, 'packages/eval/dist/index.js');
+const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
+const QUALITY_GOLDEN_DIR = resolve(ROOT, 'eval/golden/quality-routing');
+const ASSERTION_GOLDEN_DIR = resolve(ROOT, 'eval/golden/assertions');
+const QUALITY_FIXTURE_DIR = resolve(ROOT, 'fixtures/quality-routing');
+const ASSERTION_FIXTURE_DIR = resolve(ROOT, 'fixtures/assertions');
+const BASELINE_PATH = resolve(ROOT, 'eval/metrics/baseline.json');
+
+const infraReady =
+	existsSync(EVAL_DIST) &&
+	existsSync(CLI) &&
+	existsSync(BASELINE_PATH) &&
+	existsSync(QUALITY_GOLDEN_DIR) &&
+	existsSync(ASSERTION_GOLDEN_DIR) &&
+	existsSync(QUALITY_FIXTURE_DIR) &&
+	existsSync(ASSERTION_FIXTURE_DIR);
+
+function buildEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		NODE_ENV: 'test',
+		MULDER_LOG_LEVEL: 'silent',
+		...extra,
+	};
+
+	for (const key of [
+		'DATABASE_URL',
+		'GOOGLE_APPLICATION_CREDENTIALS',
+		'GOOGLE_CLOUD_PROJECT',
+		'GCLOUD_PROJECT',
+		'GCP_PROJECT',
+		'CLOUDSDK_CORE_PROJECT',
+		'VERTEX_AI_PROJECT',
+		'VERTEX_AI_LOCATION',
+	]) {
+		delete env[key];
+	}
+
+	return env;
+}
+
+function evalExpr(expression: string): unknown {
+	const script = `
+		import * as evalPkg from ${JSON.stringify(`file://${EVAL_DIST}`)};
+		const result = ${expression};
+		process.stdout.write(JSON.stringify(result));
+	`;
+	const result = execFileSync('node', ['--input-type=module', '-e', script], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: 30_000,
+		env: buildEnv(),
+	});
+	return JSON.parse(result);
+}
+
+function runCli(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+	const result = spawnSync('node', [CLI, ...args], {
+		cwd: ROOT,
+		encoding: 'utf-8',
+		timeout: 60_000,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		env: buildEnv(),
+	});
+
+	return {
+		stdout: result.stdout ?? '',
+		stderr: result.stderr ?? '',
+		exitCode: result.status ?? 1,
+	};
+}
+
+function parseJsonOutput(stdout: string): { results?: Record<string, unknown>; comparison?: Record<string, unknown> } {
+	const trimmed = stdout.trim();
+	if (!trimmed) {
+		throw new Error('CLI returned empty stdout');
+	}
+
+	return JSON.parse(trimmed) as { results?: Record<string, unknown>; comparison?: Record<string, unknown> };
+}
+
+function readJson(path: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+function expectOnlyResultKeys(stdout: string, keys: string[]): void {
+	const parsed = parseJsonOutput(stdout);
+	expect(Object.keys(parsed.results ?? {}).sort()).toEqual(keys.slice().sort());
+}
+
+describe('Spec 106: Golden tests for quality routing and assertion classification', () => {
+	let tempDir = '';
+
+	beforeAll(() => {
+		expect(infraReady, 'Spec 106 requires built eval and CLI dist artifacts plus checked-in fixtures').toBe(true);
+		tempDir = mkdtempSync(join(tmpdir(), 'mulder-spec-106-'));
+	});
+
+	afterAll(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('QA-01: quality-routing goldens cover every required quality and route', () => {
+		const files = readdirSync(QUALITY_GOLDEN_DIR).filter((file) => file.endsWith('.json'));
+		expect(files.length).toBeGreaterThanOrEqual(4);
+
+		const cases = files.map((file) => readJson(join(QUALITY_GOLDEN_DIR, file)));
+		const expected = cases.map((entry) => (entry.expected ?? {}) as Record<string, unknown>);
+
+		expect(new Set(expected.map((entry) => entry.overallQuality))).toEqual(
+			new Set(['high', 'medium', 'low', 'unusable']),
+		);
+		for (const route of ['standard', 'enhanced_ocr', 'visual_extraction', 'skip']) {
+			expect(
+				expected.some((entry) => entry.recommendedPath === route),
+				`missing route ${route}`,
+			).toBe(true);
+		}
+		for (const entry of expected) {
+			expect(typeof entry.processable).toBe('boolean');
+			expect(entry.qualityMetadata).toBeDefined();
+			expect(entry.signals).toBeDefined();
+		}
+	});
+
+	it('QA-02: assertion goldens cover labels and complete confidence metadata', () => {
+		const files = readdirSync(ASSERTION_GOLDEN_DIR).filter((file) => file.endsWith('.json'));
+		expect(files.length).toBeGreaterThanOrEqual(3);
+
+		const cases = files.map((file) => readJson(join(ASSERTION_GOLDEN_DIR, file)));
+		const expected = cases.map((entry) => (entry.expected ?? {}) as Record<string, unknown>);
+
+		expect(new Set(expected.map((entry) => entry.assertionType))).toEqual(
+			new Set(['observation', 'interpretation', 'hypothesis']),
+		);
+		for (const entry of expected) {
+			const confidence = entry.confidenceMetadata as Record<string, unknown>;
+			for (const key of [
+				'witness_count',
+				'measurement_based',
+				'contemporaneous',
+				'corroborated',
+				'peer_reviewed',
+				'author_is_interpreter',
+			]) {
+				expect(confidence, `missing confidence key ${key}`).toHaveProperty(key);
+			}
+		}
+	});
+
+	it('QA-03 and QA-04: public runners validate, score, and pass checked-in fixtures deterministically', () => {
+		const first = evalExpr(`({
+			quality: evalPkg.runQualityRoutingEval(${JSON.stringify(QUALITY_GOLDEN_DIR)}, ${JSON.stringify(QUALITY_FIXTURE_DIR)}),
+			assertions: evalPkg.runAssertionClassificationEval(${JSON.stringify(ASSERTION_GOLDEN_DIR)}, ${JSON.stringify(ASSERTION_FIXTURE_DIR)})
+		})`) as {
+			quality: { summary: { failedCases: number; coverage: { byQuality: Record<string, number> } } };
+			assertions: { summary: { failedCases: number; coverage: { byAssertionType: Record<string, number> } } };
+		};
+		const second = evalExpr(`({
+			quality: evalPkg.runQualityRoutingEval(${JSON.stringify(QUALITY_GOLDEN_DIR)}, ${JSON.stringify(QUALITY_FIXTURE_DIR)}),
+			assertions: evalPkg.runAssertionClassificationEval(${JSON.stringify(ASSERTION_GOLDEN_DIR)}, ${JSON.stringify(ASSERTION_FIXTURE_DIR)})
+		})`);
+
+		expect(first).toEqual(second);
+		expect(first.quality.summary.failedCases).toBe(0);
+		expect(first.assertions.summary.failedCases).toBe(0);
+		expect(Object.keys(first.quality.summary.coverage.byQuality).sort()).toEqual(['high', 'low', 'medium', 'unusable']);
+		expect(Object.keys(first.assertions.summary.coverage.byAssertionType).sort()).toEqual([
+			'hypothesis',
+			'interpretation',
+			'observation',
+		]);
+	});
+
+	it('QA-05: runners report route and assertion mismatches without live services', () => {
+		const qualityFixtures = join(tempDir, 'quality-fixtures');
+		const assertionFixtures = join(tempDir, 'assertion-fixtures');
+		cpSync(QUALITY_FIXTURE_DIR, qualityFixtures, { recursive: true });
+		cpSync(ASSERTION_FIXTURE_DIR, assertionFixtures, { recursive: true });
+
+		const qualityPath = join(qualityFixtures, 'medium-enhanced-ocr.json');
+		const qualityFixture = readJson(qualityPath);
+		(qualityFixture.assessment as Record<string, unknown>).recommendedPath = 'standard';
+		writeFileSync(qualityPath, `${JSON.stringify(qualityFixture, null, 2)}\n`);
+
+		const assertionPath = join(assertionFixtures, 'interpretation-correlation.json');
+		const assertionFixture = readJson(assertionPath);
+		(assertionFixture.assertion as Record<string, unknown>).assertion_type = 'observation';
+		writeFileSync(assertionPath, `${JSON.stringify(assertionFixture, null, 2)}\n`);
+
+		const result = evalExpr(`({
+			quality: evalPkg.runQualityRoutingEval(${JSON.stringify(QUALITY_GOLDEN_DIR)}, ${JSON.stringify(qualityFixtures)}),
+			assertions: evalPkg.runAssertionClassificationEval(${JSON.stringify(ASSERTION_GOLDEN_DIR)}, ${JSON.stringify(assertionFixtures)})
+		})`) as {
+			quality: { summary: { failedCases: number }; cases: Array<{ mismatches: Array<{ field: string }> }> };
+			assertions: { summary: { failedCases: number }; cases: Array<{ mismatches: Array<{ field: string }> }> };
+		};
+
+		expect(result.quality.summary.failedCases).toBe(1);
+		expect(result.quality.cases.flatMap((entry) => entry.mismatches.map((mismatch) => mismatch.field))).toContain(
+			'recommendedPath',
+		);
+		expect(result.assertions.summary.failedCases).toBe(1);
+		expect(result.assertions.cases.flatMap((entry) => entry.mismatches.map((mismatch) => mismatch.field))).toContain(
+			'assertionType',
+		);
+	});
+
+	it('validates malformed temp goldens with eval errors', () => {
+		const badQualityDir = join(tempDir, 'bad-quality');
+		const badAssertionDir = join(tempDir, 'bad-assertion');
+		cpSync(QUALITY_GOLDEN_DIR, badQualityDir, { recursive: true });
+		cpSync(ASSERTION_GOLDEN_DIR, badAssertionDir, { recursive: true });
+		writeFileSync(join(badQualityDir, 'bad.json'), JSON.stringify({ caseId: 'bad' }));
+		writeFileSync(join(badAssertionDir, 'bad.json'), JSON.stringify({ caseId: 'bad' }));
+
+		const result = evalExpr(`({
+			quality: (() => {
+				try { evalPkg.loadQualityRoutingGoldenSet(${JSON.stringify(badQualityDir)}); return null; }
+				catch (error) { return { name: error.name, code: error.code }; }
+			})(),
+			assertions: (() => {
+				try { evalPkg.loadAssertionGoldenSet(${JSON.stringify(badAssertionDir)}); return null; }
+				catch (error) { return { name: error.name, code: error.code }; }
+			})()
+		})`) as { quality: { name: string; code: string }; assertions: { name: string; code: string } };
+
+		expect(result.quality.name).toBe('MulderEvalError');
+		expect(result.quality.code).toBe('EVAL_GOLDEN_INVALID');
+		expect(result.assertions.name).toBe('MulderEvalError');
+		expect(result.assertions.code).toBe('EVAL_GOLDEN_INVALID');
+	});
+
+	it('QA-06 and QA-07: eval CLI selects quality/assertions and full eval includes all suites', () => {
+		const quality = runCli(['eval', '--step', 'quality', '--json']);
+		expect(quality.exitCode).toBe(0);
+		expectOnlyResultKeys(quality.stdout, ['qualityRouting']);
+
+		const assertions = runCli(['eval', '--step', 'assertions', '--json']);
+		expect(assertions.exitCode).toBe(0);
+		expectOnlyResultKeys(assertions.stdout, ['assertions']);
+
+		const full = runCli(['eval', '--json']);
+		expect(full.exitCode).toBe(0);
+		expectOnlyResultKeys(full.stdout, ['assertions', 'entities', 'extraction', 'qualityRouting', 'segmentation']);
+	});
+
+	it('QA-08: baseline comparison supports the new suite keys and rejects invalid steps with updated help text', () => {
+		const quality = runCli(['eval', '--step', 'quality', '--compare', 'baseline', '--json']);
+		expect(quality.exitCode).toBe(0);
+		expect(Object.keys((parseJsonOutput(quality.stdout).comparison?.suites as Record<string, unknown>) ?? {})).toEqual([
+			'qualityRouting',
+		]);
+
+		const assertions = runCli(['eval', '--step', 'assertions', '--compare', 'baseline', '--json']);
+		expect(assertions.exitCode).toBe(0);
+		expect(
+			Object.keys((parseJsonOutput(assertions.stdout).comparison?.suites as Record<string, unknown>) ?? {}),
+		).toEqual(['assertions']);
+
+		const bogus = runCli(['eval', '--step', 'bogus']);
+		expect(bogus.exitCode).not.toBe(0);
+		expect((bogus.stdout + bogus.stderr).toLowerCase()).toMatch(/quality|assertions/);
+	});
+
+	it('QA-09: new fixture-backed CLI suites succeed without cloud or database environment variables', () => {
+		const quality = runCli(['eval', '--step', 'quality', '--json']);
+		const assertions = runCli(['eval', '--step', 'assertions', '--json']);
+
+		expect(quality.exitCode).toBe(0);
+		expect(assertions.exitCode).toBe(0);
+		expectOnlyResultKeys(quality.stdout, ['qualityRouting']);
+		expectOnlyResultKeys(assertions.stdout, ['assertions']);
+	});
+});

--- a/tests/specs/77_eval_cli_reporter.test.ts
+++ b/tests/specs/77_eval_cli_reporter.test.ts
@@ -1,11 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-const BASELINE_PATH = resolve(ROOT, 'eval/metrics/baseline.json');
+const CHECKED_IN_BASELINE_PATH = resolve(ROOT, 'eval/metrics/baseline.json');
 const GOLDEN_DIRS = [
 	resolve(ROOT, 'eval/golden/extraction'),
 	resolve(ROOT, 'eval/golden/segmentation'),
@@ -30,15 +31,18 @@ const FIXTURE_DIRS = [
 
 const infraReady =
 	existsSync(CLI) &&
-	existsSync(BASELINE_PATH) &&
+	existsSync(CHECKED_IN_BASELINE_PATH) &&
 	GOLDEN_DIRS.every((dir) => existsSync(dir)) &&
 	FIXTURE_DIRS.every((dir) => existsSync(dir));
+
+let isolatedBaselinePath = '';
 
 function buildEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		NODE_ENV: 'test',
 		MULDER_LOG_LEVEL: 'silent',
+		...(isolatedBaselinePath ? { MULDER_EVAL_BASELINE_PATH: isolatedBaselinePath } : {}),
 		...extra,
 	};
 
@@ -118,12 +122,15 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 	let tempDir = '';
 
 	beforeAll(() => {
-		expect(infraReady, `Missing required infra for spec 77: CLI=${CLI}, baseline=${BASELINE_PATH}`).toBe(true);
+		expect(infraReady, `Missing required infra for spec 77: CLI=${CLI}, baseline=${CHECKED_IN_BASELINE_PATH}`).toBe(
+			true,
+		);
 		if (!infraReady) {
 			return;
 		}
-		tempDir = resolve(ROOT, '.tmp-spec-77');
-		mkdirSync(tempDir, { recursive: true });
+		tempDir = mkdtempSync(join(tmpdir(), 'mulder-spec-77-'));
+		isolatedBaselinePath = join(tempDir, 'baseline.json');
+		copyFileSync(CHECKED_IN_BASELINE_PATH, isolatedBaselinePath);
 	});
 
 	afterAll(() => {
@@ -196,8 +203,8 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 		});
 
 		it('QA-07: missing baseline is rejected for compare mode', () => {
-			const backupPath = backupFile(BASELINE_PATH, tempDir);
-			rmSync(BASELINE_PATH);
+			const backupPath = backupFile(isolatedBaselinePath, tempDir);
+			rmSync(isolatedBaselinePath);
 			try {
 				const { exitCode, stderr, stdout } = runCli(['eval', '--compare', 'baseline']);
 
@@ -205,26 +212,26 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 				expect((stdout + stderr).toLowerCase()).toMatch(/baseline/);
 				expect((stdout + stderr).toLowerCase()).toMatch(/missing|not found|absent|no such/);
 			} finally {
-				copyFileSync(backupPath, BASELINE_PATH);
+				copyFileSync(backupPath, isolatedBaselinePath);
 			}
 		});
 
 		it('QA-08: invalid baseline JSON is rejected', () => {
-			const backupPath = backupFile(BASELINE_PATH, tempDir);
-			writeFileSync(BASELINE_PATH, '{ invalid json', 'utf-8');
+			const backupPath = backupFile(isolatedBaselinePath, tempDir);
+			writeFileSync(isolatedBaselinePath, '{ invalid json', 'utf-8');
 			try {
 				const { exitCode, stderr, stdout } = runCli(['eval', '--compare', 'baseline']);
 
 				expect(exitCode).not.toBe(0);
 				expect((stdout + stderr).toLowerCase()).toMatch(/json|parse|unexpected/i);
 			} finally {
-				copyFileSync(backupPath, BASELINE_PATH);
+				copyFileSync(backupPath, isolatedBaselinePath);
 			}
 		});
 
 		it('QA-09: baseline update rewrites only selected suites', () => {
-			const backupPath = backupFile(BASELINE_PATH, tempDir);
-			const original = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as Record<string, unknown>;
+			const backupPath = backupFile(isolatedBaselinePath, tempDir);
+			const original = JSON.parse(readFileSync(isolatedBaselinePath, 'utf-8')) as Record<string, unknown>;
 
 			try {
 				const { exitCode, stdout } = runCli(['eval', '--step', 'extract', '--update-baseline', '--json']);
@@ -237,7 +244,7 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 				expect(parsed.baselineUpdated).toBe(true);
 				expectOnlyResultsKeys(parsed, ['extraction']);
 
-				const updated = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as Record<string, unknown>;
+				const updated = JSON.parse(readFileSync(isolatedBaselinePath, 'utf-8')) as Record<string, unknown>;
 				expect(updated.extraction).toBeDefined();
 				expect(updated.extraction).not.toEqual(original.extraction);
 
@@ -246,7 +253,7 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 					expect(updated[key]).toEqual(original[key]);
 				}
 			} finally {
-				copyFileSync(backupPath, BASELINE_PATH);
+				copyFileSync(backupPath, isolatedBaselinePath);
 			}
 		});
 
@@ -327,16 +334,16 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 		});
 
 		it('CLI-07: mulder eval --update-baseline --step extract --json', () => {
-			const backupPath = backupFile(BASELINE_PATH, tempDir);
+			const backupPath = backupFile(isolatedBaselinePath, tempDir);
 			try {
 				const { exitCode, stdout } = runCli(['eval', '--update-baseline', '--step', 'extract', '--json']);
 
 				expect(exitCode).toBe(0);
 				const parsed = parseJsonOutput(stdout) as { baselineUpdated?: boolean };
 				expect(parsed.baselineUpdated).toBe(true);
-				expect(JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'))).toBeDefined();
+				expect(JSON.parse(readFileSync(isolatedBaselinePath, 'utf-8'))).toBeDefined();
 			} finally {
-				copyFileSync(backupPath, BASELINE_PATH);
+				copyFileSync(backupPath, isolatedBaselinePath);
 			}
 		});
 
@@ -355,8 +362,8 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 		});
 
 		it('CLI-10: mulder eval --compare baseline with missing baseline file', () => {
-			const backupPath = backupFile(BASELINE_PATH, tempDir);
-			rmSync(BASELINE_PATH);
+			const backupPath = backupFile(isolatedBaselinePath, tempDir);
+			rmSync(isolatedBaselinePath);
 			try {
 				const { exitCode, stderr, stdout } = runCli(['eval', '--compare', 'baseline']);
 
@@ -364,7 +371,7 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 				expect((stdout + stderr).toLowerCase()).toMatch(/baseline/);
 				expect((stdout + stderr).toLowerCase()).toMatch(/missing|not found|absent|no such/);
 			} finally {
-				copyFileSync(backupPath, BASELINE_PATH);
+				copyFileSync(backupPath, isolatedBaselinePath);
 			}
 		});
 	});

--- a/tests/specs/77_eval_cli_reporter.test.ts
+++ b/tests/specs/77_eval_cli_reporter.test.ts
@@ -10,11 +10,15 @@ const GOLDEN_DIRS = [
 	resolve(ROOT, 'eval/golden/extraction'),
 	resolve(ROOT, 'eval/golden/segmentation'),
 	resolve(ROOT, 'eval/golden/entities'),
+	resolve(ROOT, 'eval/golden/quality-routing'),
+	resolve(ROOT, 'eval/golden/assertions'),
 ];
 const FIXTURE_DIRS = [
 	resolve(ROOT, 'fixtures/extracted'),
 	resolve(ROOT, 'fixtures/segments'),
 	resolve(ROOT, 'fixtures/entities'),
+	resolve(ROOT, 'fixtures/quality-routing'),
+	resolve(ROOT, 'fixtures/assertions'),
 ];
 
 /**
@@ -133,7 +137,13 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 			const { exitCode, stdout } = runCli(['eval']);
 
 			expect(exitCode).toBe(0);
-			expectReportSections(stdout, ['Extraction Quality', 'Segmentation Quality', 'Entity Extraction']);
+			expectReportSections(stdout, [
+				'Extraction Quality',
+				'Segmentation Quality',
+				'Entity Extraction',
+				'Quality Routing',
+				'Assertion Classification',
+			]);
 		});
 
 		it('QA-02: single-step extract run is scoped', () => {
@@ -261,7 +271,13 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 			const { exitCode, stdout } = runCli(['eval']);
 
 			expect(exitCode).toBe(0);
-			expectReportSections(stdout, ['Extraction Quality', 'Segmentation Quality', 'Entity Extraction']);
+			expectReportSections(stdout, [
+				'Extraction Quality',
+				'Segmentation Quality',
+				'Entity Extraction',
+				'Quality Routing',
+				'Assertion Classification',
+			]);
 		});
 
 		it('CLI-02: mulder eval --step extract', () => {
@@ -369,7 +385,7 @@ describe('Spec 77: Eval CLI + Reporter', () => {
 
 			expect(exitCode).toBe(0);
 			const parsed = parseJsonOutput(stdout) as { results?: Record<string, unknown> };
-			expectOnlyResultsKeys(parsed, ['entities', 'extraction', 'segmentation']);
+			expectOnlyResultsKeys(parsed, ['assertions', 'entities', 'extraction', 'qualityRouting', 'segmentation']);
 		});
 
 		it('smoke: eval --step extract --compare baseline --json stays scoped to the selected suite', () => {


### PR DESCRIPTION
Summary
- Adds deterministic fixture-backed quality-routing goldens and assertions goldens.
- Adds public @mulder/eval runners, CLI step selection, baseline sections, and black-box coverage.
- Keeps suites cost-free and domain-agnostic.

Traceability
- Spec: docs/specs/106_golden_tests_quality_routing_assertion_classification.spec.md
- Roadmap: M10-K9
- Issue: Closes #279

Verification
- pnpm turbo run build --filter='...[HEAD]'
- npx biome check .
- pnpm vitest run tests/specs/106_golden_tests_quality_routing_assertion_classification.test.ts
- pnpm vitest run tests/specs/77_eval_cli_reporter.test.ts tests/specs/106_golden_tests_quality_routing_assertion_classification.test.ts --pool=forks --maxWorkers=1
- pnpm vitest run tests/specs/100_document_quality_assessment_step.test.ts tests/specs/101_assertion_classification_enrich.test.ts --pool=forks --maxWorkers=1