### PR TITLE
CI: use affected checks for milestone pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
         run: pnpm typecheck
 
   health:
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/'))) && (needs.pr-affected-plan.outputs.has_schema == 'true' || needs.pr-affected-plan.outputs.has_db == 'true' || needs.pr-affected-plan.outputs.has_heavy == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: build
+    needs: [build, pr-affected-plan]
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -159,11 +159,11 @@ jobs:
           if-no-files-found: ignore
 
   pr-affected-plan:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/'))
     name: affected plan
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build, health]
+    needs: build
     outputs:
       has_schema: ${{ steps.plan.outputs.has_schema }}
       has_db: ${{ steps.plan.outputs.has_db }}
@@ -189,8 +189,15 @@ jobs:
       - name: Build affected plan
         id: plan
         run: |
-          node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} --json > .test-results/affected-plan.json
-          node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-plan.txt
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          node scripts/test-lanes.mjs affected-plan "$BASE_REF" --json > .test-results/affected-plan.json
+          node scripts/test-lanes.mjs affected-plan "$BASE_REF" | tee .test-results/affected-plan.txt
           node <<'NODE'
           const fs = require('node:fs');
           const plan = JSON.parse(fs.readFileSync('.test-results/affected-plan.json', 'utf8'));
@@ -212,7 +219,7 @@ jobs:
           if-no-files-found: ignore
 
   pr-affected-schema:
-    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_schema == 'true'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/'))) && needs.pr-affected-plan.outputs.has_schema == 'true'
     name: affected schema
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -267,13 +274,29 @@ jobs:
         run: mkdir -p .test-results
 
       - name: Show affected schema plan
-        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-schema-plan.txt
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          node scripts/test-lanes.mjs affected-plan "$BASE_REF" | tee .test-results/affected-schema-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
           MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected schema tests
-        run: pnpm test:affected:lane -- schema origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-schema-junit.xml
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          pnpm test:affected:lane -- schema "$BASE_REF" -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-schema-junit.xml
         env:
           NODE_ENV: test
           PGHOST: localhost
@@ -294,7 +317,7 @@ jobs:
           if-no-files-found: ignore
 
   pr-affected-db:
-    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_db == 'true'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/'))) && needs.pr-affected-plan.outputs.has_db == 'true'
     name: affected db (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -354,13 +377,29 @@ jobs:
         run: mkdir -p .test-results
 
       - name: Show affected db plan
-        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-db-${{ matrix.shard_index }}-plan.txt
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          node scripts/test-lanes.mjs affected-plan "$BASE_REF" | tee .test-results/affected-db-${{ matrix.shard_index }}-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
           MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected db tests
-        run: pnpm test:affected:lane -- db ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-db-${{ matrix.shard_index }}-junit.xml
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          pnpm test:affected:lane -- db ${{ matrix.shard_index }} ${{ matrix.shard_total }} "$BASE_REF" -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-db-${{ matrix.shard_index }}-junit.xml
         env:
           NODE_ENV: test
           PGHOST: localhost
@@ -381,7 +420,7 @@ jobs:
           if-no-files-found: ignore
 
   pr-affected-heavy:
-    if: github.event_name == 'pull_request' && needs.pr-affected-plan.outputs.has_heavy == 'true'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/'))) && needs.pr-affected-plan.outputs.has_heavy == 'true'
     name: affected heavy (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -441,13 +480,29 @@ jobs:
         run: mkdir -p .test-results
 
       - name: Show affected heavy plan
-        run: node scripts/test-lanes.mjs affected-plan origin/${{ github.base_ref }} | tee .test-results/affected-heavy-${{ matrix.shard_index }}-plan.txt
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          node scripts/test-lanes.mjs affected-plan "$BASE_REF" | tee .test-results/affected-heavy-${{ matrix.shard_index }}-plan.txt
         env:
           MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"
           MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"
 
       - name: Run affected heavy tests
-        run: pnpm test:affected:lane -- heavy ${{ matrix.shard_index }} ${{ matrix.shard_total }} origin/${{ github.base_ref }} -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-heavy-${{ matrix.shard_index }}-junit.xml
+        run: |
+          BASE_REF="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          fi
+          if [ -z "$BASE_REF" ] || printf '%s' "$BASE_REF" | grep -Eq '^0+$'; then
+            BASE_REF="HEAD~1"
+          fi
+          pnpm test:affected:lane -- heavy ${{ matrix.shard_index }} ${{ matrix.shard_total }} "$BASE_REF" -- --reporter=verbose --reporter=junit --outputFile.junit=.test-results/affected-heavy-${{ matrix.shard_index }}-junit.xml
         env:
           NODE_ENV: test
           PGHOST: localhost
@@ -468,15 +523,16 @@ jobs:
           if-no-files-found: ignore
 
   pr-affected-tests:
-    if: always() && github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/milestone/')))
     name: affected tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [pr-affected-plan, pr-affected-schema, pr-affected-db, pr-affected-heavy]
+    needs: [pr-affected-plan, health, pr-affected-schema, pr-affected-db, pr-affected-heavy]
     steps:
       - name: Check affected lane results
         run: |
           echo "plan: ${{ needs.pr-affected-plan.result }}"
+          echo "health: ${{ needs.health.result }}"
           echo "schema: ${{ needs.pr-affected-schema.result }}"
           echo "db: ${{ needs.pr-affected-db.result }}"
           echo "heavy: ${{ needs.pr-affected-heavy.result }}"
@@ -485,7 +541,7 @@ jobs:
             exit 1
           fi
 
-          for result in "${{ needs.pr-affected-schema.result }}" "${{ needs.pr-affected-db.result }}" "${{ needs.pr-affected-heavy.result }}"; do
+          for result in "${{ needs.health.result }}" "${{ needs.pr-affected-schema.result }}" "${{ needs.pr-affected-db.result }}" "${{ needs.pr-affected-heavy.result }}"; do
             case "$result" in
               success|skipped)
                 ;;
@@ -496,7 +552,7 @@ jobs:
           done
 
   full-schema-tests:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/milestone/'))
     name: schema tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -571,7 +627,7 @@ jobs:
           if-no-files-found: ignore
 
   full-db-tests:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/milestone/'))
     name: db tests (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -651,7 +707,7 @@ jobs:
           if-no-files-found: ignore
 
   full-heavy-tests:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/milestone/'))
     name: heavy tests (${{ matrix.shard_index }}/${{ matrix.shard_total }})
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/docs/specs/59_hermetic_test_infrastructure.spec.md
+++ b/docs/specs/59_hermetic_test_infrastructure.spec.md
@@ -38,7 +38,7 @@ Close the remaining test-infrastructure gaps tracked by Issue `#143` after the e
 5. **`tests/specs/20_fixture_generator.test.ts`** — split deterministic fixture-generator checks from real-GCP checks and gate the credential-dependent cases behind `MULDER_TEST_GCP=true`
 6. **`tests/specs/47_document_ai_extraction.test.ts`** — normalize the real-GCP gate to `MULDER_TEST_GCP=true` while preserving compatibility with the legacy env name during transition
 7. **`package.json`** — add dedicated test scripts for the Spec 44 health lane and the opt-in GCP lane
-8. **`.github/workflows/ci.yml`** — run the Spec 44 health check as an explicit CI step before the broader test suite
+8. **`.github/workflows/ci.yml`** — run the Spec 44 health check as an explicit CI step before affected DB/schema/heavy lanes, keep milestone-branch pushes on affected testing, and reserve full schema/db/heavy suites for default-branch or manual full gates
 9. **`.github/workflows/gcp-tests.yml`** — add a separate manual/scheduled workflow for credentialed GCP black-box tests
 
 ### 4.2 Database Changes
@@ -55,7 +55,8 @@ None in repository config files. CI/workflow env changes only:
 ### 4.4 Integration Points
 
 - DB-backed suites share one defensive cleanup path from `tests/lib/schema.ts`
-- Spec 44 becomes a named, first-class CI health indicator via a dedicated script and workflow step
+- Spec 44 becomes a named, first-class CI health indicator via a dedicated script and workflow step when affected testing selects data-backed lanes
+- Milestone-branch pushes use affected planning against the pushed range, including docs-only short-circuiting, so integration commits do not run unrelated full DB/heavy suites
 - Credentialed test workflows run separately from the default CI lane and enable the GCP-gated suites with one env variable
 
 ### 4.5 Implementation Phases
@@ -71,7 +72,8 @@ None in repository config files. CI/workflow env changes only:
 
 **Phase 3: CI health and opt-in workflow wiring**
 - add package scripts for the Spec 44 health lane and GCP lane
-- update `ci.yml` to run Spec 44 explicitly
+- update `ci.yml` to run Spec 44 explicitly before affected data-backed lanes
+- keep milestone-branch push CI on affected lanes while full schema/db/heavy suites remain default-branch/manual gates
 - add a separate manual/scheduled workflow for the real-GCP suites
 
 ## 5. QA Contract
@@ -96,10 +98,10 @@ None in repository config files. CI/workflow env changes only:
    - When: the GCP black-box lane runs
    - Then: the credential-dependent cases in the fixture-generator and Document AI suites execute under the same env gate
 
-5. **QA-05: Spec 44 is a named CI health signal**
-   - Given: the default GitHub Actions CI workflow for pull requests
+5. **QA-05: CI separates affected integration feedback from full gates**
+   - Given: the default GitHub Actions CI workflow for pull requests and milestone-branch pushes
    - When: the test job reaches the verification phase
-   - Then: Spec 44 runs as an explicit health-check step before the broader suite, and a separate workflow exists for manual/scheduled GCP tests
+   - Then: affected planning runs before DB-backed checks, Spec 44 runs only when affected lanes select schema/db/heavy tests, milestone pushes do not trigger full schema/db/heavy suites, and a separate workflow exists for manual/scheduled GCP tests
 
 ## 5b. CLI Test Matrix
 

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -141,17 +141,26 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		const gcpWorkflow = readFileSync(GCP_WORKFLOW, 'utf-8');
 
 		expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
+		expect(ciWorkflow).toContain("startsWith(github.ref, 'refs/heads/milestone/')");
 		expect(ciWorkflow).toContain('pr-affected-plan');
 		expect(ciWorkflow).toContain('pr-affected-schema');
 		expect(ciWorkflow).toContain('pr-affected-db');
 		expect(ciWorkflow).toContain('pr-affected-heavy');
 		expect(ciWorkflow).toContain('pr-affected-tests');
 		expect(ciWorkflow).toContain('Check affected lane results');
+		expect(ciWorkflow).toContain('needs: build');
+		expect(ciWorkflow).toContain('needs: [build, pr-affected-plan]');
+		expect(ciWorkflow).toContain(
+			'needs: [pr-affected-plan, health, pr-affected-schema, pr-affected-db, pr-affected-heavy]',
+		);
+		expect(ciWorkflow).toContain(['echo "health: $', '{{ needs.health.result }}"'].join(''));
+		expect(ciWorkflow).not.toContain('needs: [build, health]');
 		expect(ciWorkflow).toContain('full-schema-tests');
 		expect(ciWorkflow).toContain('full-db-tests');
 		expect(ciWorkflow).toContain('full-heavy-tests');
 		expect(ciWorkflow).toContain('full-external-tests');
-		expect(ciWorkflow).toContain('affected-plan origin/');
+		expect(ciWorkflow).toContain(['BASE_REF="$', '{{ github.event.before }}"'].join(''));
+		expect(ciWorkflow).toContain(['BASE_REF="origin/$', '{{ github.base_ref }}"'].join(''));
 		expect(ciWorkflow).toContain('--json > .test-results/affected-plan.json');
 		expect(ciWorkflow).toContain('pnpm test:affected:lane -- schema');
 		expect(ciWorkflow).toContain('pnpm test:affected:lane -- db');
@@ -159,9 +168,13 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		expect(ciWorkflow).toContain('pnpm test:lane -- schema');
 		expect(ciWorkflow).toContain('pnpm test:lane -- db');
 		expect(ciWorkflow).toContain('pnpm test:lane -- heavy');
+		expect(ciWorkflow).toContain(
+			"if: github.event_name != 'pull_request' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/milestone/'))",
+		);
 		expect(ciWorkflow).toContain('Run E2E health check (Spec 44)');
 		expect(ciWorkflow).toContain('pnpm test:health');
 		expect(ciWorkflow).toContain('MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: "true"');
+		expect(ciWorkflow).toContain('MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: "true"');
 		expect(gcpWorkflow).toContain('workflow_dispatch');
 		expect(gcpWorkflow).toContain('schedule:');
 	});


### PR DESCRIPTION
## Summary
- run affected planning on milestone branch pushes instead of full schema/db/heavy suites
- gate Spec 44 health after affected planning, only when schema/db/heavy lanes are selected
- document and test the CI contract in Spec 59

## Verification
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/ci.yml
- git diff --check
- node scripts/test-lanes.mjs affected-plan --changed-file .github/workflows/ci.yml --changed-file tests/specs/59_hermetic_test_infrastructure.test.ts --changed-file docs/specs/59_hermetic_test_infrastructure.spec.md
- MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY=true MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES=docs/roadmap.md node scripts/test-lanes.mjs affected-plan origin/milestone/11
- npx biome check tests/specs/59_hermetic_test_infrastructure.test.ts
- pnpm exec vitest run tests/specs/59_hermetic_test_infrastructure.test.ts -t QA-05 --reporter=verbose
- pnpm test:affected:plan -- origin/milestone/11