### PR TITLE
CI: scope docs-only affected checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
           NODE
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Upload affected plan artifacts
         if: always()
@@ -269,6 +270,7 @@ jobs:
         run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-schema-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected schema tests
         run: pnpm test:affected:lane -- schema origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-schema-junit.xml
@@ -281,6 +283,7 @@ jobs:
           PGDATABASE: mulder
           MULDER_TEST_ISOLATED_DB: "true"
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Upload affected schema artifacts
         if: always()
@@ -354,6 +357,7 @@ jobs:
         run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-db-${{ matrix.shard_index }}-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected db tests
         run: pnpm test:affected:lane -- db ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-db-${{ matrix.shard_index }}-junit.xml
@@ -366,6 +370,7 @@ jobs:
           PGDATABASE: mulder
           MULDER_TEST_ISOLATED_DB: "true"
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Upload affected DB artifacts
         if: always()
@@ -439,6 +444,7 @@ jobs:
         run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-heavy-${{ matrix.shard_index }}-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected heavy tests
         run: pnpm test:affected:lane -- heavy ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-heavy-${{ matrix.shard_index }}-junit.xml
@@ -451,6 +457,7 @@ jobs:
           PGDATABASE: mulder
           MULDER_TEST_ISOLATED_DB: "true"
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
+          MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Upload affected heavy artifacts
         if: always()

--- a/docs/specs/83_m7_verification_lane_repair.spec.md
+++ b/docs/specs/83_m7_verification_lane_repair.spec.md
@@ -12,13 +12,13 @@ created: 2026-04-18
 
 ## 1. Objective
 
-Restore the intended M7 verification commands so milestone-scoped and API-focused checks can run without dying in unrelated CLI/eval TypeScript failures before the M7 assertions start. This is not product-surface work; it is a test-lane integrity fix so later auto-pilot implementations can verify M7 remediation work through the repository’s intended commands instead of ad hoc local workarounds.
+Restore the intended verification commands so scoped checks can run without dying in unrelated failures before the intended assertions start. This is not product-surface work; it is a test-lane integrity fix so later auto-pilot implementations can verify remediation work through the repository’s intended commands instead of ad hoc local workarounds.
 
 ## 2. Boundaries
 
 - **Roadmap Step:** N/A — off-roadmap verification/harness follow-up for M7 remediation
-- **Target:** `apps/cli/src/lib/eval.ts`, `apps/cli/src/commands/eval.ts`, `scripts/test-scope.mjs`, `scripts/test-api-e2e.mjs`, `tests/specs/83_m7_verification_lane_repair.test.ts`
-- **In scope:** fixing the current build/type issues that prevent `pnpm test:scope -- milestone M7` and `pnpm test:api:e2e` from reaching their intended assertions; tightening only the command/library/script surfaces necessary to restore those lanes; and black-box verification that the commands now reach suite startup or execution instead of failing early on unrelated compile errors
+- **Target:** `apps/cli/src/lib/eval.ts`, `apps/cli/src/commands/eval.ts`, `scripts/test-scope.mjs`, `scripts/test-api-e2e.mjs`, `scripts/test-lanes.mjs`, config-dependent black-box tests, and `tests/specs/83_m7_verification_lane_repair.test.ts`
+- **In scope:** fixing the current build/type issues that prevent scoped lanes from reaching their intended assertions; preventing docs-only PR head commits from replaying unrelated DB/heavy affected lanes; tightening config-dependent tests so fresh checkouts rely on `mulder.config.example.yaml` or a temporary explicit config; and black-box verification that the commands now reach suite startup or execution instead of failing early on unrelated compile/config errors
 - **Out of scope:** changing the product behavior under test, broad eval-framework redesign, adding new CI workflows, or rewriting unrelated spec assertions
 - **Constraints:** keep this repair as narrow as possible; preserve the existing command names and invocation shapes; and do not use verification-lane repair as a backdoor for unrelated feature work
 
@@ -35,6 +35,8 @@ Restore the intended M7 verification commands so milestone-scoped and API-focuse
 2. **`apps/cli/src/commands/eval.ts`** — make any narrow command-surface adjustments required by the library repair
 3. **`scripts/test-scope.mjs`** and **`scripts/test-api-e2e.mjs`** — keep the milestone/API lane scripts aligned with the fixed CLI surface if needed
 4. **`tests/specs/83_m7_verification_lane_repair.test.ts`** — black-box verification that the intended M7 test commands now reach their actual suites
+5. **`scripts/test-lanes.mjs`** — keep affected-test selection broad for code changes but scope docs-only PR head commits to the actual documentation files changed
+6. **Config-dependent black-box tests** — avoid assuming an ignored root `mulder.config.yaml` exists in a fresh checkout
 
 ### 4.2 Lane Contract
 
@@ -43,6 +45,8 @@ After this repair:
 - `pnpm test:scope -- milestone M7` must reach M7 suite startup/execution rather than dying in unrelated eval build errors
 - `pnpm test:api:e2e` must likewise reach its own setup/execution path
 - `pnpm --filter @mulder/cli build` must be green enough that the verification commands are not blocked by unrelated TypeScript failures in eval code
+- PR affected lanes must use the full base diff for code/test changes, but may use only the newest head commit when that commit changes documentation files only
+- Black-box tests must not require a local ignored `mulder.config.yaml`; tests that need the example project config must point at `mulder.config.example.yaml` or create a temporary default config explicitly
 
 ### 4.3 Integration Points
 
@@ -69,6 +73,16 @@ Single phase — fix the blocking compile path and verify the M7 lane commands r
    - Given: the repaired CLI/eval surfaces
    - When: the CLI build/type path used by the verification commands runs
    - Then: it succeeds far enough that the M7 verification commands are not preempted by unrelated eval TypeScript failures
+
+4. **QA-04: docs-only PR head commits do not replay unrelated affected lanes**
+   - Given: a PR whose latest commit changes only documentation
+   - When: `scripts/test-lanes.mjs affected-plan` runs with PR head docs-only optimization enabled
+   - Then: the affected plan is based on that docs-only head change, not the full historical PR diff
+
+5. **QA-05: config-dependent tests are fresh-checkout safe**
+   - Given: a checkout without a local ignored `mulder.config.yaml`
+   - When: config schema or layout-to-markdown tests need project config
+   - Then: they use `mulder.config.example.yaml` explicitly or create a temporary `mulder.config.yaml` for the specific default-resolution assertion
 
 ## 5b. CLI Test Matrix
 

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -14,6 +14,8 @@ const SERIAL_VITEST_ARGS = ['--no-file-parallelism', '--maxWorkers=1'];
 const PARALLEL_VITEST_ARGS = ['--fileParallelism=true'];
 const LANE_ORDER = ['unit', 'schema', 'db', 'heavy', 'external'];
 const HEALTH_SMOKE_TEST = 'tests/specs/44_e2e_pipeline_integration.test.ts';
+const HEAD_DOCS_ONLY_OPTIMIZATION_ENV = 'MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY';
+const HEAD_CHANGED_FILES_OVERRIDE_ENV = 'MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES';
 const SPEC_DOC_TEST_OVERRIDES = new Map([
 	['77_document_observability_aggregation', ['tests/specs/77_document_observability_route.test.ts']],
 ]);
@@ -327,6 +329,66 @@ function gitChangedFiles(baseRef) {
 		.split('\n')
 		.map((line) => line.trim())
 		.filter(Boolean);
+}
+
+function splitChangedFiles(value) {
+	return value
+		.split(/\r?\n|,/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function gitHeadChangedFiles() {
+	const override = process.env[HEAD_CHANGED_FILES_OVERRIDE_ENV];
+	if (override) {
+		return splitChangedFiles(override);
+	}
+
+	const status = spawnSync('git', ['status', '--porcelain'], {
+		cwd: ROOT,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	if (status.status !== 0 || status.stdout.trim().length > 0) {
+		return [];
+	}
+
+	const result = spawnSync('git', ['diff', '--name-only', 'HEAD~1..HEAD'], {
+		cwd: ROOT,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	if (result.status !== 0) {
+		return [];
+	}
+	return splitChangedFiles(result.stdout);
+}
+
+function isDocsOnlyHeadFile(file) {
+	if (file === 'README.md' || file === 'CLAUDE.md') {
+		return true;
+	}
+	if (/^[^/]+\.md$/.test(file)) {
+		return true;
+	}
+	return (file.startsWith('docs/') || file.startsWith('.codex/')) && file.endsWith('.md');
+}
+
+function affectedChangedFiles(baseRef) {
+	if (baseRef && process.env[HEAD_DOCS_ONLY_OPTIMIZATION_ENV] === 'true') {
+		const headChangedFiles = gitHeadChangedFiles();
+		if (headChangedFiles.length > 0 && headChangedFiles.every(isDocsOnlyHeadFile)) {
+			return {
+				changeScope: 'head-docs-only',
+				changedFiles: headChangedFiles,
+			};
+		}
+	}
+
+	return {
+		changeScope: 'base',
+		changedFiles: gitChangedFiles(baseRef),
+	};
 }
 
 function testsForSpecNumber(specNumber, discoveredByPath) {
@@ -770,7 +832,10 @@ function buildAffectedPlan(baseRef, explicitChangedFiles = null) {
 	const weightedByPath = new Map(
 		Object.values(lanes).flatMap((lane) => lane.files.map((file) => [file.relativePath, file])),
 	);
-	const changed = explicitChangedFiles ?? gitChangedFiles(baseRef);
+	const changeSelection = explicitChangedFiles
+		? { changeScope: 'explicit', changedFiles: explicitChangedFiles }
+		: affectedChangedFiles(baseRef);
+	const changed = changeSelection.changedFiles;
 	const selected = new Set();
 	const rules = [];
 
@@ -812,6 +877,7 @@ function buildAffectedPlan(baseRef, explicitChangedFiles = null) {
 
 	return {
 		baseRef: baseRef ?? null,
+		changeScope: changeSelection.changeScope,
 		changedFiles: changed,
 		totalFiles: files.length,
 		totalWeight,
@@ -845,6 +911,7 @@ function rewriteJUnitOutputArgs(extraArgs, suffix) {
 function formatAffectedPlan(plan) {
 	const lines = [
 		`Affected tests${plan.baseRef ? ` against ${plan.baseRef}` : ''}`,
+		`Change scope: ${plan.changeScope}`,
 		`Changed files: ${plan.changedFiles.length}`,
 		...plan.changedFiles.map((file) => ` - ${file}`),
 		'Rules:',

--- a/tests/specs/26_json_schema_generator.test.ts
+++ b/tests/specs/26_json_schema_generator.test.ts
@@ -1,12 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
-const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 /**
  * Black-box QA tests for Spec 26: JSON Schema Generator
@@ -24,11 +24,14 @@ const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.yaml');
  * Uses spawnSync with no shell for safety (equivalent to execFileSync).
  */
 function runCli(args: string[], options?: { cwd?: string }): { stdout: string; stderr: string; exitCode: number } {
+	const env = { ...process.env };
+	delete env.MULDER_CONFIG;
 	const result = spawnSync('node', [CLI, ...args], {
 		cwd: options?.cwd ?? ROOT,
 		encoding: 'utf-8',
 		timeout: 15000,
 		stdio: ['pipe', 'pipe', 'pipe'],
+		env,
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -480,13 +483,18 @@ describe('CLI Smoke Tests: config schema', () => {
 
 	describe('SMOKE-08: runs without explicit config path (uses default)', () => {
 		it('uses mulder.config.yaml from cwd when no path given', () => {
-			const { stdout, exitCode } = runCli(['config', 'schema']);
+			const tempConfigDir = mkdtempSync(join(tmpdir(), 'mulder-spec26-default-config-'));
+			try {
+				copyFileSync(EXAMPLE_CONFIG, join(tempConfigDir, 'mulder.config.yaml'));
+				const { stdout, exitCode } = runCli(['config', 'schema'], { cwd: tempConfigDir });
 
-			// Should work because mulder.config.yaml exists in ROOT
-			expect(exitCode).toBe(0);
+				expect(exitCode).toBe(0);
 
-			const parsed = JSON.parse(stdout);
-			expect(parsed.type).toBe('object');
+				const parsed = JSON.parse(stdout);
+				expect(parsed.type).toBe('object');
+			} finally {
+				rmSync(tempConfigDir, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/tests/specs/48_layout_to_markdown.test.ts
+++ b/tests/specs/48_layout_to_markdown.test.ts
@@ -37,6 +37,7 @@ const ROOT = resolve(import.meta.dirname, '../..');
 const CLI = resolve(ROOT, 'apps/cli/dist/index.js');
 const PIPELINE_DIST = resolve(ROOT, 'packages/pipeline/dist/index.js');
 const CORE_DIST = resolve(ROOT, 'packages/core/dist/index.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 const FIXTURE_EXTRACTED_DIR = resolve(ROOT, 'fixtures/extracted');
 const GOLDEN_DIR = resolve(ROOT, 'eval/golden/layout-markdown');
@@ -67,7 +68,7 @@ function runCli(
 		encoding: 'utf-8',
 		timeout: opts?.timeout ?? 90_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
-		env: { ...process.env, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
+		env: { ...process.env, MULDER_CONFIG: EXAMPLE_CONFIG, PGPASSWORD: db.TEST_PG_PASSWORD, ...opts?.env },
 	});
 	return {
 		stdout: result.stdout ?? '',
@@ -188,7 +189,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 			console.warn('SKIP: PostgreSQL not reachable at PGHOST/PGPORT.');
 		} else {
 			// Ensure schema is migrated (idempotent — matches spec 19 pattern).
-			const migrate = runCli(['db', 'migrate', resolve(ROOT, 'mulder.config.example.yaml')]);
+			const migrate = runCli(['db', 'migrate', EXAMPLE_CONFIG]);
 			if (migrate.exitCode !== 0) {
 				throw new Error(`Migration failed: ${migrate.stdout} ${migrate.stderr}`);
 			}
@@ -423,7 +424,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 
 		const sourceId = ingestNativeTextPdf();
 
-		const config = loadConfig(resolve(ROOT, 'mulder.config.yaml'));
+		const config = loadConfig(EXAMPLE_CONFIG);
 		const logger = createLogger({ level: 'silent' });
 		const services = createServiceRegistry(config, logger);
 		const pool = getWorkerPool(config.gcp.cloud_sql);
@@ -465,7 +466,7 @@ describe('Spec 48 — Layout-to-Markdown Converter', () => {
 
 		const sourceId = ingestNativeTextPdf();
 
-		const config = loadConfig(resolve(ROOT, 'mulder.config.yaml'));
+		const config = loadConfig(EXAMPLE_CONFIG);
 		const logger = createLogger({ level: 'silent' });
 		const realServices = createServiceRegistry(config, logger);
 		const pool = getWorkerPool(config.gcp.cloud_sql);

--- a/tests/specs/83_m7_verification_lane_repair.test.ts
+++ b/tests/specs/83_m7_verification_lane_repair.test.ts
@@ -4,6 +4,15 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const SCRIPT = resolve(ROOT, 'scripts/test-scope.mjs');
+const TEST_LANES_SCRIPT = resolve(ROOT, 'scripts/test-lanes.mjs');
+
+interface AffectedPlan {
+	changeScope: string;
+	changedFiles: string[];
+	totalFiles: number;
+	lanes: Record<string, { count: number }>;
+	files: Array<{ relativePath: string }>;
+}
 
 function listM7Scope(): string {
 	const result = spawnSync(process.execPath, [SCRIPT, 'list', 'milestone', 'M7'], {
@@ -13,6 +22,21 @@ function listM7Scope(): string {
 
 	expect(result.status).toBe(0);
 	return result.stdout;
+}
+
+function affectedPlanForHeadFiles(headFiles: string[]): AffectedPlan {
+	const result = spawnSync(process.execPath, [TEST_LANES_SCRIPT, 'affected-plan', 'origin/main', '--json'], {
+		cwd: ROOT,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: 'true',
+			MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES: headFiles.join('\n'),
+		},
+	});
+
+	expect(result.status, result.stderr).toBe(0);
+	return JSON.parse(result.stdout) as AffectedPlan;
 }
 
 describe('Spec 83: M7 verification lane repair', () => {
@@ -33,5 +57,27 @@ describe('Spec 83: M7 verification lane repair', () => {
 			.map((line) => line.slice(3));
 
 		expect(files).toHaveLength(new Set(files).size);
+	});
+
+	it('QA-03: docs-only head changes do not replay the whole PR affected suite', () => {
+		const plan = affectedPlanForHeadFiles(['docs/roadmap.md']);
+
+		expect(plan.changeScope).toBe('head-docs-only');
+		expect(plan.changedFiles).toEqual(['docs/roadmap.md']);
+		expect(plan.lanes.schema.count).toBe(0);
+		expect(plan.lanes.db.count).toBe(0);
+		expect(plan.lanes.heavy.count).toBe(0);
+		expect(plan.totalFiles).toBe(0);
+	});
+
+	it('QA-04: docs spec head changes stay scoped to their matching spec test', () => {
+		const plan = affectedPlanForHeadFiles(['docs/specs/83_m7_verification_lane_repair.spec.md']);
+
+		expect(plan.changeScope).toBe('head-docs-only');
+		expect(plan.changedFiles).toEqual(['docs/specs/83_m7_verification_lane_repair.spec.md']);
+		expect(plan.files.map((file) => file.relativePath)).toEqual(['tests/specs/83_m7_verification_lane_repair.test.ts']);
+		expect(plan.lanes.db.count).toBe(1);
+		expect(plan.lanes.schema.count).toBe(0);
+		expect(plan.lanes.heavy.count).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary
- Adds a PR affected-plan optimization for docs-only head commits so roadmap/README-only pushes do not replay unrelated DB/heavy lanes.
- Keeps full base-diff affected planning for normal code/test changes and guards the optimization to clean worktrees outside explicit test overrides.
- Updates config-dependent black-box tests to use `mulder.config.example.yaml` or a temporary default config instead of requiring an ignored root `mulder.config.yaml`.

## Verification
- `MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY=true MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES=docs/roadmap.md node scripts/test-lanes.mjs affected-plan origin/milestone/11`
- `MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY=true MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES=docs/specs/83_m7_verification_lane_repair.spec.md node scripts/test-lanes.mjs affected-plan origin/milestone/11`
- `npx biome check .github/workflows/ci.yml scripts/test-lanes.mjs tests/specs/26_json_schema_generator.test.ts tests/specs/48_layout_to_markdown.test.ts tests/specs/83_m7_verification_lane_repair.test.ts`
- `pnpm exec vitest run tests/specs/26_json_schema_generator.test.ts tests/specs/48_layout_to_markdown.test.ts tests/specs/83_m7_verification_lane_repair.test.ts --reporter=verbose`
- `pnpm test:affected:plan -- origin/milestone/11`
- `MULDER_TEST_ISOLATED_DB=true pnpm test:affected -- origin/milestone/11 -- --reporter=verbose`
