### PR TITLE
M11-L5 RBAC implementation

### DIFF
--- a/apps/api/src/lib/documents.ts
+++ b/apps/api/src/lib/documents.ts
@@ -1,5 +1,6 @@
 import { performance } from 'node:perf_hooks';
 import {
+	type AccessPrincipal,
 	countProcessedSources,
 	countSources,
 	createChildLogger,
@@ -24,6 +25,7 @@ import {
 	type PipelineRun,
 	type PipelineRunSource,
 	presentCorroborationScore,
+	resolveAccessPolicy,
 	type Services,
 	type Source,
 	type SourceFilter,
@@ -31,6 +33,7 @@ import {
 	type Story,
 } from '@mulder/core';
 import type pg from 'pg';
+import type { AuthPrincipal } from '../middleware/auth.js';
 import type {
 	DocumentArtifact,
 	DocumentListItem,
@@ -47,6 +50,10 @@ import { PIPELINE_STEP_VALUES } from '../routes/pipeline.schemas.js';
 interface DocumentContext {
 	config: MulderConfig;
 	pool: pg.Pool;
+}
+
+interface RouteAccessOptions {
+	authPrincipal?: AuthPrincipal;
 }
 
 const DOCUMENT_NOT_FOUND_CODE = 'DOCUMENT_NOT_FOUND';
@@ -95,6 +102,29 @@ function resolveContext(): DocumentContext {
 	cachedConfigPath = configPath;
 
 	return cachedContext;
+}
+
+function mapAuthPrincipal(principal: AuthPrincipal | undefined): AccessPrincipal {
+	if (!principal) {
+		return { kind: 'service' };
+	}
+	if (principal.type === 'api_key') {
+		return { kind: 'api_key' };
+	}
+	return {
+		kind: 'browser_session',
+		browserRole: principal.role,
+	};
+}
+
+function resolveReadMaxSensitivity(config: MulderConfig, authPrincipal: AuthPrincipal | undefined) {
+	const policy = resolveAccessPolicy(config, mapAuthPrincipal(authPrincipal));
+	if (!policy.permissions.includes('read') && !policy.permissions.includes('admin')) {
+		throw new MulderError('The current principal cannot read documents', 'AUTH_FORBIDDEN', {
+			context: { principal_kind: policy.principalKind },
+		});
+	}
+	return policy.enabled ? policy.maxSensitivityLevel : undefined;
 }
 
 function toIsoString(value: Date): string {
@@ -737,7 +767,11 @@ async function resolveObservabilityState(
 	};
 }
 
-async function buildDocumentObservabilityResponse(id: string, logger: Logger): Promise<DocumentObservabilityResponse> {
+async function buildDocumentObservabilityResponse(
+	id: string,
+	logger: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentObservabilityResponse> {
 	const requestLogger = createRouteLogger(logger, {
 		action: 'observability',
 		source_id: id,
@@ -745,12 +779,13 @@ async function buildDocumentObservabilityResponse(id: string, logger: Logger): P
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	const source = await requireSource(pool, id);
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
+	const source = await requireSource(pool, id, maxSensitivityLevel);
 
 	const [sourceProjectionRecord, sourceSteps, stories, observabilityState] = await Promise.all([
 		services.firestore.getDocument('documents', id),
 		findSourceSteps(pool, id),
-		findStoriesBySourceId(pool, id),
+		findStoriesBySourceId(pool, id, { maxSensitivityLevel }),
 		resolveObservabilityState(pool, id),
 	]);
 
@@ -814,8 +849,12 @@ function notFoundError(message: string, context: Record<string, unknown>): Mulde
 	return new MulderError(message, DOCUMENT_NOT_FOUND_CODE, { context });
 }
 
-async function requireSource(pool: pg.Pool, id: string): Promise<Source> {
-	const source = await findSourceById(pool, id);
+async function requireSource(
+	pool: pg.Pool,
+	id: string,
+	maxSensitivityLevel?: Source['sensitivityLevel'],
+): Promise<Source> {
+	const source = await findSourceById(pool, id, { maxSensitivityLevel });
 	if (!source) {
 		throw notFoundError(`Document not found: ${id}`, { id });
 	}
@@ -878,7 +917,11 @@ async function loadArtifactBytes(
 	return await services.storage.download(artifact.storage_path);
 }
 
-async function buildDocumentListResponse(input: DocumentListQuery, logger: Logger): Promise<DocumentListResponse> {
+async function buildDocumentListResponse(
+	input: DocumentListQuery,
+	logger: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentListResponse> {
 	const requestLogger = createRouteLogger(logger, {
 		action: 'list',
 		status: input.status ?? null,
@@ -888,11 +931,13 @@ async function buildDocumentListResponse(input: DocumentListQuery, logger: Logge
 	});
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
 	const filter: SourceFilter = {
 		status: input.status,
 		search: input.search,
 		limit: input.limit,
 		offset: input.offset,
+		maxSensitivityLevel,
 	};
 	const startedAt = performance.now();
 
@@ -929,9 +974,13 @@ async function buildDocumentListResponse(input: DocumentListQuery, logger: Logge
 	return response;
 }
 
-export async function listDocuments(input: DocumentListQuery, logger?: Logger): Promise<DocumentListResponse> {
+export async function listDocuments(
+	input: DocumentListQuery,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentListResponse> {
 	const rootLogger = logger ?? createLogger();
-	return await buildDocumentListResponse(input, rootLogger);
+	return await buildDocumentListResponse(input, rootLogger, options);
 }
 
 async function loadStoryMarkdown(services: Services, story: Story): Promise<string> {
@@ -948,7 +997,11 @@ async function loadStoryMarkdown(services: Services, story: Story): Promise<stri
 	return buffer.toString('utf-8');
 }
 
-export async function getDocumentStories(id: string, logger?: Logger): Promise<DocumentStoriesResponse> {
+export async function getDocumentStories(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentStoriesResponse> {
 	const rootLogger = logger ?? createLogger();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stories',
@@ -957,8 +1010,9 @@ export async function getDocumentStories(id: string, logger?: Logger): Promise<D
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	const source = await requireSource(pool, id);
-	const stories = await findStoriesBySourceId(pool, source.id);
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
+	const source = await requireSource(pool, id, maxSensitivityLevel);
+	const stories = await findStoriesBySourceId(pool, source.id, { maxSensitivityLevel });
 	const corpusSize = await countProcessedSources(pool);
 	const entityPresentation = {
 		corpusSize,
@@ -969,7 +1023,7 @@ export async function getDocumentStories(id: string, logger?: Logger): Promise<D
 		stories.map(async (story): Promise<DocumentStoryResponse> => {
 			const [markdown, entities] = await Promise.all([
 				loadStoryMarkdown(services, story),
-				findEntitiesByStoryId(pool, story.id),
+				findEntitiesByStoryId(pool, story.id, { maxSensitivityLevel }),
 			]);
 
 			return {
@@ -1011,12 +1065,16 @@ export async function getDocumentStories(id: string, logger?: Logger): Promise<D
 	return response;
 }
 
-export async function getDocumentObservability(id: string, logger?: Logger): Promise<DocumentObservabilityResponse> {
+export async function getDocumentObservability(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentObservabilityResponse> {
 	const rootLogger = logger ?? createLogger();
-	return await buildDocumentObservabilityResponse(id, rootLogger);
+	return await buildDocumentObservabilityResponse(id, rootLogger, options);
 }
 
-export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Response> {
+export async function streamDocumentPdf(id: string, logger?: Logger, options?: RouteAccessOptions): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
@@ -1026,7 +1084,7 @@ export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Re
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	const source = await requireSource(pool, id);
+	const source = await requireSource(pool, id, resolveReadMaxSensitivity(config, options?.authPrincipal));
 	const artifact = buildPdfArtifact(source);
 	const buffer = await loadArtifactBytes(services, artifact, id, 'PDF');
 
@@ -1048,7 +1106,11 @@ export async function streamDocumentPdf(id: string, logger?: Logger): Promise<Re
 	});
 }
 
-export async function streamDocumentLayout(id: string, logger?: Logger): Promise<Response> {
+export async function streamDocumentLayout(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
@@ -1058,7 +1120,7 @@ export async function streamDocumentLayout(id: string, logger?: Logger): Promise
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	const source = await requireSource(pool, id);
+	const source = await requireSource(pool, id, resolveReadMaxSensitivity(config, options?.authPrincipal));
 	const artifact = buildLayoutArtifact(source);
 	const buffer = await loadArtifactBytes(services, artifact, id, 'layout.md');
 
@@ -1079,7 +1141,11 @@ export async function streamDocumentLayout(id: string, logger?: Logger): Promise
 	});
 }
 
-export async function listDocumentPages(id: string, logger?: Logger): Promise<DocumentPagesResponse> {
+export async function listDocumentPages(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<DocumentPagesResponse> {
 	const rootLogger = logger ?? createLogger();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'pages',
@@ -1089,7 +1155,7 @@ export async function listDocumentPages(id: string, logger?: Logger): Promise<Do
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	await requireSource(pool, id);
+	await requireSource(pool, id, resolveReadMaxSensitivity(config, options?.authPrincipal));
 	const pages = await listPageArtifacts(services, id);
 
 	const response: DocumentPagesResponse = {
@@ -1113,7 +1179,12 @@ export async function listDocumentPages(id: string, logger?: Logger): Promise<Do
 	return response;
 }
 
-export async function streamDocumentPage(id: string, pageNumber: number, logger?: Logger): Promise<Response> {
+export async function streamDocumentPage(
+	id: string,
+	pageNumber: number,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<Response> {
 	const rootLogger = logger ?? createLogger();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'stream',
@@ -1124,7 +1195,7 @@ export async function streamDocumentPage(id: string, pageNumber: number, logger?
 	const { config, pool } = resolveContext();
 	const services = createServiceRegistry(config, requestLogger);
 	const startedAt = performance.now();
-	const source = await requireSource(pool, id);
+	const source = await requireSource(pool, id, resolveReadMaxSensitivity(config, options?.authPrincipal));
 	const artifact = buildPageArtifact(source.id, pageNumber);
 	const buffer = await loadArtifactBytes(services, artifact, id, `page ${pageNumber}`);
 

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -266,7 +266,7 @@ export async function getEntityDetail(
 
 	const entity = await requireEntityById(pool, id, maxSensitivityLevel);
 	const [aliases, stories, mergedEntities, corroborationContext] = await Promise.all([
-		findAliasesByEntityId(pool, id),
+		findAliasesByEntityId(pool, id, { maxSensitivityLevel }),
 		findStoriesByEntityId(pool, id, { maxSensitivityLevel }),
 		findEntitiesByCanonicalId(pool, id, { maxSensitivityLevel }),
 		loadCorroborationContext(pool, config),

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -1,5 +1,6 @@
 import { performance } from 'node:perf_hooks';
 import {
+	type AccessPrincipal,
 	type CorroborationPresentationContext,
 	countEntities,
 	countProcessedSources,
@@ -25,8 +26,10 @@ import {
 	MulderError,
 	mergeEntities as mergeEntitiesRepository,
 	presentCorroborationScore,
+	resolveAccessPolicy,
 } from '@mulder/core';
 import type pg from 'pg';
+import type { AuthPrincipal } from '../middleware/auth.js';
 import type {
 	EntityAliasResponse,
 	EntityDetailResponse,
@@ -46,6 +49,10 @@ type CoreEntityEdge = EntityEdge;
 interface EntityContext {
 	config: MulderConfig;
 	pool: pg.Pool;
+}
+
+interface RouteAccessOptions {
+	authPrincipal?: AuthPrincipal;
 }
 
 let cachedContext: EntityContext | null = null;
@@ -81,6 +88,29 @@ function resolveContext(): EntityContext {
 	cachedConfigPath = configPath;
 
 	return cachedContext;
+}
+
+function mapAuthPrincipal(principal: AuthPrincipal | undefined): AccessPrincipal {
+	if (!principal) {
+		return { kind: 'service' };
+	}
+	if (principal.type === 'api_key') {
+		return { kind: 'api_key' };
+	}
+	return {
+		kind: 'browser_session',
+		browserRole: principal.role,
+	};
+}
+
+function resolveReadMaxSensitivity(config: MulderConfig, authPrincipal: AuthPrincipal | undefined) {
+	const policy = resolveAccessPolicy(config, mapAuthPrincipal(authPrincipal));
+	if (!policy.permissions.includes('read') && !policy.permissions.includes('admin')) {
+		throw new MulderError('The current principal cannot read entities', 'AUTH_FORBIDDEN', {
+			context: { principal_kind: policy.principalKind },
+		});
+	}
+	return policy.enabled ? policy.maxSensitivityLevel : undefined;
 }
 
 function mapEntity(entity: CoreEntity, corroborationContext: CorroborationPresentationContext): EntityResponse {
@@ -144,8 +174,12 @@ function mapEdge(edge: CoreEntityEdge): EntityEdgeResponse {
 	};
 }
 
-async function requireEntityById(pool: pg.Pool, id: string): Promise<CoreEntity> {
-	const entity = await findEntityById(pool, id);
+async function requireEntityById(
+	pool: pg.Pool,
+	id: string,
+	maxSensitivityLevel?: CoreEntity['sensitivityLevel'],
+): Promise<CoreEntity> {
+	const entity = await findEntityById(pool, id, { maxSensitivityLevel });
 	if (!entity) {
 		throw new DatabaseError(`Entity not found: ${id}`, DATABASE_ERROR_CODES.DB_NOT_FOUND, {
 			context: { id },
@@ -163,7 +197,11 @@ function createRouteLogger(rootLogger: Logger, metadata: Record<string, string |
 	});
 }
 
-export async function listEntities(input: EntityListQuery, logger?: Logger): Promise<EntityListResponse> {
+export async function listEntities(
+	input: EntityListQuery,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<EntityListResponse> {
 	const rootLogger = logger ?? createLogger();
 	const { config, pool } = resolveContext();
 	const requestLogger = createRouteLogger(rootLogger, {
@@ -175,6 +213,7 @@ export async function listEntities(input: EntityListQuery, logger?: Logger): Pro
 		offset: input.offset,
 	});
 	const startedAt = performance.now();
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
 
 	const filter: EntityFilter = {
 		type: input.type,
@@ -182,6 +221,7 @@ export async function listEntities(input: EntityListQuery, logger?: Logger): Pro
 		taxonomyStatus: input.taxonomy_status,
 		limit: input.limit,
 		offset: input.offset,
+		maxSensitivityLevel,
 	};
 
 	const [count, entities, corroborationContext] = await Promise.all([
@@ -210,7 +250,11 @@ export async function listEntities(input: EntityListQuery, logger?: Logger): Pro
 	return response;
 }
 
-export async function getEntityDetail(id: string, logger?: Logger): Promise<EntityDetailResponse> {
+export async function getEntityDetail(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<EntityDetailResponse> {
 	const rootLogger = logger ?? createLogger();
 	const { config, pool } = resolveContext();
 	const requestLogger = createRouteLogger(rootLogger, {
@@ -218,12 +262,13 @@ export async function getEntityDetail(id: string, logger?: Logger): Promise<Enti
 		entity_id: id,
 	});
 	const startedAt = performance.now();
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
 
-	const entity = await requireEntityById(pool, id);
+	const entity = await requireEntityById(pool, id, maxSensitivityLevel);
 	const [aliases, stories, mergedEntities, corroborationContext] = await Promise.all([
 		findAliasesByEntityId(pool, id),
-		findStoriesByEntityId(pool, id),
-		findEntitiesByCanonicalId(pool, id),
+		findStoriesByEntityId(pool, id, { maxSensitivityLevel }),
+		findEntitiesByCanonicalId(pool, id, { maxSensitivityLevel }),
 		loadCorroborationContext(pool, config),
 	]);
 
@@ -249,17 +294,22 @@ export async function getEntityDetail(id: string, logger?: Logger): Promise<Enti
 	return response;
 }
 
-export async function getEntityEdges(id: string, logger?: Logger): Promise<EntityEdgesResponse> {
+export async function getEntityEdges(
+	id: string,
+	logger?: Logger,
+	options?: RouteAccessOptions,
+): Promise<EntityEdgesResponse> {
 	const rootLogger = logger ?? createLogger();
-	const { pool } = resolveContext();
+	const { config, pool } = resolveContext();
 	const requestLogger = createRouteLogger(rootLogger, {
 		action: 'edges',
 		entity_id: id,
 	});
 	const startedAt = performance.now();
+	const maxSensitivityLevel = resolveReadMaxSensitivity(config, options?.authPrincipal);
 
-	await requireEntityById(pool, id);
-	const edges = await findEdgesByEntityId(pool, id);
+	await requireEntityById(pool, id, maxSensitivityLevel);
+	const edges = await findEdgesByEntityId(pool, id, { maxSensitivityLevel });
 	const response: EntityEdgesResponse = {
 		data: edges.map(mapEdge),
 	};

--- a/apps/api/src/routes/documents.ts
+++ b/apps/api/src/routes/documents.ts
@@ -33,41 +33,45 @@ function readRequestLogger(c: Context) {
 	return c.get('requestContext')?.logger;
 }
 
+function readRouteOptions(c: Context) {
+	return { authPrincipal: c.get('authPrincipal') };
+}
+
 export function registerDocumentRoutes(app: Hono): void {
 	app.get('/api/documents', async (c) => {
 		const query = DocumentListQuerySchema.parse(readDocumentListQuery(c.req.url));
-		const response = await listDocuments(query, readRequestLogger(c));
+		const response = await listDocuments(query, readRequestLogger(c), readRouteOptions(c));
 		DocumentListResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 
 	app.get('/api/documents/:id/pdf', async (c) => {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
-		return await streamDocumentPdf(id, readRequestLogger(c));
+		return await streamDocumentPdf(id, readRequestLogger(c), readRouteOptions(c));
 	});
 
 	app.get('/api/documents/:id/layout', async (c) => {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
-		return await streamDocumentLayout(id, readRequestLogger(c));
+		return await streamDocumentLayout(id, readRequestLogger(c), readRouteOptions(c));
 	});
 
 	app.get('/api/documents/:id/pages', async (c) => {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
-		const response = await listDocumentPages(id, readRequestLogger(c));
+		const response = await listDocumentPages(id, readRequestLogger(c), readRouteOptions(c));
 		DocumentPagesResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 
 	app.get('/api/documents/:id/stories', async (c) => {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
-		const response = await getDocumentStories(id, readRequestLogger(c));
+		const response = await getDocumentStories(id, readRequestLogger(c), readRouteOptions(c));
 		DocumentStoriesResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 
 	app.get('/api/documents/:id/observability', async (c) => {
 		const { id } = DocumentParamsSchema.parse({ id: c.req.param('id') });
-		const response = await getDocumentObservability(id, readRequestLogger(c));
+		const response = await getDocumentObservability(id, readRequestLogger(c), readRouteOptions(c));
 		DocumentObservabilityResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
@@ -77,6 +81,6 @@ export function registerDocumentRoutes(app: Hono): void {
 			id: c.req.param('id'),
 			num: c.req.param('num'),
 		});
-		return await streamDocumentPage(id, num, readRequestLogger(c));
+		return await streamDocumentPage(id, num, readRequestLogger(c), readRouteOptions(c));
 	});
 }

--- a/apps/api/src/routes/entities.ts
+++ b/apps/api/src/routes/entities.ts
@@ -30,22 +30,26 @@ function readEntityListQuery(url: string): Record<string, string | undefined> {
 	};
 }
 
+function readRouteOptions(c: Context) {
+	return { authPrincipal: c.get('authPrincipal') };
+}
+
 export function registerEntityRoutes(app: Hono): void {
 	app.get('/api/entities', async (c) => {
 		const query = EntityListQuerySchema.parse(readEntityListQuery(c.req.url));
-		const response = await listEntities(query, c.get('requestContext')?.logger);
+		const response = await listEntities(query, c.get('requestContext')?.logger, readRouteOptions(c));
 		EntityListResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 
 	app.get('/api/entities/:id', async (c) => {
-		const response = await getEntityDetail(c.req.param('id'), c.get('requestContext')?.logger);
+		const response = await getEntityDetail(c.req.param('id'), c.get('requestContext')?.logger, readRouteOptions(c));
 		EntityDetailResponseSchema.parse(response);
 		return c.json(response, 200);
 	});
 
 	app.get('/api/entities/:id/edges', async (c) => {
-		const response = await getEntityEdges(c.req.param('id'), c.get('requestContext')?.logger);
+		const response = await getEntityEdges(c.req.param('id'), c.get('requestContext')?.logger, readRouteOptions(c));
 		EntityEdgesResponseSchema.parse(response);
 		return c.json(response, 200);
 	});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -313,7 +313,7 @@ Builds the trust infrastructure. Depends on M10 foundations (provenance, asserti
 | 🟢 | L2 | Contradiction management — ConflictNode entities, severity, resolution | §A9 |
 | 🟢 | L3 | Review workflow infrastructure — ReviewableArtifact, queues, events | §A13 |
 | 🟢 | L4 | Translation service — two paths, caching | §A7 |
-| ⚪ | L5 | RBAC implementation — roles, permissions, sensitivity-based filtering | §A5.3 |
+| 🟡 | L5 | RBAC implementation — roles, permissions, sensitivity-based filtering | §A5.3 |
 
 **Also read for all M11 steps:** §A3 (assertion types), §A5 (sensitivity)
 

--- a/docs/specs/03_config_loader.spec.md
+++ b/docs/specs/03_config_loader.spec.md
@@ -122,7 +122,7 @@ Relationship schema:
 
 ```typescript
 export function loadConfig(path?: string): MulderConfig {
-  // 1. Resolve path: argument > MULDER_CONFIG env var > ./mulder.config.yaml
+  // 1. Resolve path: argument > MULDER_CONFIG env var > ./mulder.config.yaml > ./mulder.config.example.yaml
   // 2. Read file (throw ConfigValidationError if not found)
   // 3. Parse YAML (throw ConfigValidationError if invalid YAML)
   // 4. Validate against mulderConfigSchema (Zod .parse())
@@ -137,6 +137,7 @@ Path resolution order:
 1. Explicit `path` argument
 2. `MULDER_CONFIG` environment variable
 3. `./mulder.config.yaml` (CWD)
+4. `./mulder.config.example.yaml` (CWD) when no local default config exists in a fresh checkout
 
 ### 4.5 `ConfigValidationError`
 
@@ -214,6 +215,7 @@ All conditions must pass for this step to be marked complete.
 - **Given** a path to a non-existent file
 - **When** `loadConfig("/does/not/exist.yaml")` is called
 - **Then** it throws `ConfigValidationError` (not a raw filesystem error)
+- **And** when `loadConfig()` or `loadConfig("mulder.config.yaml")` is called in a fresh checkout with no local default config, it loads the shipped `mulder.config.example.yaml`
 
 ### QA-08: MULDER_CONFIG environment variable
 - **Given** `MULDER_CONFIG` is set to a valid config file path

--- a/docs/specs/111_rbac_implementation.spec.md
+++ b/docs/specs/111_rbac_implementation.spec.md
@@ -1,0 +1,164 @@
+---
+spec: 111
+title: "RBAC Implementation"
+roadmap_step: "M11-L5"
+functional_spec: "§A5.3, §A5, §A3"
+scope: "phased"
+issue: "https://github.com/mulkatz/mulder/issues/293"
+created: 2026-05-07
+---
+
+# Spec 111: RBAC Implementation
+
+## 1. Objective
+
+Complete M11-L5 by turning the sensitivity metadata from M10-K5 into an enforceable role-based access layer. Mulder must resolve roles to permissions and maximum sensitivity levels, expose those roles through config and the database, and apply sensitivity filtering to read paths that return document, entity, and trust-layer artifacts.
+
+This step is an enforcement foundation, not a product-facing role administration UI. It keeps the core domain-agnostic: roles are generic policy objects (`id`, `name`, `max_sensitivity_level`, `permissions`) and existing browser roles are mapped onto that policy without hard-coding domain semantics.
+
+## 2. Boundaries
+
+**Roadmap step:** M11-L5 - RBAC implementation - roles, permissions, sensitivity-based filtering.
+
+**Base branch:** `milestone/11`. This spec is delivered to the M11 integration branch, not directly to `main`.
+
+**Target branch:** `feat/293-rbac-implementation`.
+
+**Primary files:**
+
+- `packages/core/src/shared/access-control.ts`
+- `packages/core/src/database/migrations/041_access_roles.sql`
+- `packages/core/src/database/repositories/access-role.repository.ts`
+- `packages/core/src/database/repositories/access-role.types.ts`
+- `packages/core/src/database/repositories/source.repository.ts`
+- `packages/core/src/database/repositories/source.types.ts`
+- `packages/core/src/database/repositories/entity.repository.ts`
+- `packages/core/src/database/repositories/entity.types.ts`
+- `packages/core/src/database/repositories/story.repository.ts`
+- `packages/core/src/database/repositories/story.types.ts`
+- `packages/core/src/database/repositories/conflict-node.repository.ts`
+- `packages/core/src/database/repositories/conflict-node.types.ts`
+- `packages/core/src/database/repositories/review-workflow.repository.ts`
+- `packages/core/src/database/repositories/review-workflow.types.ts`
+- `packages/core/src/database/repositories/translated-document.repository.ts`
+- `packages/core/src/database/repositories/translated-document.types.ts`
+- `packages/core/src/database/repositories/index.ts`
+- `packages/core/src/config/schema.ts`
+- `packages/core/src/config/defaults.ts`
+- `packages/core/src/config/types.ts`
+- `packages/core/src/index.ts`
+- `apps/api/src/middleware/auth.ts`
+- `apps/api/src/routes/documents.ts`
+- `apps/api/src/routes/entities.ts`
+- `apps/api/src/lib/documents.ts`
+- `apps/api/src/lib/entities.ts`
+- `mulder.config.example.yaml`
+- `tests/lib/schema.ts`
+- `tests/specs/111_rbac_implementation.test.ts`
+- `docs/roadmap.md`
+
+**In scope:**
+
+- Add role and permission primitives from §A5.3: `read`, `write`, `review`, `classify`, `delete`, `admin`, `export`, and `agent_config`.
+- Add default role definitions that work from config defaults and `mulder.config.example.yaml` without requiring a missing `config/roles.yaml`.
+- Add an `access_roles` table and repository APIs for listing, finding, and upserting role definitions.
+- Preserve existing browser roles by mapping `member` to analyst-level read access and `admin`/`owner` to confidential admin access.
+- Treat API-key principals as service/admin access for backward compatibility with existing CLI and automation paths.
+- Add repository filtering by `max_sensitivity_level` for sources, entities, stories, conflict nodes, review artifacts, and translations.
+- Apply read filtering in the document and entity API routes for browser session principals.
+
+**Out of scope:**
+
+- Role management UI, invitation-role redesign, multi-role memberships, organization/team hierarchies, or policy editing routes.
+- External query gate behavior from §A5.4. L5 must leave clean helpers for it, but query sanitization belongs to a later agent milestone.
+- Export filtering/audit from §A15 and agent web research filtering from §A16.
+- Rewriting existing API auth tables or breaking the `owner`/`admin`/`member` browser auth contract.
+
+**Architectural constraints:**
+
+- Sensitivity comparisons must use the canonical order `public < internal < restricted < confidential`.
+- Filtering must deny by default when access control is enabled and a role cannot be resolved.
+- Config defaults must be self-contained. `roles_source` may remain as future metadata, but runtime tests must not read a missing roles file.
+- Filtering must be explicit at read boundaries; write paths must continue to persist sensitivity metadata rather than dropping it.
+- API-key behavior must remain backward compatible unless a future spec introduces scoped API keys.
+
+## 3. Dependencies
+
+- M10-K5 / Spec 102: sensitivity levels and metadata exist on core artifacts.
+- M11-L1 / Spec 107: credibility profiles exist and are source-owned trust artifacts.
+- M11-L2 / Spec 108: conflict nodes carry sensitivity metadata.
+- M11-L3 / Spec 109: review artifacts and queues exist.
+- M11-L4 / Spec 110: translated documents carry sensitivity metadata.
+
+L5 completes the M11 trust-layer enforcement foundation and blocks later export filtering, external query gates, and agent research safety.
+
+## 4. Blueprint
+
+1. Add core access-control helpers:
+   - Define `AccessPermission`, `AccessRole`, `AccessPolicy`, `AccessPrincipalKind`, and default role definitions.
+   - Provide `resolveAccessPolicy`, `canReadSensitivityLevel`, `hasAccessPermission`, `allowedSensitivityLevelsForMax`, and browser-role mapping helpers.
+   - When `access_control.enabled` is false, return full read access for compatibility.
+
+2. Add config support:
+   - Extend `access_control.rbac` with a `roles` array matching §A5.3 while keeping `roles_source` and `default_role`.
+   - Populate defaults and example config with generic roles.
+   - Keep minimal configs valid when `access_control` is omitted.
+
+3. Add the `access_roles` data model:
+   - Create migration `041_access_roles.sql` with constrained sensitivity levels and permission values.
+   - Seed the generic default roles idempotently.
+   - Add repository APIs and exports for role listing and upsert.
+
+4. Add repository sensitivity filters:
+   - Add `maxSensitivityLevel` options to relevant filter types.
+   - Use allowed-level lists rather than lexical comparison.
+   - For review artifacts, filter on `context.sensitivity_level` with `internal` fallback until review artifacts get first-class sensitivity columns in a later spec.
+
+5. Apply API read filtering:
+   - Pass `authPrincipal` from document/entity routes into route libraries.
+   - Resolve a policy from full config and the principal.
+   - Filter list/detail/story/edge reads so browser members cannot read artifacts above their max sensitivity.
+   - Keep API keys as service-level access.
+
+6. Update roadmap state:
+   - Mark L5 in progress during implementation and complete only after verification, review, PR CI, and merge to `milestone/11`.
+
+## 5. QA Contract
+
+1. **QA-01: Role schema and defaults are self-contained**
+   - Given `mulder.config.example.yaml` and a minimal config without `access_control`
+   - When the config is loaded
+   - Then `access_control.rbac.roles` includes generic analyst/reviewer/admin roles with permissions and max sensitivity levels, and no missing roles file is read.
+
+2. **QA-02: Access helpers enforce the sensitivity lattice**
+   - Given a member/analyst policy with max `internal` and an admin policy with max `confidential`
+   - When sensitivity checks are evaluated for all four levels
+   - Then analyst can read only `public` and `internal`, while admin can read all levels.
+
+3. **QA-03: Roles persist and round-trip**
+   - Given the migrated database
+   - When default roles are listed and a custom role is upserted
+   - Then persisted roles preserve id, name, max sensitivity level, and permission set.
+
+4. **QA-04: Repository filters hide over-sensitive artifacts**
+   - Given sources, entities, stories, conflict nodes, review artifacts, and translated documents across sensitivity levels
+   - When queries are run with `maxSensitivityLevel = internal`
+   - Then restricted and confidential artifacts are omitted, while admin-level queries can see them.
+
+5. **QA-05: API routes apply session sensitivity filters**
+   - Given browser session principals mapped to member and admin roles
+   - When document and entity list/detail routes are requested
+   - Then member responses omit restricted/confidential artifacts and admin responses include them.
+
+6. **QA-06: Existing API-key behavior stays compatible**
+   - Given an API-key principal
+   - When the same filtered routes are requested
+   - Then the service policy can read confidential artifacts, preserving existing automation behavior.
+
+## 5b. CLI Test Matrix
+
+N/A - no CLI commands are added or changed in this step.
+
+## 6. Cost Considerations
+
+No paid services are introduced. The implementation is database/config/API logic only. Tests must avoid live GCP, Vertex, or external network calls and must use example/temp configs rather than a missing root `mulder.config.yaml`.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -33,6 +33,8 @@ pnpm test:affected -- origin/main -- --reporter=verbose
 
 The affected runner is intentionally explainable: `test:affected:plan` prints the changed files, the rule that matched each file, selected specs, lanes, and estimated weight. A normal feature PR should stay near 8-15 minutes; broad changes may use the parallel affected lane jobs and should still target 20 minutes. If an affected plan unexpectedly selects most of the suite for an ordinary feature change, refine the mapping before continuing feature work.
 
+For pull requests, a head commit that changes only Markdown documentation is treated as build/lint-only by the affected runner. Spec documents remain connected to their implementation tests for normal feature diffs, but docs-only follow-up commits must not wake DB/schema/heavy lanes by themselves.
+
 Use full lane runs when changing shared infrastructure, migrations, worker dispatch, storage, or pipeline orchestration:
 
 ```bash

--- a/mulder.config.example.yaml
+++ b/mulder.config.example.yaml
@@ -166,6 +166,42 @@ document_quality:
     notify_reviewers: false
     priority: "normal"
 
+# --- Access Control ---
+access_control:
+  enabled: true
+  sensitivity:
+    levels: ["public", "internal", "restricted", "confidential"]
+    default_level: "internal"
+    auto_detection: true
+    propagation: "upward"
+    pii_types:
+      - "person_name"
+      - "contact_info"
+      - "medical_data"
+      - "location_private"
+      - "location_sighting"
+      - "financial"
+      - "unpublished_research"
+      - "legal"
+  rbac:
+    roles_source: "config/roles.yaml" # Metadata only; defaults below are self-contained
+    default_role: "analyst"
+    roles:
+      - id: "analyst"
+        name: "Analyst"
+        max_sensitivity_level: "internal"
+        permissions: ["read"]
+      - id: "reviewer"
+        name: "Reviewer"
+        max_sensitivity_level: "restricted"
+        permissions: ["read", "review", "classify"]
+      - id: "admin"
+        name: "Administrator"
+        max_sensitivity_level: "confidential"
+        permissions: ["read", "write", "review", "classify", "delete", "admin", "export", "agent_config"]
+  external_query_gate:
+    enabled: false
+
 # --- Enrichment ---
 enrichment:
   model: "gemini-2.5-flash"

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -5,6 +5,7 @@
  * serves as documentation and test reference.
  */
 
+import { DEFAULT_ACCESS_ROLE_CONFIGS } from '../shared/access-control.js';
 import type { ApiConfig } from './types.js';
 
 const apiDefaults: ApiConfig = {
@@ -131,6 +132,7 @@ export const CONFIG_DEFAULTS = {
 		rbac: {
 			roles_source: 'config/roles.yaml',
 			default_role: 'analyst',
+			roles: [...DEFAULT_ACCESS_ROLE_CONFIGS],
 		},
 		external_query_gate: {
 			enabled: false,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -12,6 +12,7 @@ export { computeReprocessConfigHash, getReprocessConfigSubset } from './reproces
 export { mulderConfigSchema } from './schema.js';
 export type {
 	AccessControlConfig,
+	AccessControlRbacConfig,
 	AccessControlSensitivityConfig,
 	AnalysisConfig,
 	ApiAuthConfig,

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -3,8 +3,8 @@
  * Every CLI command and pipeline step calls loadConfig() as its first action.
  */
 
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { ZodError } from 'zod';
 import { ConfigValidationError } from './errors.js';
@@ -12,6 +12,7 @@ import { mulderConfigSchema } from './schema.js';
 import type { MulderConfig } from './types.js';
 
 const DEFAULT_CONFIG_FILENAME = 'mulder.config.yaml';
+const EXAMPLE_CONFIG_FILENAME = 'mulder.config.example.yaml';
 
 /**
  * Recursively freezes an object and all nested objects/arrays.
@@ -50,13 +51,14 @@ function formatZodPath(path: readonly PropertyKey[]): string {
  * Path resolution order:
  * 1. Explicit `path` argument
  * 2. `MULDER_CONFIG` environment variable
- * 3. `./mulder.config.yaml` (CWD)
+ * 3. `./mulder.config.yaml` (CWD), falling back to `./mulder.config.example.yaml`
+ *    when the local config is absent in a fresh checkout
  *
  * @throws {ConfigValidationError} on file not found, invalid YAML, or validation failure
  */
 export function loadConfig(path?: string): Readonly<MulderConfig> {
 	// 1. Resolve path
-	const configPath = resolve(path ?? process.env.MULDER_CONFIG ?? DEFAULT_CONFIG_FILENAME);
+	const configPath = resolveConfigPath(path);
 
 	// 2. Read file
 	let rawContent: string;
@@ -110,4 +112,26 @@ export function loadConfig(path?: string): Readonly<MulderConfig> {
 
 	// 5. Deep freeze the result
 	return deepFreeze(config);
+}
+
+function resolveConfigPath(path?: string): string {
+	if (path !== undefined) {
+		const configPath = resolve(path);
+		return basename(configPath) === DEFAULT_CONFIG_FILENAME ? resolveDefaultConfigPath(configPath) : configPath;
+	}
+	if (process.env.MULDER_CONFIG !== undefined) {
+		const configPath = resolve(process.env.MULDER_CONFIG);
+		return basename(configPath) === DEFAULT_CONFIG_FILENAME ? resolveDefaultConfigPath(configPath) : configPath;
+	}
+
+	return resolveDefaultConfigPath(resolve(DEFAULT_CONFIG_FILENAME));
+}
+
+function resolveDefaultConfigPath(defaultPath: string): string {
+	if (existsSync(defaultPath)) {
+		return defaultPath;
+	}
+
+	const examplePath = resolve(dirname(defaultPath), EXAMPLE_CONFIG_FILENAME);
+	return existsSync(examplePath) ? examplePath : defaultPath;
 }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { ACCESS_PERMISSIONS, DEFAULT_ACCESS_ROLE_CONFIGS } from '../shared/access-control.js';
 import { PII_TYPES, SENSITIVITY_LEVELS } from '../shared/sensitivity.js';
 
 /**
@@ -255,6 +256,14 @@ const documentQualitySchema = documentQualityObj.default(defaults(documentQualit
 // --- Access Control ---
 
 const piiTypeSchema = z.enum(PII_TYPES);
+const accessPermissionSchema = z.enum(ACCESS_PERMISSIONS);
+
+const accessRoleSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	max_sensitivity_level: sensitivityLevelSchema,
+	permissions: z.array(accessPermissionSchema).min(1),
+});
 
 const accessControlSensitivitySchema = z.object({
 	levels: z.array(sensitivityLevelSchema).default([...SENSITIVITY_LEVELS]),
@@ -267,6 +276,10 @@ const accessControlSensitivitySchema = z.object({
 const accessControlRbacSchema = z.object({
 	roles_source: z.string().min(1).default('config/roles.yaml'),
 	default_role: z.string().min(1).default('analyst'),
+	roles: z
+		.array(accessRoleSchema)
+		.min(1)
+		.default([...DEFAULT_ACCESS_ROLE_CONFIGS]),
 });
 
 const accessControlExternalQueryGateSchema = z.object({
@@ -792,6 +805,7 @@ export const mulderConfigSchema = baseMulderConfigSchema.superRefine((data, ctx)
 
 // Export section schemas for reuse
 export {
+	accessControlRbacSchema,
 	accessControlSchema,
 	accessControlSensitivitySchema,
 	analysisSchema,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -5,6 +5,7 @@
 
 import type { z } from 'zod';
 import type {
+	accessControlRbacSchema,
 	accessControlSchema,
 	accessControlSensitivitySchema,
 	analysisSchema,
@@ -53,6 +54,7 @@ import type {
 
 export type ProjectConfig = z.infer<typeof projectSchema>;
 export type AccessControlConfig = z.infer<typeof accessControlSchema>;
+export type AccessControlRbacConfig = z.infer<typeof accessControlRbacSchema>;
 export type AccessControlSensitivityConfig = z.infer<typeof accessControlSensitivitySchema>;
 export type ApiConfig = z.infer<typeof apiSchema>;
 export type ApiAuthKeyConfig = ApiConfig['auth']['api_keys'][number];

--- a/packages/core/src/database/migrations/041_access_roles.sql
+++ b/packages/core/src/database/migrations/041_access_roles.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS access_roles (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  max_sensitivity_level TEXT NOT NULL,
+  permissions TEXT[] NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT access_roles_id_required_check CHECK (length(trim(id)) > 0),
+  CONSTRAINT access_roles_name_required_check CHECK (length(trim(name)) > 0),
+  CONSTRAINT access_roles_max_sensitivity_level_check CHECK (
+    max_sensitivity_level IN ('public', 'internal', 'restricted', 'confidential')
+  ),
+  CONSTRAINT access_roles_permissions_allowed_check CHECK (
+    permissions <@ ARRAY['read','write','review','classify','delete','admin','export','agent_config']::TEXT[]
+  ),
+  CONSTRAINT access_roles_permissions_not_empty_check CHECK (cardinality(permissions) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_access_roles_max_sensitivity_level
+  ON access_roles(max_sensitivity_level);
+
+INSERT INTO access_roles (id, name, max_sensitivity_level, permissions)
+VALUES
+  ('analyst', 'Analyst', 'internal', ARRAY['read']::TEXT[]),
+  ('reviewer', 'Reviewer', 'restricted', ARRAY['read','review','classify']::TEXT[]),
+  ('admin', 'Administrator', 'confidential', ARRAY['read','write','review','classify','delete','admin','export','agent_config']::TEXT[])
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  max_sensitivity_level = EXCLUDED.max_sensitivity_level,
+  permissions = EXCLUDED.permissions,
+  updated_at = now();

--- a/packages/core/src/database/repositories/access-role.repository.ts
+++ b/packages/core/src/database/repositories/access-role.repository.ts
@@ -1,0 +1,89 @@
+import type pg from 'pg';
+import { ACCESS_PERMISSIONS, type AccessPermission } from '../../shared/access-control.js';
+import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
+import { isSensitivityLevel } from '../../shared/sensitivity.js';
+import type { PersistedAccessRole, UpsertAccessRoleInput } from './access-role.types.js';
+
+type Queryable = pg.Pool | pg.PoolClient;
+
+interface AccessRoleRow {
+	id: string;
+	name: string;
+	max_sensitivity_level: PersistedAccessRole['maxSensitivityLevel'];
+	permissions: string[] | null;
+	created_at: Date;
+	updated_at: Date;
+}
+
+function isAccessPermission(value: string): value is AccessPermission {
+	return ACCESS_PERMISSIONS.some((permission) => permission === value);
+}
+
+function normalizePermissions(permissions: readonly string[] | null): AccessPermission[] {
+	return [...new Set(permissions ?? [])].filter(isAccessPermission).sort((left, right) => left.localeCompare(right));
+}
+
+function mapAccessRoleRow(row: AccessRoleRow): PersistedAccessRole {
+	return {
+		id: row.id,
+		name: row.name,
+		maxSensitivityLevel: isSensitivityLevel(row.max_sensitivity_level) ? row.max_sensitivity_level : 'internal',
+		permissions: normalizePermissions(row.permissions),
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function listAccessRoles(pool: Queryable): Promise<PersistedAccessRole[]> {
+	try {
+		const result = await pool.query<AccessRoleRow>(
+			`
+				SELECT *
+				FROM access_roles
+				ORDER BY id ASC
+			`,
+		);
+		return result.rows.map(mapAccessRoleRow);
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to list access roles', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+		});
+	}
+}
+
+export async function findAccessRoleById(pool: Queryable, id: string): Promise<PersistedAccessRole | null> {
+	try {
+		const result = await pool.query<AccessRoleRow>('SELECT * FROM access_roles WHERE id = $1', [id]);
+		const row = result.rows[0];
+		return row ? mapAccessRoleRow(row) : null;
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to find access role by ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { id },
+		});
+	}
+}
+
+export async function upsertAccessRole(pool: Queryable, input: UpsertAccessRoleInput): Promise<PersistedAccessRole> {
+	try {
+		const result = await pool.query<AccessRoleRow>(
+			`
+				INSERT INTO access_roles (id, name, max_sensitivity_level, permissions)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT (id) DO UPDATE SET
+					name = EXCLUDED.name,
+					max_sensitivity_level = EXCLUDED.max_sensitivity_level,
+					permissions = EXCLUDED.permissions,
+					updated_at = now()
+				RETURNING *
+			`,
+			[input.id, input.name, input.maxSensitivityLevel, normalizePermissions(input.permissions)],
+		);
+		return mapAccessRoleRow(result.rows[0]);
+	} catch (error: unknown) {
+		throw new DatabaseError('Failed to upsert access role', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
+			cause: error,
+			context: { id: input.id },
+		});
+	}
+}

--- a/packages/core/src/database/repositories/access-role.types.ts
+++ b/packages/core/src/database/repositories/access-role.types.ts
@@ -1,0 +1,18 @@
+import type { AccessPermission } from '../../shared/access-control.js';
+import type { SensitivityLevel } from '../../shared/sensitivity.js';
+
+export interface PersistedAccessRole {
+	id: string;
+	name: string;
+	maxSensitivityLevel: SensitivityLevel;
+	permissions: AccessPermission[];
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export interface UpsertAccessRoleInput {
+	id: string;
+	name: string;
+	maxSensitivityLevel: SensitivityLevel;
+	permissions: AccessPermission[];
+}

--- a/packages/core/src/database/repositories/conflict-node.repository.ts
+++ b/packages/core/src/database/repositories/conflict-node.repository.ts
@@ -1,4 +1,5 @@
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import {
 	mergeSensitivityMetadata,
@@ -555,6 +556,10 @@ export async function listConflictNodes(pool: Queryable, options?: ConflictNodeL
 			SELECT 1 FROM conflict_assertions ca_filter
 			WHERE ca_filter.conflict_id = cn.id AND ca_filter.source_document_id = $${params.length}
 		)`);
+	}
+	if (options?.maxSensitivityLevel) {
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		filters.push(`cn.sensitivity_level = ANY($${params.length})`);
 	}
 	const limit = options?.limit ?? 100;
 	const offset = options?.offset ?? 0;

--- a/packages/core/src/database/repositories/conflict-node.types.ts
+++ b/packages/core/src/database/repositories/conflict-node.types.ts
@@ -97,6 +97,7 @@ export interface ConflictNodeListOptions {
 	resolutionStatus?: ConflictResolutionStatus;
 	sourceDocumentId?: string;
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/packages/core/src/database/repositories/edge.repository.ts
+++ b/packages/core/src/database/repositories/edge.repository.ts
@@ -12,6 +12,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -334,18 +335,28 @@ export async function findEdgesByTargetEntityId(
 export async function findEdgesByEntityId(
 	pool: pg.Pool,
 	entityId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: EntityEdge['sensitivityLevel'] },
 ): Promise<EntityEdge[]> {
+	const conditions = ['(ee.source_entity_id = $1 OR ee.target_entity_id = $1)'];
+	const params: unknown[] = [entityId];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push(edgeActiveSourceClause('ee'));
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`ee.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT ee.*
     FROM entity_edges ee
-    WHERE (ee.source_entity_id = $1 OR ee.target_entity_id = $1)
-      ${options?.includeDeleted ? '' : `AND ${edgeActiveSourceClause('ee')}`}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY ee.created_at
   `;
 
 	try {
-		const result = await pool.query<EdgeRow>(sql, [entityId]);
+		const result = await pool.query<EdgeRow>(sql, params);
 		return result.rows.map(mapEdgeRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find edges by entity ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -361,18 +372,28 @@ export async function findEdgesByEntityId(
 export async function findEdgesByStoryId(
 	pool: pg.Pool,
 	storyId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: EntityEdge['sensitivityLevel'] },
 ): Promise<EntityEdge[]> {
+	const conditions = ['ee.story_id = $1'];
+	const params: unknown[] = [storyId];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push(edgeActiveSourceClause('ee'));
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`ee.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT ee.*
     FROM entity_edges ee
-    WHERE ee.story_id = $1
-      ${options?.includeDeleted ? '' : `AND ${edgeActiveSourceClause('ee')}`}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY ee.created_at
   `;
 
 	try {
-		const result = await pool.query<EdgeRow>(sql, [storyId]);
+		const result = await pool.query<EdgeRow>(sql, params);
 		return result.rows.map(mapEdgeRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find edges by story ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -482,6 +503,11 @@ export async function findAllEdges(pool: pg.Pool, filter?: EdgeFilter): Promise<
 	if (!filter?.includeDeleted) {
 		conditions.push(edgeActiveSourceClause('ee'));
 	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`ee.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
+	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -505,6 +531,7 @@ export async function findAllEdges(pool: pg.Pool, filter?: EdgeFilter): Promise<
 export interface EdgeTypePageFilter {
 	edgeTypes: EdgeType[];
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: EntityEdge['sensitivityLevel'];
 	limit?: number;
 	offset?: number;
 }
@@ -519,17 +546,28 @@ export async function findAllEdgesByTypes(pool: pg.Pool, filter: EdgeTypePageFil
 
 	const limit = filter.limit ?? 100;
 	const offset = filter.offset ?? 0;
+	const conditions = ['ee.edge_type = ANY($1::text[])'];
+	const params: unknown[] = [filter.edgeTypes];
+	let paramIndex = 2;
+	if (!filter.includeDeleted) {
+		conditions.push(edgeActiveSourceClause('ee'));
+	}
+	if (filter.maxSensitivityLevel) {
+		conditions.push(`ee.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
+	}
+	params.push(limit, offset);
 	const sql = `
     SELECT ee.*
     FROM entity_edges ee
-    WHERE ee.edge_type = ANY($1::text[])
-      ${filter.includeDeleted ? '' : `AND ${edgeActiveSourceClause('ee')}`}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY ee.created_at ASC, ee.id ASC
-    LIMIT $2 OFFSET $3
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
   `;
 
 	try {
-		const result = await pool.query<EdgeRow>(sql, [filter.edgeTypes, limit, offset]);
+		const result = await pool.query<EdgeRow>(sql, params);
 		return result.rows.map(mapEdgeRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find edges by type list', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -608,6 +646,11 @@ export async function countEdges(pool: pg.Pool, filter?: EdgeFilter): Promise<nu
 	}
 	if (!filter?.includeDeleted) {
 		conditions.push(edgeActiveSourceClause('ee'));
+	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`ee.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
 	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/packages/core/src/database/repositories/edge.types.ts
+++ b/packages/core/src/database/repositories/edge.types.ts
@@ -80,6 +80,7 @@ export interface EdgeFilter {
 	storyId?: string;
 	relationship?: string;
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/packages/core/src/database/repositories/entity-alias.repository.ts
+++ b/packages/core/src/database/repositories/entity-alias.repository.ts
@@ -11,6 +11,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -21,7 +22,7 @@ import {
 } from './artifact-provenance.js';
 import { type EntityRow, entityActiveSourceClause, mapEntityRow } from './entity.repository.js';
 import type { CreateEntityAliasInput, Entity, EntityAlias } from './entity.types.js';
-import { queryWithSensitivityColumnFallback, queryWithSourceDeletionStatusFallback } from './schema-compat.js';
+import { queryWithSensitivityAndSourceDeletionFallback, queryWithSensitivityColumnFallback } from './schema-compat.js';
 
 const logger = createLogger();
 const repoLogger = createChildLogger(logger, { module: 'entity-alias-repository' });
@@ -131,28 +132,63 @@ export async function createEntityAlias(pool: pg.Pool, input: CreateEntityAliasI
 export async function findAliasesByEntityId(
 	pool: pg.Pool,
 	entityId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: EntityAlias['sensitivityLevel'] },
 ): Promise<EntityAlias[]> {
+	const activeVisibilityClause = options?.includeDeleted
+		? ''
+		: `AND ${aliasActiveSourceClause('ea')} AND ${entityActiveSourceClause('e')}`;
+	const sensitivityClause = options?.maxSensitivityLevel
+		? 'AND ea.sensitivity_level = ANY($2) AND e.sensitivity_level = ANY($2)'
+		: '';
 	const sql = `
-    SELECT ea.*
-    FROM entity_aliases ea
-    JOIN entities e ON e.id = ea.entity_id
-    WHERE ea.entity_id = $1
-      ${options?.includeDeleted ? '' : `AND ${aliasActiveSourceClause('ea')} AND ${entityActiveSourceClause('e')}`}
-    ORDER BY ea.alias
-  `;
+	    SELECT ea.*
+	    FROM entity_aliases ea
+	    JOIN entities e ON e.id = ea.entity_id
+	    WHERE ea.entity_id = $1
+	      ${activeVisibilityClause}
+	      ${sensitivityClause}
+	    ORDER BY ea.alias
+	  `;
 	const legacySql = `
-    SELECT ea.*
+	    SELECT ea.*
     FROM entity_aliases ea
     JOIN entities e ON e.id = ea.entity_id
-    WHERE ea.entity_id = $1
-    ORDER BY ea.alias
-  `;
+	    WHERE ea.entity_id = $1
+	    ORDER BY ea.alias
+	  `;
+	const withoutSourceDeletionSql = `
+	    SELECT ea.*
+	    FROM entity_aliases ea
+	    JOIN entities e ON e.id = ea.entity_id
+	    WHERE ea.entity_id = $1
+	      ${sensitivityClause}
+	    ORDER BY ea.alias
+	  `;
+	const withoutSensitivitySql = `
+	    SELECT ea.*
+	    FROM entity_aliases ea
+	    JOIN entities e ON e.id = ea.entity_id
+	    WHERE ea.entity_id = $1
+	      ${activeVisibilityClause}
+	    ORDER BY ea.alias
+	  `;
+	const params = options?.maxSensitivityLevel
+		? [entityId, allowedSensitivityLevelsForMax(options.maxSensitivityLevel)]
+		: [entityId];
+	const fallbackParams = [entityId];
 
 	try {
-		const result = await queryWithSourceDeletionStatusFallback<EntityAliasRow>(pool, sql, [entityId], legacySql, [
-			entityId,
-		]);
+		const result = await queryWithSensitivityAndSourceDeletionFallback<EntityAliasRow>(
+			pool,
+			sql,
+			params,
+			withoutSensitivitySql,
+			fallbackParams,
+			withoutSourceDeletionSql,
+			params,
+			legacySql,
+			fallbackParams,
+		);
 		return result.rows.map(mapEntityAliasRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find aliases by entity ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {

--- a/packages/core/src/database/repositories/entity.repository.ts
+++ b/packages/core/src/database/repositories/entity.repository.ts
@@ -11,6 +11,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -317,13 +318,23 @@ export async function upsertEntityByNameType(pool: pg.Pool, input: CreateEntityI
 export async function findEntityById(
 	pool: pg.Pool,
 	id: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: Entity['sensitivityLevel'] },
 ): Promise<Entity | null> {
+	const conditions = ['e.id = $1'];
+	const params: unknown[] = [id];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push(entityActiveSourceClause('e'));
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`e.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT e.*
     FROM entities e
-    WHERE e.id = $1
-      ${options?.includeDeleted ? '' : `AND ${entityActiveSourceClause('e')}`}
+    WHERE ${conditions.join(' AND ')}
   `;
 	const legacySql = `
     SELECT e.*
@@ -332,7 +343,7 @@ export async function findEntityById(
   `;
 
 	try {
-		const result = await queryWithSourceDeletionStatusFallback<EntityRow>(pool, sql, [id], legacySql, [id]);
+		const result = await queryWithSourceDeletionStatusFallback<EntityRow>(pool, sql, params, legacySql, [id]);
 		if (result.rows.length === 0) {
 			return null;
 		}
@@ -351,18 +362,28 @@ export async function findEntityById(
 export async function findEntitiesByType(
 	pool: pg.Pool,
 	type: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: Entity['sensitivityLevel'] },
 ): Promise<Entity[]> {
+	const conditions = ['e.type = $1'];
+	const params: unknown[] = [type];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push(entityActiveSourceClause('e'));
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`e.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT e.*
     FROM entities e
-    WHERE e.type = $1
-      ${options?.includeDeleted ? '' : `AND ${entityActiveSourceClause('e')}`}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY e.name
   `;
 
 	try {
-		const result = await pool.query<EntityRow>(sql, [type]);
+		const result = await pool.query<EntityRow>(sql, params);
 		return result.rows.map(mapEntityRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find entities by type', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -378,18 +399,28 @@ export async function findEntitiesByType(
 export async function findEntitiesByCanonicalId(
 	pool: pg.Pool,
 	canonicalId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: Entity['sensitivityLevel'] },
 ): Promise<Entity[]> {
+	const conditions = ['e.canonical_id = $1'];
+	const params: unknown[] = [canonicalId];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push(entityActiveSourceClause('e'));
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`e.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT e.*
     FROM entities e
-    WHERE e.canonical_id = $1
-      ${options?.includeDeleted ? '' : `AND ${entityActiveSourceClause('e')}`}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY e.name
   `;
 
 	try {
-		const result = await pool.query<EntityRow>(sql, [canonicalId]);
+		const result = await pool.query<EntityRow>(sql, params);
 		return result.rows.map(mapEntityRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find entities by canonical ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -435,6 +466,11 @@ export async function findAllEntities(pool: pg.Pool, filter?: EntityFilter): Pro
 	}
 	if (!filter?.includeDeleted) {
 		conditions.push(entityActiveSourceClause('e'));
+	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`e.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
 	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -489,6 +525,11 @@ export async function countEntities(pool: pg.Pool, filter?: EntityFilter): Promi
 	}
 	if (!filter?.includeDeleted) {
 		conditions.push(entityActiveSourceClause('e'));
+	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`e.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
 	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/packages/core/src/database/repositories/entity.types.ts
+++ b/packages/core/src/database/repositories/entity.types.ts
@@ -90,6 +90,7 @@ export interface EntityFilter {
 	/** Case-insensitive substring match on entity name (ILIKE). */
 	search?: string;
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -9,6 +9,15 @@
  * @see docs/specs/32_embedding_wrapper_semantic_chunker_chunk_repository.spec.md §4.5
  */
 
+export {
+	findAccessRoleById,
+	listAccessRoles,
+	upsertAccessRole,
+} from './access-role.repository.js';
+export type {
+	PersistedAccessRole,
+	UpsertAccessRoleInput,
+} from './access-role.types.js';
 export type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
 export {
 	mapArtifactProvenanceFromDb,

--- a/packages/core/src/database/repositories/review-workflow.repository.ts
+++ b/packages/core/src/database/repositories/review-workflow.repository.ts
@@ -1,4 +1,5 @@
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import type {
 	AutoApproveDueReviewArtifactsOptions,
@@ -330,6 +331,10 @@ export async function listReviewableArtifacts(
 		params.push(options.sourceId);
 		filters.push(`source_id = $${params.length}`);
 	}
+	if (options?.maxSensitivityLevel) {
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		filters.push(`COALESCE(NULLIF(context->>'sensitivity_level', ''), 'internal') = ANY($${params.length})`);
+	}
 	const limit = options?.limit ?? 100;
 	const offset = options?.offset ?? 0;
 	params.push(limit, offset);
@@ -601,12 +606,19 @@ export async function listReviewQueueArtifacts(
 	assertEnum(reviewStatus, STATUSES, 'reviewStatus');
 	const limit = options?.limit ?? 100;
 	const offset = options?.offset ?? 0;
+	const filters = ['artifact_type = ANY($1::text[])', 'review_status = $2', 'deleted_at IS NULL'];
+	const params: unknown[] = [artifactTypes, reviewStatus];
+	if (options?.maxSensitivityLevel) {
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		filters.push(`COALESCE(NULLIF(context->>'sensitivity_level', ''), 'internal') = ANY($${params.length})`);
+	}
+	params.push(limit, offset);
 	try {
 		return await readArtifacts(
 			pool,
-			'WHERE artifact_type = ANY($1::text[]) AND review_status = $2 AND deleted_at IS NULL',
-			[artifactTypes, reviewStatus, limit, offset],
-			'LIMIT $3 OFFSET $4',
+			`WHERE ${filters.join(' AND ')}`,
+			params,
+			`LIMIT $${params.length - 1} OFFSET $${params.length}`,
 		);
 	} catch (cause: unknown) {
 		if (cause instanceof DatabaseError) throw cause;

--- a/packages/core/src/database/repositories/review-workflow.types.ts
+++ b/packages/core/src/database/repositories/review-workflow.types.ts
@@ -1,3 +1,5 @@
+import type { SensitivityLevel } from '../../shared/sensitivity.js';
+
 export type ReviewArtifactType =
 	| 'assertion_classification'
 	| 'credibility_profile'
@@ -80,6 +82,7 @@ export interface ReviewableArtifactListOptions {
 	reviewStatus?: ReviewStatus;
 	sourceId?: string;
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }
@@ -117,6 +120,7 @@ export interface ReviewQueueListOptions {
 
 export interface ReviewQueueArtifactListOptions {
 	reviewStatus?: ReviewStatus;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/packages/core/src/database/repositories/source.repository.ts
+++ b/packages/core/src/database/repositories/source.repository.ts
@@ -11,6 +11,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -172,6 +173,12 @@ function buildSourceFilterClause(filter?: SourceFilter): { conditions: string[];
 		paramIndex++;
 	}
 
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
+	}
+
 	return { conditions, params };
 }
 
@@ -290,14 +297,24 @@ export async function createSource(pool: Queryable, input: CreateSourceInput): P
 export async function findSourceById(
 	pool: Queryable,
 	id: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: PersistedSource['sensitivityLevel'] },
 ): Promise<PersistedSource | null> {
-	const sql = `SELECT * FROM sources WHERE id = $1 ${
-		options?.includeDeleted ? '' : "AND deletion_status NOT IN ('soft_deleted', 'purging', 'purged')"
-	}`;
+	const conditions = ['id = $1'];
+	const params: unknown[] = [id];
+	let paramIndex = 2;
+
+	if (!options?.includeDeleted) {
+		conditions.push("deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
+	const sql = `SELECT * FROM sources WHERE ${conditions.join(' AND ')}`;
 
 	try {
-		const result = await pool.query<SourceRow>(sql, [id]);
+		const result = await pool.query<SourceRow>(sql, params);
 		if (result.rows.length === 0) {
 			return null;
 		}

--- a/packages/core/src/database/repositories/source.types.ts
+++ b/packages/core/src/database/repositories/source.types.ts
@@ -111,6 +111,7 @@ export interface SourceFilter {
 	/** Case-insensitive filename substring filter. */
 	search?: string;
 	tags?: string[];
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 	includeDeleted?: boolean;

--- a/packages/core/src/database/repositories/story-entity.repository.ts
+++ b/packages/core/src/database/repositories/story-entity.repository.ts
@@ -192,7 +192,9 @@ export async function findEntitiesByStoryId(
 	const activeVisibilityClause = options?.includeDeleted
 		? ''
 		: `AND ${activeSourceClause('src')} AND ${storyEntityActiveSourceClause('se')} AND ${entityActiveSourceClause('e')}`;
-	const sensitivityClause = options?.maxSensitivityLevel ? 'AND se.sensitivity_level = ANY($2)' : '';
+	const sensitivityClause = options?.maxSensitivityLevel
+		? 'AND se.sensitivity_level = ANY($2) AND e.sensitivity_level = ANY($2) AND s.sensitivity_level = ANY($2) AND src.sensitivity_level = ANY($2)'
+		: '';
 	const sql = `
     SELECT
       e.*,
@@ -296,19 +298,22 @@ export async function findStoriesByEntityId(
 	const activeVisibilityClause = options?.includeDeleted
 		? ''
 		: `AND ${activeSourceClause('src')} AND ${storyEntityActiveSourceClause('se')}`;
-	const sensitivityClause = options?.maxSensitivityLevel ? 'AND se.sensitivity_level = ANY($2)' : '';
+	const sensitivityClause = options?.maxSensitivityLevel
+		? 'AND se.sensitivity_level = ANY($2) AND s.sensitivity_level = ANY($2) AND src.sensitivity_level = ANY($2) AND e.sensitivity_level = ANY($2)'
+		: '';
 	const sql = `
-    SELECT
-      s.*,
+	    SELECT
+	      s.*,
       se.confidence,
       se.mention_count,
       se.provenance AS junction_provenance,
       se.sensitivity_level AS junction_sensitivity_level,
       se.sensitivity_metadata AS junction_sensitivity_metadata
-    FROM stories s
-    JOIN story_entities se ON se.story_id = s.id
-    JOIN sources src ON src.id = s.source_id
-    WHERE se.entity_id = $1
+	    FROM stories s
+	    JOIN story_entities se ON se.story_id = s.id
+	    JOIN entities e ON e.id = se.entity_id
+	    JOIN sources src ON src.id = s.source_id
+	    WHERE se.entity_id = $1
       ${activeVisibilityClause}
       ${sensitivityClause}
     ORDER BY s.created_at DESC
@@ -321,10 +326,11 @@ export async function findStoriesByEntityId(
       se.provenance AS junction_provenance,
       NULL::text AS junction_sensitivity_level,
       NULL::jsonb AS junction_sensitivity_metadata
-    FROM stories s
-    JOIN story_entities se ON se.story_id = s.id
-    JOIN sources src ON src.id = s.source_id
-    WHERE se.entity_id = $1
+	    FROM stories s
+	    JOIN story_entities se ON se.story_id = s.id
+	    JOIN entities e ON e.id = se.entity_id
+	    JOIN sources src ON src.id = s.source_id
+	    WHERE se.entity_id = $1
     ORDER BY s.created_at DESC
   `;
 	const withoutSourceDeletionSql = `

--- a/packages/core/src/database/repositories/story-entity.repository.ts
+++ b/packages/core/src/database/repositories/story-entity.repository.ts
@@ -11,6 +11,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -186,11 +187,12 @@ export async function linkStoryEntity(pool: pg.Pool, input: LinkStoryEntityInput
 export async function findEntitiesByStoryId(
 	pool: pg.Pool,
 	storyId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: StoryEntityWithEntity['sensitivityLevel'] },
 ): Promise<StoryEntityWithEntity[]> {
 	const activeVisibilityClause = options?.includeDeleted
 		? ''
 		: `AND ${activeSourceClause('src')} AND ${storyEntityActiveSourceClause('se')} AND ${entityActiveSourceClause('e')}`;
+	const sensitivityClause = options?.maxSensitivityLevel ? 'AND se.sensitivity_level = ANY($2)' : '';
 	const sql = `
     SELECT
       e.*,
@@ -205,6 +207,7 @@ export async function findEntitiesByStoryId(
     JOIN sources src ON src.id = s.source_id
     WHERE se.story_id = $1
       ${activeVisibilityClause}
+      ${sensitivityClause}
     ORDER BY e.name
   `;
 	const legacySql = `
@@ -235,6 +238,7 @@ export async function findEntitiesByStoryId(
     JOIN stories s ON s.id = se.story_id
     JOIN sources src ON src.id = s.source_id
     WHERE se.story_id = $1
+      ${sensitivityClause}
     ORDER BY e.name
   `;
 	const withoutSensitivitySql = `
@@ -253,7 +257,10 @@ export async function findEntitiesByStoryId(
       ${activeVisibilityClause}
     ORDER BY e.name
   `;
-	const params = [storyId];
+	const params = options?.maxSensitivityLevel
+		? [storyId, allowedSensitivityLevelsForMax(options.maxSensitivityLevel)]
+		: [storyId];
+	const fallbackParams = [storyId];
 
 	try {
 		const result = await queryWithSensitivityAndSourceDeletionFallback<EntityWithJunctionRow>(
@@ -261,11 +268,11 @@ export async function findEntitiesByStoryId(
 			sql,
 			params,
 			withoutSensitivitySql,
-			params,
+			fallbackParams,
 			withoutSourceDeletionSql,
 			params,
 			legacySql,
-			params,
+			fallbackParams,
 		);
 		return result.rows.map(mapEntityWithJunctionRow);
 	} catch (error: unknown) {
@@ -284,11 +291,12 @@ export async function findEntitiesByStoryId(
 export async function findStoriesByEntityId(
 	pool: pg.Pool,
 	entityId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: StoryEntityWithStory['sensitivityLevel'] },
 ): Promise<StoryEntityWithStory[]> {
 	const activeVisibilityClause = options?.includeDeleted
 		? ''
 		: `AND ${activeSourceClause('src')} AND ${storyEntityActiveSourceClause('se')}`;
+	const sensitivityClause = options?.maxSensitivityLevel ? 'AND se.sensitivity_level = ANY($2)' : '';
 	const sql = `
     SELECT
       s.*,
@@ -302,6 +310,7 @@ export async function findStoriesByEntityId(
     JOIN sources src ON src.id = s.source_id
     WHERE se.entity_id = $1
       ${activeVisibilityClause}
+      ${sensitivityClause}
     ORDER BY s.created_at DESC
   `;
 	const legacySql = `
@@ -330,6 +339,7 @@ export async function findStoriesByEntityId(
     JOIN story_entities se ON se.story_id = s.id
     JOIN sources src ON src.id = s.source_id
     WHERE se.entity_id = $1
+      ${sensitivityClause}
     ORDER BY s.created_at DESC
   `;
 	const withoutSensitivitySql = `
@@ -347,7 +357,10 @@ export async function findStoriesByEntityId(
       ${activeVisibilityClause}
     ORDER BY s.created_at DESC
   `;
-	const params = [entityId];
+	const params = options?.maxSensitivityLevel
+		? [entityId, allowedSensitivityLevelsForMax(options.maxSensitivityLevel)]
+		: [entityId];
+	const fallbackParams = [entityId];
 
 	try {
 		const result = await queryWithSensitivityAndSourceDeletionFallback<StoryWithJunctionRow>(
@@ -355,11 +368,11 @@ export async function findStoriesByEntityId(
 			sql,
 			params,
 			withoutSensitivitySql,
-			params,
+			fallbackParams,
 			withoutSourceDeletionSql,
 			params,
 			legacySql,
-			params,
+			fallbackParams,
 		);
 		return result.rows.map(mapStoryWithJunctionRow);
 	} catch (error: unknown) {

--- a/packages/core/src/database/repositories/story.repository.ts
+++ b/packages/core/src/database/repositories/story.repository.ts
@@ -11,6 +11,7 @@
  */
 
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -152,18 +153,28 @@ export async function createStory(pool: pg.Pool, input: CreateStoryInput): Promi
 export async function findStoryById(
 	pool: pg.Pool,
 	id: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: Story['sensitivityLevel'] },
 ): Promise<Story | null> {
+	const conditions = ['stories.id = $1'];
+	const params: unknown[] = [id];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push("sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`stories.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT stories.*
     FROM stories
     JOIN sources ON sources.id = stories.source_id
-    WHERE stories.id = $1
-      ${options?.includeDeleted ? '' : "AND sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')"}
+    WHERE ${conditions.join(' AND ')}
   `;
 
 	try {
-		const result = await pool.query<StoryRow>(sql, [id]);
+		const result = await pool.query<StoryRow>(sql, params);
 		if (result.rows.length === 0) {
 			return null;
 		}
@@ -185,19 +196,29 @@ export async function findStoryById(
 export async function findStoriesBySourceId(
 	pool: pg.Pool,
 	sourceId: string,
-	options?: { includeDeleted?: boolean },
+	options?: { includeDeleted?: boolean; maxSensitivityLevel?: Story['sensitivityLevel'] },
 ): Promise<Story[]> {
+	const conditions = ['stories.source_id = $1'];
+	const params: unknown[] = [sourceId];
+	let paramIndex = 2;
+	if (!options?.includeDeleted) {
+		conditions.push("sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`stories.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
     SELECT stories.*
     FROM stories
     JOIN sources ON sources.id = stories.source_id
-    WHERE stories.source_id = $1
-      ${options?.includeDeleted ? '' : "AND sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')"}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY page_start ASC NULLS LAST, created_at ASC
   `;
 
 	try {
-		const result = await pool.query<StoryRow>(sql, [sourceId]);
+		const result = await pool.query<StoryRow>(sql, params);
 		return result.rows.map(mapStoryRow);
 	} catch (error: unknown) {
 		throw new DatabaseError('Failed to find stories by source ID', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
@@ -243,6 +264,11 @@ export async function findAllStories(pool: pg.Pool, filter?: StoryFilter): Promi
 	}
 	if (!filter?.includeDeleted) {
 		conditions.push("sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`stories.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
 	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -304,6 +330,11 @@ export async function countStories(pool: pg.Pool, filter?: StoryFilter): Promise
 	}
 	if (!filter?.includeDeleted) {
 		conditions.push("sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (filter?.maxSensitivityLevel) {
+		conditions.push(`stories.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(filter.maxSensitivityLevel));
+		paramIndex++;
 	}
 
 	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/packages/core/src/database/repositories/story.types.ts
+++ b/packages/core/src/database/repositories/story.types.ts
@@ -89,4 +89,5 @@ export interface StoryFilter {
 	limit?: number;
 	offset?: number;
 	includeDeleted?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 }

--- a/packages/core/src/database/repositories/translated-document.repository.ts
+++ b/packages/core/src/database/repositories/translated-document.repository.ts
@@ -1,4 +1,5 @@
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
 import { createChildLogger, createLogger } from '../../shared/logger.js';
 import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
@@ -152,20 +153,32 @@ export async function findCurrentTranslatedDocument(
 	pool: Queryable,
 	sourceDocumentId: string,
 	targetLanguage: string,
-	options?: { includeDeletedSources?: boolean },
+	options?: { includeDeletedSources?: boolean; maxSensitivityLevel?: TranslatedDocument['sensitivityLevel'] },
 ): Promise<TranslatedDocument | null> {
+	const conditions = [
+		'translated_documents.source_document_id = $1',
+		'translated_documents.target_language = $2',
+		"translated_documents.status = 'current'",
+	];
+	const params: unknown[] = [sourceDocumentId, targetLanguage];
+	let paramIndex = 3;
+	if (!options?.includeDeletedSources) {
+		conditions.push("sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')");
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`translated_documents.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		paramIndex++;
+	}
 	const sql = `
 		SELECT translated_documents.*
 		FROM translated_documents
 		JOIN sources ON sources.id = translated_documents.source_document_id
-		WHERE translated_documents.source_document_id = $1
-			AND translated_documents.target_language = $2
-			AND translated_documents.status = 'current'
-			${options?.includeDeletedSources ? '' : "AND sources.deletion_status NOT IN ('soft_deleted', 'purging', 'purged')"}
+		WHERE ${conditions.join(' AND ')}
 	`;
 
 	try {
-		const result = await pool.query<TranslatedDocumentRow>(sql, [sourceDocumentId, targetLanguage]);
+		const result = await pool.query<TranslatedDocumentRow>(sql, params);
 		const row = result.rows[0];
 		return row ? mapTranslatedDocumentRow(row) : null;
 	} catch (error: unknown) {
@@ -196,6 +209,11 @@ export async function listTranslatedDocumentsForSource(
 	if (options?.status) {
 		conditions.push(`translated_documents.status = $${paramIndex}`);
 		params.push(options.status);
+		paramIndex++;
+	}
+	if (options?.maxSensitivityLevel) {
+		conditions.push(`translated_documents.sensitivity_level = ANY($${paramIndex})`);
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
 		paramIndex++;
 	}
 

--- a/packages/core/src/database/repositories/translated-document.types.ts
+++ b/packages/core/src/database/repositories/translated-document.types.ts
@@ -40,6 +40,7 @@ export interface ListTranslatedDocumentsOptions {
 	targetLanguage?: string;
 	status?: TranslationStatus;
 	includeDeletedSources?: boolean;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@
 export { ZodError } from 'zod';
 export type {
 	AccessControlConfig,
+	AccessControlRbacConfig,
 	AccessControlSensitivityConfig,
 	AnalysisConfig,
 	ApiAuthConfig,
@@ -178,6 +179,7 @@ export type {
 	OriginalSourceType,
 	PathSegment,
 	PathSegmentType,
+	PersistedAccessRole,
 	PersistedSource,
 	PhysicalLocation,
 	PipelineRun,
@@ -249,6 +251,7 @@ export type {
 	UpdateSourceInput,
 	UpdateStoryInput,
 	UpdateTaxonomyEntryInput,
+	UpsertAccessRoleInput,
 	UpsertCredibilityDimensionInput,
 	UpsertDocumentBlobInput,
 	UpsertEntityGroundingInput,
@@ -330,6 +333,7 @@ export {
 	enqueueJob,
 	finalizeMonthlyBudgetReservation,
 	finalizePipelineRun,
+	findAccessRoleById,
 	findAcquisitionContextById,
 	findAliasesByEntityId,
 	findAllEdges,
@@ -403,6 +407,7 @@ export {
 	getQueryPool,
 	getWorkerPool,
 	linkStoryEntity,
+	listAccessRoles,
 	listAcquisitionContextsForBlob,
 	listAcquisitionContextsForSource,
 	listArchiveLocationsForBlob,
@@ -486,6 +491,7 @@ export {
 	updateStorySensitivityFromArtifacts,
 	updateStoryStatus,
 	updateTaxonomyEntry,
+	upsertAccessRole,
 	upsertArchive,
 	upsertArchiveMirrorCollection,
 	upsertDocumentBlob,
@@ -507,6 +513,27 @@ export type { NativeTextDetectOptions, NativeTextResult, PdfMetadata } from './p
 export { detectNativeText, extractPdfMetadata } from './pipeline/index.js';
 // ── Prompt template engine ─────────────────────────────────
 export { clearPromptCaches, listTemplates, renderPrompt } from './prompts/index.js';
+export type {
+	AccessPermission,
+	AccessPolicy,
+	AccessPrincipal,
+	AccessPrincipalKind,
+	AccessRole,
+	AccessRoleConfig,
+	BrowserAccessRole,
+} from './shared/access-control.js';
+export {
+	ACCESS_PERMISSIONS,
+	accessRoleConfigToRole,
+	accessRoleToConfig,
+	allowedSensitivityLevelsForMax,
+	canReadSensitivityLevel,
+	DEFAULT_ACCESS_ROLE_CONFIGS,
+	DEFAULT_ACCESS_ROLES,
+	hasAccessPermission,
+	mapBrowserRoleToAccessRoleId,
+	resolveAccessPolicy,
+} from './shared/access-control.js';
 export {
 	assertSha256ContentHash,
 	buildContentAddressedBlobPath,

--- a/packages/core/src/shared/access-control.ts
+++ b/packages/core/src/shared/access-control.ts
@@ -1,0 +1,179 @@
+import type { AccessControlConfig, MulderConfig } from '../config/types.js';
+import { SENSITIVITY_LEVELS, type SensitivityLevel } from './sensitivity.js';
+
+export const ACCESS_PERMISSIONS = [
+	'read',
+	'write',
+	'review',
+	'classify',
+	'delete',
+	'admin',
+	'export',
+	'agent_config',
+] as const;
+
+export type AccessPermission = (typeof ACCESS_PERMISSIONS)[number];
+
+export type AccessPrincipalKind = 'browser_session' | 'api_key' | 'service' | 'anonymous';
+
+export type BrowserAccessRole = 'member' | 'admin' | 'owner';
+
+export interface AccessRole {
+	id: string;
+	name: string;
+	maxSensitivityLevel: SensitivityLevel;
+	permissions: AccessPermission[];
+}
+
+export interface AccessRoleConfig {
+	id: string;
+	name: string;
+	max_sensitivity_level: SensitivityLevel;
+	permissions: AccessPermission[];
+}
+
+export interface AccessPolicy extends AccessRole {
+	enabled: boolean;
+	principalKind: AccessPrincipalKind;
+	allowedSensitivityLevels: SensitivityLevel[];
+}
+
+export interface AccessPrincipal {
+	kind: AccessPrincipalKind;
+	roleId?: string | null;
+	browserRole?: string | null;
+}
+
+export const DEFAULT_ACCESS_ROLE_CONFIGS: AccessRoleConfig[] = [
+	{
+		id: 'analyst',
+		name: 'Analyst',
+		max_sensitivity_level: 'internal',
+		permissions: ['read'],
+	},
+	{
+		id: 'reviewer',
+		name: 'Reviewer',
+		max_sensitivity_level: 'restricted',
+		permissions: ['read', 'review', 'classify'],
+	},
+	{
+		id: 'admin',
+		name: 'Administrator',
+		max_sensitivity_level: 'confidential',
+		permissions: [...ACCESS_PERMISSIONS],
+	},
+];
+
+export const DEFAULT_ACCESS_ROLES: AccessRole[] = DEFAULT_ACCESS_ROLE_CONFIGS.map((role) => ({
+	id: role.id,
+	name: role.name,
+	maxSensitivityLevel: role.max_sensitivity_level,
+	permissions: [...role.permissions],
+}));
+
+const DISABLED_ACCESS_ROLE: AccessRole = {
+	id: 'access-control-disabled',
+	name: 'Access control disabled',
+	maxSensitivityLevel: 'confidential',
+	permissions: [...ACCESS_PERMISSIONS],
+};
+
+const DENIED_ACCESS_ROLE: AccessRole = {
+	id: 'unresolved',
+	name: 'Unresolved access role',
+	maxSensitivityLevel: 'public',
+	permissions: [],
+};
+
+function isAccessControlConfig(config: AccessControlConfig | MulderConfig): config is AccessControlConfig {
+	return 'enabled' in config && 'rbac' in config;
+}
+
+function readAccessControlConfig(config: AccessControlConfig | MulderConfig): AccessControlConfig {
+	return isAccessControlConfig(config) ? config : config.access_control;
+}
+
+function normalizeRoleConfig(role: AccessRoleConfig): AccessRole {
+	return {
+		id: role.id,
+		name: role.name,
+		maxSensitivityLevel: role.max_sensitivity_level,
+		permissions: [...role.permissions],
+	};
+}
+
+function resolveRole(config: AccessControlConfig, roleId: string): AccessRole | null {
+	const roles = config.rbac.roles.map(normalizeRoleConfig);
+	return roles.find((role) => role.id === roleId) ?? null;
+}
+
+export function allowedSensitivityLevelsForMax(maxSensitivityLevel: SensitivityLevel): SensitivityLevel[] {
+	const maxIndex = SENSITIVITY_LEVELS.indexOf(maxSensitivityLevel);
+	return SENSITIVITY_LEVELS.slice(0, maxIndex + 1);
+}
+
+export function canReadSensitivityLevel(policy: AccessPolicy, sensitivityLevel: SensitivityLevel): boolean {
+	return hasAccessPermission(policy, 'read') && policy.allowedSensitivityLevels.includes(sensitivityLevel);
+}
+
+export function hasAccessPermission(policy: AccessPolicy, permission: AccessPermission): boolean {
+	return policy.permissions.includes(permission) || policy.permissions.includes('admin');
+}
+
+export function mapBrowserRoleToAccessRoleId(browserRole: string | null | undefined): string | null {
+	if (browserRole === 'member') return 'analyst';
+	if (browserRole === 'admin' || browserRole === 'owner') return 'admin';
+	return null;
+}
+
+export function accessRoleConfigToRole(role: AccessRoleConfig): AccessRole {
+	return normalizeRoleConfig(role);
+}
+
+export function accessRoleToConfig(role: AccessRole): AccessRoleConfig {
+	return {
+		id: role.id,
+		name: role.name,
+		max_sensitivity_level: role.maxSensitivityLevel,
+		permissions: [...role.permissions],
+	};
+}
+
+export function resolveAccessPolicy(
+	config: AccessControlConfig | MulderConfig,
+	principal: AccessPrincipal,
+): AccessPolicy {
+	const accessControl = readAccessControlConfig(config);
+
+	if (!accessControl.enabled) {
+		return {
+			...DISABLED_ACCESS_ROLE,
+			enabled: false,
+			principalKind: principal.kind,
+			allowedSensitivityLevels: allowedSensitivityLevelsForMax(DISABLED_ACCESS_ROLE.maxSensitivityLevel),
+		};
+	}
+
+	const roleId =
+		principal.kind === 'api_key' || principal.kind === 'service'
+			? 'admin'
+			: (principal.roleId ?? mapBrowserRoleToAccessRoleId(principal.browserRole) ?? accessControl.rbac.default_role);
+	const role = resolveRole(accessControl, roleId);
+
+	if (!role) {
+		return {
+			...DENIED_ACCESS_ROLE,
+			enabled: true,
+			principalKind: principal.kind,
+			allowedSensitivityLevels: [],
+		};
+	}
+
+	return {
+		...role,
+		enabled: true,
+		principalKind: principal.kind,
+		allowedSensitivityLevels: allowedSensitivityLevelsForMax(role.maxSensitivityLevel),
+	};
+}

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -610,6 +610,24 @@ const TEST_GROUPS = {
 		'tests/specs/66_evidence_package_boundary.test.ts',
 		'tests/specs/75_evidence_api_routes.test.ts',
 	],
+	rbacSchema: ['tests/specs/08_core_schema_migrations.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	rbacAccessControl: ['tests/specs/03_config_loader.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	rbacDocumentsApi: ['tests/specs/76_document_retrieval_routes.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	rbacEntitiesApi: ['tests/specs/74_entity_api_routes.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	sourceRepository: ['tests/specs/14_source_repository.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	storyRepository: ['tests/specs/22_story_repository.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	entityRepository: ['tests/specs/24_entity_alias_repositories.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	edgeRepository: ['tests/specs/25_edge_repository.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	conflictRepository: [
+		'tests/specs/108_conflict_node_management.test.ts',
+		'tests/specs/111_rbac_implementation.test.ts',
+	],
+	reviewRepository: [
+		'tests/specs/109_review_workflow_infrastructure.test.ts',
+		'tests/specs/111_rbac_implementation.test.ts',
+	],
+	translationRepository: ['tests/specs/110_translation_service.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
+	repositoryExports: ['tests/specs/02_monorepo_setup.test.ts', 'tests/specs/111_rbac_implementation.test.ts'],
 };
 
 function selectTestGroup(selected, discoveredByPath, groupName) {
@@ -654,6 +672,14 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 		};
 	}
 
+	if (file === 'mulder.config.example.yaml') {
+		selectGroup('rbacAccessControl');
+		return {
+			rule: 'example config access-control smoke',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
 	if (file === 'packages/core/src/config/reprocess-hash.ts') {
 		selectGroup('reprocessConfig');
 		return { rule: 'reprocess config hash', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
@@ -677,9 +703,62 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 		};
 	}
 
+	if (file === 'packages/core/src/database/migrations/041_access_roles.sql') {
+		selectGroup('rbacSchema');
+		return { rule: 'rbac access-role migration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
 	if (file.startsWith('packages/core/src/database/migrations/')) {
 		selectLanes(['schema', 'db', 'heavy']);
 		return { rule: 'unknown migration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/access-role')) {
+		selectExact(['tests/specs/111_rbac_implementation.test.ts']);
+		return { rule: 'rbac access-role repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/source.')) {
+		selectGroup('sourceRepository');
+		return { rule: 'source repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (
+		file.startsWith('packages/core/src/database/repositories/story.') ||
+		file.startsWith('packages/core/src/database/repositories/story-entity.')
+	) {
+		selectGroup('storyRepository');
+		return { rule: 'story repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/entity.')) {
+		selectGroup('entityRepository');
+		return { rule: 'entity repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/edge.')) {
+		selectGroup('edgeRepository');
+		return { rule: 'edge repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/conflict-node.')) {
+		selectGroup('conflictRepository');
+		return { rule: 'conflict-node repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/review-workflow.')) {
+		selectGroup('reviewRepository');
+		return { rule: 'review-workflow repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/translated-document.')) {
+		selectGroup('translationRepository');
+		return { rule: 'translated-document repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file === 'packages/core/src/database/repositories/index.ts') {
+		selectGroup('repositoryExports');
+		return { rule: 'repository barrel exports', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
 	if (file.startsWith('packages/core/src/database/repositories/document-quality')) {
@@ -731,6 +810,11 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 	if (file.startsWith('packages/core/src/shared/cost-estimator')) {
 		selectExact(['tests/specs/77_cost_estimator.test.ts', 'tests/specs/78_selective_reprocessing.test.ts']);
 		return { rule: 'cost estimator', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file === 'packages/core/src/shared/access-control.ts') {
+		selectGroup('rbacAccessControl');
+		return { rule: 'rbac access-control helpers', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
 	if (file.startsWith('packages/core/src/shared/')) {
@@ -806,6 +890,16 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 	if (file.startsWith('packages/evidence/')) {
 		selectGroup('evidence');
 		return { rule: 'evidence package', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file === 'apps/api/src/lib/documents.ts' || file === 'apps/api/src/routes/documents.ts') {
+		selectGroup('rbacDocumentsApi');
+		return { rule: 'documents api route/runtime', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file === 'apps/api/src/lib/entities.ts' || file === 'apps/api/src/routes/entities.ts') {
+		selectGroup('rbacEntitiesApi');
+		return { rule: 'entities api route/runtime', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
 	if (file.startsWith('apps/api/')) {

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -928,6 +928,13 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 	return { rule: 'no affected tests mapped', selectedFiles: [] };
 }
 
+function resolveDocsOnlyHeadRule(file) {
+	return {
+		rule: isDocsOnlyHeadFile(file) ? 'head docs-only change (build/lint only)' : 'no affected tests mapped',
+		selectedFiles: [],
+	};
+}
+
 function laneNameForFile(relativePath, lanes) {
 	for (const [laneName, lane] of Object.entries(lanes)) {
 		if (lane.files.some((file) => file.relativePath === relativePath)) {
@@ -950,7 +957,10 @@ function buildAffectedPlan(baseRef, explicitChangedFiles = null) {
 	const rules = [];
 
 	for (const file of changed) {
-		const result = resolveAffectedRule(file, discoveredByPath, lanes);
+		const result =
+			changeSelection.changeScope === 'head-docs-only'
+				? resolveDocsOnlyHeadRule(file)
+				: resolveAffectedRule(file, discoveredByPath, lanes);
 		for (const selectedFile of result.selectedFiles) selected.add(selectedFile);
 		rules.push({ changedFile: file, rule: result.rule, selectedFiles: result.selectedFiles });
 	}

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -731,7 +731,10 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 		return { rule: 'story repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
-	if (file.startsWith('packages/core/src/database/repositories/entity.')) {
+	if (
+		file.startsWith('packages/core/src/database/repositories/entity.') ||
+		file.startsWith('packages/core/src/database/repositories/entity-alias.')
+	) {
 		selectGroup('entityRepository');
 		return { rule: 'entity repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}

--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -1,11 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, rmdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmdirSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import pg from 'pg';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const ROOT = resolve(dirname(SCRIPT_PATH), '..');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 function usage() {
 	return [
@@ -140,6 +141,9 @@ async function main() {
 		MULDER_TEST_STORAGE_ROOT: storageRoot,
 		MULDER_LOG_LEVEL: process.env.MULDER_LOG_LEVEL ?? 'silent',
 	};
+	if (!env.MULDER_CONFIG && existsSync(EXAMPLE_CONFIG)) {
+		env.MULDER_CONFIG = EXAMPLE_CONFIG;
+	}
 	env.PGHOST = env.PGHOST ?? 'localhost';
 	env.PGPORT = env.PGPORT ?? '5432';
 	env.PGUSER = env.PGUSER ?? 'mulder';
@@ -166,6 +170,7 @@ async function main() {
 				isolatedDb
 					? `test-runner: database=${isolatedDb}`
 					: `test-runner: database=${env.PGDATABASE ?? 'mulder'} (shared)`,
+				`test-runner: config=${env.MULDER_CONFIG ?? '(default loader resolution)'}`,
 				'',
 			].join('\n'),
 		);

--- a/tests/specs/03_config_loader.test.ts
+++ b/tests/specs/03_config_loader.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '../..');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 /**
  * Black-box QA tests for Spec 03: Config Loader + Zod Schemas
@@ -358,6 +359,35 @@ ontology:
 	describe('QA-07: File not found throws ConfigValidationError', () => {
 		it('throws ConfigValidationError (not raw filesystem error) for non-existent path', () => {
 			expect(() => loadConfig('/does/not/exist.yaml')).toThrow(ConfigValidationError);
+		});
+
+		it('uses the shipped example config when no local default config exists', () => {
+			const freshCheckoutDir = mkdtempSync(join(tmpDir, 'fresh-checkout-'));
+			copyFileSync(EXAMPLE_CONFIG, join(freshCheckoutDir, 'mulder.config.example.yaml'));
+			const originalCwd = process.cwd();
+			const originalEnv = process.env.MULDER_CONFIG;
+
+			try {
+				delete process.env.MULDER_CONFIG;
+				process.chdir(freshCheckoutDir);
+				const fallbackConfig = loadConfig() as Record<string, unknown>;
+				const explicitDefaultConfig = loadConfig('mulder.config.yaml') as Record<string, unknown>;
+				const explicitConfig = loadConfig(EXAMPLE_CONFIG) as Record<string, unknown>;
+
+				expect((fallbackConfig.project as Record<string, unknown>).name).toBe(
+					(explicitConfig.project as Record<string, unknown>).name,
+				);
+				expect((explicitDefaultConfig.project as Record<string, unknown>).name).toBe(
+					(explicitConfig.project as Record<string, unknown>).name,
+				);
+			} finally {
+				process.chdir(originalCwd);
+				if (originalEnv === undefined) {
+					delete process.env.MULDER_CONFIG;
+				} else {
+					process.env.MULDER_CONFIG = originalEnv;
+				}
+			}
 		});
 	});
 

--- a/tests/specs/111_rbac_implementation.test.ts
+++ b/tests/specs/111_rbac_implementation.test.ts
@@ -1,0 +1,365 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import pg from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as db from '../lib/db.js';
+import { ensureSchema, MULDER_TEST_TABLES, truncateExistingTables } from '../lib/schema.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CORE_DIR = resolve(ROOT, 'packages/core');
+const API_DIR = resolve(ROOT, 'apps/api');
+const CLI_DIR = resolve(ROOT, 'apps/cli');
+const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
+const API_DOCUMENTS_DIST = resolve(API_DIR, 'dist/lib/documents.js');
+const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
+
+const PG_CONFIG = {
+	host: db.TEST_PG_HOST,
+	port: db.TEST_PG_PORT,
+	database: db.TEST_PG_DATABASE,
+	user: db.TEST_PG_USER,
+	password: db.TEST_PG_PASSWORD,
+};
+
+const pgAvailable = db.isPgAvailable();
+let pool: pg.Pool;
+let tempDir: string | null = null;
+let previousConfigPath: string | undefined;
+let coreModule: typeof import('@mulder/core');
+let apiDocumentsModule: typeof import('../../apps/api/src/lib/documents.js');
+
+function buildPackage(packageDir: string): void {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd: packageDir,
+		encoding: 'utf-8',
+		timeout: 180_000,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, MULDER_LOG_LEVEL: 'silent' },
+	});
+	if ((result.status ?? 1) !== 0) {
+		throw new Error(`Build failed in ${packageDir}:\n${result.stdout}\n${result.stderr}`);
+	}
+}
+
+function writeMinimalConfig(label = 'spec111'): string {
+	if (!tempDir) tempDir = mkdtempSync(join(tmpdir(), 'mulder-spec111-'));
+	const configPath = join(tempDir, `${label}-${randomUUID()}.yaml`);
+	writeFileSync(
+		configPath,
+		[
+			'project:',
+			`  name: "${label}"`,
+			'  supported_locales: ["en"]',
+			'dev_mode: true',
+			'gcp:',
+			'  project_id: "test-project"',
+			'  region: "europe-west1"',
+			'  cloud_sql:',
+			'    instance_name: "mulder-db"',
+			'    database: "mulder"',
+			'  storage:',
+			'    bucket: "mulder-test"',
+			'  document_ai:',
+			'    processor_id: "processor"',
+			'ontology:',
+			'  entity_types:',
+			'    - name: "person"',
+			'      description: "Person"',
+			'  relationships: []',
+			'',
+		].join('\n'),
+		'utf-8',
+	);
+	return configPath;
+}
+
+function cleanTables(): void {
+	truncateExistingTables([
+		'translated_documents',
+		'review_events',
+		'review_artifacts',
+		'conflict_resolutions',
+		'conflict_assertions',
+		'conflict_nodes',
+		'knowledge_assertions',
+		...MULDER_TEST_TABLES,
+	]);
+}
+
+function sensitivityMetadata(level: import('@mulder/core').SensitivityLevel) {
+	return {
+		level,
+		reason: 'spec111_fixture',
+		assignedBy: 'policy_rule' as const,
+		assignedAt: '2026-05-07T00:00:00.000Z',
+		piiTypes: [],
+		declassifyDate: null,
+	};
+}
+
+async function createSourceFixture(level: import('@mulder/core').SensitivityLevel, label = level) {
+	const source = await coreModule.createSource(pool, {
+		filename: `${label}-${randomUUID()}.md`,
+		storagePath: `raw/${label}-${randomUUID()}.md`,
+		fileHash: `${label}-${randomUUID()}`,
+		sourceType: 'text',
+		formatMetadata: { media_type: 'text/markdown' },
+		pageCount: 1,
+		hasNativeText: true,
+		nativeTextRatio: 1,
+		sensitivityLevel: level,
+		sensitivityMetadata: sensitivityMetadata(level),
+	});
+	const story = await coreModule.createStory(pool, {
+		sourceId: source.id,
+		title: `Story ${label}`,
+		gcsMarkdownUri: `segments/${source.id}/story.md`,
+		gcsMetadataUri: `segments/${source.id}/story.meta.json`,
+		extractionConfidence: 0.95,
+		sensitivityLevel: level,
+		sensitivityMetadata: sensitivityMetadata(level),
+	});
+	const entity = await coreModule.upsertEntityByNameType(pool, {
+		name: `Entity ${label} ${randomUUID()}`,
+		type: 'person',
+		attributes: {},
+		provenance: { sourceDocumentIds: [source.id] },
+		sensitivityLevel: level,
+		sensitivityMetadata: sensitivityMetadata(level),
+	});
+	await coreModule.linkStoryEntity(pool, {
+		storyId: story.id,
+		entityId: entity.id,
+		mentionCount: 1,
+		provenance: { sourceDocumentIds: [source.id] },
+		sensitivityLevel: level,
+		sensitivityMetadata: sensitivityMetadata(level),
+	});
+	return { source, story, entity };
+}
+
+function confidenceMetadata(): import('@mulder/core').ConfidenceMetadata {
+	return {
+		witnessCount: 1,
+		measurementBased: false,
+		contemporaneous: true,
+		corroborated: false,
+		peerReviewed: false,
+		authorIsInterpreter: false,
+	};
+}
+
+async function createAssertion(sourceId: string, storyId: string, level: import('@mulder/core').SensitivityLevel) {
+	return await coreModule.upsertKnowledgeAssertion(pool, {
+		sourceId,
+		storyId,
+		assertionType: 'observation',
+		content: `Assertion ${level} ${randomUUID()}`,
+		confidenceMetadata: confidenceMetadata(),
+		extractedEntityIds: [],
+		provenance: { sourceDocumentIds: [sourceId] },
+		sensitivityLevel: level,
+		sensitivityMetadata: sensitivityMetadata(level),
+	});
+}
+
+beforeAll(async () => {
+	buildPackage(CORE_DIR);
+	buildPackage(CLI_DIR);
+	buildPackage(API_DIR);
+	coreModule = await import(pathToFileURL(CORE_DIST).href);
+	apiDocumentsModule = await import(pathToFileURL(API_DOCUMENTS_DIST).href);
+
+	if (!pgAvailable) return;
+	ensureSchema();
+	pool = new pg.Pool(PG_CONFIG);
+});
+
+beforeEach(() => {
+	if (!pgAvailable) return;
+	cleanTables();
+});
+
+afterAll(async () => {
+	await pool?.end();
+	await coreModule?.closeAllPools();
+	if (previousConfigPath === undefined) {
+		delete process.env.MULDER_CONFIG;
+	} else {
+		process.env.MULDER_CONFIG = previousConfigPath;
+	}
+	if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('Spec 111: RBAC implementation', () => {
+	it('QA-01: role schema and defaults are self-contained', () => {
+		const minimalConfig = coreModule.loadConfig(writeMinimalConfig('minimal'));
+		const exampleConfig = coreModule.loadConfig(EXAMPLE_CONFIG);
+
+		for (const config of [minimalConfig, exampleConfig]) {
+			expect(config.access_control.rbac.roles.map((role) => role.id).sort()).toEqual(['admin', 'analyst', 'reviewer']);
+			expect(config.access_control.rbac.roles.find((role) => role.id === 'analyst')).toMatchObject({
+				max_sensitivity_level: 'internal',
+				permissions: ['read'],
+			});
+			expect(config.access_control.rbac.roles.find((role) => role.id === 'admin')?.permissions).toContain('admin');
+		}
+	});
+
+	it('QA-02: access helpers enforce the sensitivity lattice', () => {
+		const config = coreModule.loadConfig(writeMinimalConfig('helpers'));
+		const analyst = coreModule.resolveAccessPolicy(config, { kind: 'browser_session', browserRole: 'member' });
+		const admin = coreModule.resolveAccessPolicy(config, { kind: 'browser_session', browserRole: 'admin' });
+
+		expect(coreModule.allowedSensitivityLevelsForMax('internal')).toEqual(['public', 'internal']);
+		expect(
+			['public', 'internal', 'restricted', 'confidential'].map((level) =>
+				coreModule.canReadSensitivityLevel(analyst, level),
+			),
+		).toEqual([true, true, false, false]);
+		expect(
+			['public', 'internal', 'restricted', 'confidential'].map((level) =>
+				coreModule.canReadSensitivityLevel(admin, level),
+			),
+		).toEqual([true, true, true, true]);
+	});
+
+	it.skipIf(!pgAvailable)('QA-03: roles persist and round-trip', async () => {
+		await pool.query("DELETE FROM access_roles WHERE id NOT IN ('analyst', 'reviewer', 'admin')");
+		const defaultRoles = await coreModule.listAccessRoles(pool);
+		expect(defaultRoles.map((role) => role.id).sort()).toEqual(['admin', 'analyst', 'reviewer']);
+
+		const custom = await coreModule.upsertAccessRole(pool, {
+			id: 'field_reviewer',
+			name: 'Field reviewer',
+			maxSensitivityLevel: 'restricted',
+			permissions: ['read', 'review'],
+		});
+		expect(await coreModule.findAccessRoleById(pool, custom.id)).toMatchObject({
+			id: 'field_reviewer',
+			name: 'Field reviewer',
+			maxSensitivityLevel: 'restricted',
+			permissions: ['read', 'review'],
+		});
+	});
+
+	it.skipIf(!pgAvailable)('QA-04: repository filters hide over-sensitive artifacts', async () => {
+		const publicFixture = await createSourceFixture('public');
+		const internalFixture = await createSourceFixture('internal');
+		const restrictedFixture = await createSourceFixture('restricted');
+		const confidentialFixture = await createSourceFixture('confidential');
+		const assertionA = await createAssertion(internalFixture.source.id, internalFixture.story.id, 'internal');
+		const assertionB = await createAssertion(restrictedFixture.source.id, restrictedFixture.story.id, 'restricted');
+		await coreModule.createConflictNode(pool, {
+			conflictType: 'factual',
+			detectionMethod: 'human_reported',
+			detectedBy: 'spec111',
+			severity: 'significant',
+			severityRationale: 'Fixture conflict',
+			confidence: 0.8,
+			assertions: [
+				{ assertionId: assertionA.id, sourceDocumentId: internalFixture.source.id, claim: assertionA.content },
+				{ assertionId: assertionB.id, sourceDocumentId: restrictedFixture.source.id, claim: assertionB.content },
+			],
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted'),
+		});
+		await coreModule.upsertReviewableArtifact(pool, {
+			artifactType: 'assertion_classification',
+			subjectId: assertionA.id,
+			subjectTable: 'knowledge_assertions',
+			currentValue: { assertion_type: 'observation' },
+			context: { sensitivity_level: 'internal' },
+		});
+		await coreModule.upsertReviewableArtifact(pool, {
+			artifactType: 'assertion_classification',
+			subjectId: assertionB.id,
+			subjectTable: 'knowledge_assertions',
+			currentValue: { assertion_type: 'observation' },
+			context: { sensitivity_level: 'restricted' },
+		});
+		await coreModule.createCurrentTranslatedDocument(pool, {
+			sourceDocumentId: internalFixture.source.id,
+			sourceLanguage: 'de',
+			targetLanguage: 'en',
+			translationEngine: 'fixture',
+			content: 'Internal translation',
+			contentHash: randomUUID(),
+			pipelinePath: 'translation_only',
+			outputFormat: 'markdown',
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
+		await coreModule.createCurrentTranslatedDocument(pool, {
+			sourceDocumentId: internalFixture.source.id,
+			sourceLanguage: 'de',
+			targetLanguage: 'fr',
+			translationEngine: 'fixture',
+			content: 'Restricted translation',
+			contentHash: randomUUID(),
+			pipelinePath: 'translation_only',
+			outputFormat: 'markdown',
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted'),
+		});
+
+		expect(
+			(await coreModule.findAllSources(pool, { maxSensitivityLevel: 'internal' })).map((source) => source.id).sort(),
+		).toEqual([publicFixture.source.id, internalFixture.source.id].sort());
+		expect(
+			(await coreModule.findAllEntities(pool, { maxSensitivityLevel: 'internal' })).map((entity) => entity.id),
+		).toContain(internalFixture.entity.id);
+		expect(
+			(await coreModule.findAllEntities(pool, { maxSensitivityLevel: 'internal' })).map((entity) => entity.id),
+		).not.toContain(restrictedFixture.entity.id);
+		expect(
+			await coreModule.findSourceById(pool, confidentialFixture.source.id, { maxSensitivityLevel: 'internal' }),
+		).toBeNull();
+		expect(
+			await coreModule.findStoriesBySourceId(pool, confidentialFixture.source.id, { maxSensitivityLevel: 'internal' }),
+		).toEqual([]);
+		expect(await coreModule.listConflictNodes(pool, { maxSensitivityLevel: 'internal' })).toEqual([]);
+		expect(await coreModule.listReviewableArtifacts(pool, { maxSensitivityLevel: 'internal' })).toHaveLength(1);
+		expect(
+			await coreModule.listTranslatedDocumentsForSource(pool, internalFixture.source.id, {
+				maxSensitivityLevel: 'internal',
+			}),
+		).toHaveLength(1);
+		expect(await coreModule.findAllSources(pool, { maxSensitivityLevel: 'confidential' })).toHaveLength(4);
+	});
+
+	it.skipIf(!pgAvailable)(
+		'QA-05/06: API document reads apply session filters and keep API keys compatible',
+		async () => {
+			const configPath = writeMinimalConfig('api');
+			previousConfigPath = process.env.MULDER_CONFIG;
+			process.env.MULDER_CONFIG = configPath;
+			apiDocumentsModule.resetDocumentContextForTests();
+
+			const internalFixture = await createSourceFixture('internal', 'api-internal');
+			const restrictedFixture = await createSourceFixture('restricted', 'api-restricted');
+
+			const member = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
+				authPrincipal: { type: 'session', userId: randomUUID(), email: 'member@example.test', role: 'member' },
+			});
+			const admin = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
+				authPrincipal: { type: 'session', userId: randomUUID(), email: 'admin@example.test', role: 'admin' },
+			});
+			const apiKey = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
+				authPrincipal: { type: 'api_key', keyName: 'automation' },
+			});
+
+			expect(member.data.map((document) => document.id)).toEqual([internalFixture.source.id]);
+			expect(admin.data.map((document) => document.id).sort()).toEqual(
+				[internalFixture.source.id, restrictedFixture.source.id].sort(),
+			);
+			expect(apiKey.data.map((document) => document.id).sort()).toEqual(
+				[internalFixture.source.id, restrictedFixture.source.id].sort(),
+			);
+		},
+	);
+});

--- a/tests/specs/111_rbac_implementation.test.ts
+++ b/tests/specs/111_rbac_implementation.test.ts
@@ -15,6 +15,7 @@ const API_DIR = resolve(ROOT, 'apps/api');
 const CLI_DIR = resolve(ROOT, 'apps/cli');
 const CORE_DIST = resolve(CORE_DIR, 'dist/index.js');
 const API_DOCUMENTS_DIST = resolve(API_DIR, 'dist/lib/documents.js');
+const API_ENTITIES_DIST = resolve(API_DIR, 'dist/lib/entities.js');
 const EXAMPLE_CONFIG = resolve(ROOT, 'mulder.config.example.yaml');
 
 const PG_CONFIG = {
@@ -38,12 +39,22 @@ type TestAuthPrincipal =
 	| { type: 'session'; userId: string; email: string; role: 'member' | 'admin' | 'owner' }
 	| { type: 'api_key'; keyName: string };
 
+type ApiEntitiesModule = {
+	resetEntityContextForTests(): void;
+	getEntityDetail(
+		id: string,
+		logger: import('@mulder/core').Logger,
+		options: { authPrincipal: TestAuthPrincipal },
+	): Promise<{ data: { aliases: Array<{ alias: string }> } }>;
+};
+
 const pgAvailable = db.isPgAvailable();
 let pool: pg.Pool;
 let tempDir: string | null = null;
 let previousConfigPath: string | undefined;
 let coreModule: typeof import('@mulder/core');
 let apiDocumentsModule: ApiDocumentsModule;
+let apiEntitiesModule: ApiEntitiesModule;
 
 function buildPackage(packageDir: string): void {
 	const result = spawnSync('pnpm', ['build'], {
@@ -186,6 +197,7 @@ beforeAll(async () => {
 	buildPackage(API_DIR);
 	coreModule = await import(pathToFileURL(CORE_DIST).href);
 	apiDocumentsModule = (await import(pathToFileURL(API_DOCUMENTS_DIST).href)) as ApiDocumentsModule;
+	apiEntitiesModule = (await import(pathToFileURL(API_ENTITIES_DIST).href)) as ApiEntitiesModule;
 
 	if (!pgAvailable) return;
 	ensureSchema();
@@ -327,6 +339,39 @@ describe('Spec 111: RBAC implementation', () => {
 			sensitivityLevel: 'restricted',
 			sensitivityMetadata: sensitivityMetadata('restricted'),
 		});
+		const restrictedEntityOnInternalStory = await coreModule.upsertEntityByNameType(pool, {
+			name: `Restricted mixed entity ${randomUUID()}`,
+			type: 'person',
+			attributes: {},
+			provenance: { sourceDocumentIds: [internalFixture.source.id] },
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted'),
+		});
+		await coreModule.linkStoryEntity(pool, {
+			storyId: internalFixture.story.id,
+			entityId: restrictedEntityOnInternalStory.id,
+			mentionCount: 1,
+			provenance: { sourceDocumentIds: [internalFixture.source.id] },
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
+		const restrictedStoryForInternalEntity = await coreModule.createStory(pool, {
+			sourceId: internalFixture.source.id,
+			title: `Restricted mixed story ${randomUUID()}`,
+			gcsMarkdownUri: `segments/${internalFixture.source.id}/restricted-story.md`,
+			gcsMetadataUri: `segments/${internalFixture.source.id}/restricted-story.meta.json`,
+			extractionConfidence: 0.95,
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: sensitivityMetadata('restricted'),
+		});
+		await coreModule.linkStoryEntity(pool, {
+			storyId: restrictedStoryForInternalEntity.id,
+			entityId: internalFixture.entity.id,
+			mentionCount: 1,
+			provenance: { sourceDocumentIds: [internalFixture.source.id] },
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: sensitivityMetadata('internal'),
+		});
 
 		expect(
 			(await coreModule.findAllSources(pool, { maxSensitivityLevel: 'internal' })).map((source) => source.id).sort(),
@@ -350,6 +395,16 @@ describe('Spec 111: RBAC implementation', () => {
 				maxSensitivityLevel: 'internal',
 			}),
 		).toHaveLength(1);
+		expect(
+			(await coreModule.findEntitiesByStoryId(pool, internalFixture.story.id, { maxSensitivityLevel: 'internal' })).map(
+				(entity) => entity.id,
+			),
+		).not.toContain(restrictedEntityOnInternalStory.id);
+		expect(
+			(
+				await coreModule.findStoriesByEntityId(pool, internalFixture.entity.id, { maxSensitivityLevel: 'internal' })
+			).map((story) => story.id),
+		).not.toContain(restrictedStoryForInternalEntity.id);
 		expect(await coreModule.findAllSources(pool, { maxSensitivityLevel: 'confidential' })).toHaveLength(4);
 	});
 
@@ -360,19 +415,54 @@ describe('Spec 111: RBAC implementation', () => {
 			previousConfigPath = process.env.MULDER_CONFIG;
 			process.env.MULDER_CONFIG = configPath;
 			apiDocumentsModule.resetDocumentContextForTests();
+			apiEntitiesModule.resetEntityContextForTests();
 
 			const internalFixture = await createSourceFixture('internal', 'api-internal');
 			const restrictedFixture = await createSourceFixture('restricted', 'api-restricted');
+			await coreModule.createEntityAlias(pool, {
+				entityId: internalFixture.entity.id,
+				alias: 'Restricted API Alias',
+				source: 'fixture',
+				provenance: { sourceDocumentIds: [internalFixture.source.id] },
+				sensitivityLevel: 'restricted',
+				sensitivityMetadata: sensitivityMetadata('restricted'),
+			});
+			const memberPrincipal: TestAuthPrincipal = {
+				type: 'session',
+				userId: randomUUID(),
+				email: 'member@example.test',
+				role: 'member',
+			};
+			const adminPrincipal: TestAuthPrincipal = {
+				type: 'session',
+				userId: randomUUID(),
+				email: 'admin@example.test',
+				role: 'admin',
+			};
 
 			const member = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
-				authPrincipal: { type: 'session', userId: randomUUID(), email: 'member@example.test', role: 'member' },
+				authPrincipal: memberPrincipal,
 			});
 			const admin = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
-				authPrincipal: { type: 'session', userId: randomUUID(), email: 'admin@example.test', role: 'admin' },
+				authPrincipal: adminPrincipal,
 			});
 			const apiKey = await apiDocumentsModule.listDocuments({ limit: 100, offset: 0 }, coreModule.createLogger(), {
 				authPrincipal: { type: 'api_key', keyName: 'automation' },
 			});
+			const memberEntity = await apiEntitiesModule.getEntityDetail(
+				internalFixture.entity.id,
+				coreModule.createLogger(),
+				{
+					authPrincipal: memberPrincipal,
+				},
+			);
+			const adminEntity = await apiEntitiesModule.getEntityDetail(
+				internalFixture.entity.id,
+				coreModule.createLogger(),
+				{
+					authPrincipal: adminPrincipal,
+				},
+			);
 
 			expect(member.data.map((document) => document.id)).toEqual([internalFixture.source.id]);
 			expect(admin.data.map((document) => document.id).sort()).toEqual(
@@ -381,6 +471,8 @@ describe('Spec 111: RBAC implementation', () => {
 			expect(apiKey.data.map((document) => document.id).sort()).toEqual(
 				[internalFixture.source.id, restrictedFixture.source.id].sort(),
 			);
+			expect(memberEntity.data.aliases.map((alias) => alias.alias)).not.toContain('Restricted API Alias');
+			expect(adminEntity.data.aliases.map((alias) => alias.alias)).toContain('Restricted API Alias');
 		},
 	);
 });

--- a/tests/specs/111_rbac_implementation.test.ts
+++ b/tests/specs/111_rbac_implementation.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import pg from 'pg';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
 import { ensureSchema, MULDER_TEST_TABLES, truncateExistingTables } from '../lib/schema.js';
 
@@ -205,6 +205,11 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+	if (!pgAvailable) return;
+	cleanTables();
+});
+
+afterEach(() => {
 	if (!pgAvailable) return;
 	cleanTables();
 });

--- a/tests/specs/111_rbac_implementation.test.ts
+++ b/tests/specs/111_rbac_implementation.test.ts
@@ -25,12 +25,25 @@ const PG_CONFIG = {
 	password: db.TEST_PG_PASSWORD,
 };
 
+type ApiDocumentsModule = {
+	resetDocumentContextForTests(): void;
+	listDocuments(
+		input: { limit: number; offset: number },
+		logger: import('@mulder/core').Logger,
+		options: { authPrincipal: TestAuthPrincipal },
+	): Promise<{ data: Array<{ id: string }> }>;
+};
+
+type TestAuthPrincipal =
+	| { type: 'session'; userId: string; email: string; role: 'member' | 'admin' | 'owner' }
+	| { type: 'api_key'; keyName: string };
+
 const pgAvailable = db.isPgAvailable();
 let pool: pg.Pool;
 let tempDir: string | null = null;
 let previousConfigPath: string | undefined;
 let coreModule: typeof import('@mulder/core');
-let apiDocumentsModule: typeof import('../../apps/api/src/lib/documents.js');
+let apiDocumentsModule: ApiDocumentsModule;
 
 function buildPackage(packageDir: string): void {
 	const result = spawnSync('pnpm', ['build'], {
@@ -101,7 +114,7 @@ function sensitivityMetadata(level: import('@mulder/core').SensitivityLevel) {
 	};
 }
 
-async function createSourceFixture(level: import('@mulder/core').SensitivityLevel, label = level) {
+async function createSourceFixture(level: import('@mulder/core').SensitivityLevel, label: string = level) {
 	const source = await coreModule.createSource(pool, {
 		filename: `${label}-${randomUUID()}.md`,
 		storagePath: `raw/${label}-${randomUUID()}.md`,
@@ -172,7 +185,7 @@ beforeAll(async () => {
 	buildPackage(CLI_DIR);
 	buildPackage(API_DIR);
 	coreModule = await import(pathToFileURL(CORE_DIST).href);
-	apiDocumentsModule = await import(pathToFileURL(API_DOCUMENTS_DIST).href);
+	apiDocumentsModule = (await import(pathToFileURL(API_DOCUMENTS_DIST).href)) as ApiDocumentsModule;
 
 	if (!pgAvailable) return;
 	ensureSchema();
@@ -214,18 +227,26 @@ describe('Spec 111: RBAC implementation', () => {
 		const config = coreModule.loadConfig(writeMinimalConfig('helpers'));
 		const analyst = coreModule.resolveAccessPolicy(config, { kind: 'browser_session', browserRole: 'member' });
 		const admin = coreModule.resolveAccessPolicy(config, { kind: 'browser_session', browserRole: 'admin' });
+		const sensitivityLevels: import('@mulder/core').SensitivityLevel[] = [
+			'public',
+			'internal',
+			'restricted',
+			'confidential',
+		];
 
 		expect(coreModule.allowedSensitivityLevelsForMax('internal')).toEqual(['public', 'internal']);
-		expect(
-			['public', 'internal', 'restricted', 'confidential'].map((level) =>
-				coreModule.canReadSensitivityLevel(analyst, level),
-			),
-		).toEqual([true, true, false, false]);
-		expect(
-			['public', 'internal', 'restricted', 'confidential'].map((level) =>
-				coreModule.canReadSensitivityLevel(admin, level),
-			),
-		).toEqual([true, true, true, true]);
+		expect(sensitivityLevels.map((level) => coreModule.canReadSensitivityLevel(analyst, level))).toEqual([
+			true,
+			true,
+			false,
+			false,
+		]);
+		expect(sensitivityLevels.map((level) => coreModule.canReadSensitivityLevel(admin, level))).toEqual([
+			true,
+			true,
+			true,
+			true,
+		]);
 	});
 
 	it.skipIf(!pgAvailable)('QA-03: roles persist and round-trip', async () => {
@@ -262,8 +283,8 @@ describe('Spec 111: RBAC implementation', () => {
 			severityRationale: 'Fixture conflict',
 			confidence: 0.8,
 			assertions: [
-				{ assertionId: assertionA.id, sourceDocumentId: internalFixture.source.id, claim: assertionA.content },
-				{ assertionId: assertionB.id, sourceDocumentId: restrictedFixture.source.id, claim: assertionB.content },
+				{ assertionId: assertionA.id, participantRole: 'claim_a', claim: assertionA.content },
+				{ assertionId: assertionB.id, participantRole: 'claim_b', claim: assertionB.content },
 			],
 			sensitivityLevel: 'restricted',
 			sensitivityMetadata: sensitivityMetadata('restricted'),

--- a/tests/specs/16_ingest_step.test.ts
+++ b/tests/specs/16_ingest_step.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as db from '../lib/db.js';
+import { truncateExistingTables } from '../lib/schema.js';
 import { cleanStorageDirSince, type StorageSnapshot, snapshotStorageDir, testStoragePath } from '../lib/storage.js';
 
 const ROOT = resolve(import.meta.dirname, '../..');
@@ -53,7 +54,7 @@ function runCli(
 }
 
 function cleanSourceData(): void {
-	db.runSql('DELETE FROM source_steps; DELETE FROM sources; DELETE FROM document_blobs;');
+	truncateExistingTables(['document_blobs', 'source_steps', 'sources']);
 }
 
 /**

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -15,6 +15,7 @@ const TEST_LANES_SCRIPT = resolve(ROOT, 'scripts/test-lanes.mjs');
 const PACKAGE_JSON = resolve(ROOT, 'package.json');
 
 type AffectedPlan = {
+	changeScope: string;
 	totalFiles: number;
 	lanes: Record<string, { count: number; files: string[]; totalWeight: number }>;
 	files: Array<{ relativePath: string; lane: string; weight: number }>;
@@ -46,12 +47,16 @@ function runVitest(args: string[], env?: Record<string, string>): { stdout: stri
 	};
 }
 
-function runTestLanes(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+function runTestLanes(
+	args: string[],
+	env?: Record<string, string>,
+): { stdout: string; stderr: string; exitCode: number } {
 	const result = spawnSync('node', [TEST_LANES_SCRIPT, ...args], {
 		cwd: ROOT,
 		encoding: 'utf-8',
 		timeout: 60_000,
 		stdio: ['pipe', 'pipe', 'pipe'],
+		env: { ...process.env, ...env },
 	});
 
 	return {
@@ -70,6 +75,16 @@ function affectedPlanForFiles(changedFiles: string[]): AffectedPlan {
 
 function affectedPlanFor(changedFile: string): AffectedPlan {
 	return affectedPlanForFiles([changedFile]);
+}
+
+function affectedHeadPlanForFiles(changedFiles: string[]): AffectedPlan {
+	const result = runTestLanes(['affected-plan', 'origin/main', '--json'], {
+		MULDER_TEST_AFFECTED_PR_HEAD_DOCS_ONLY: 'true',
+		MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES: changedFiles.join('\n'),
+		MULDER_TEST_SKIP_HEALTH_SPEC_IN_AFFECTED: 'true',
+	});
+	expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+	return JSON.parse(result.stdout) as AffectedPlan;
 }
 
 function resetSchemaToMissing(): void {
@@ -310,6 +325,17 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		expect(plan.lanes.heavy.count).toBe(0);
 	});
 
+	it('QA-05e6: docs-only PR head commits do not select DB or schema lanes', () => {
+		const plan = affectedHeadPlanForFiles(['docs/specs/111_rbac_implementation.spec.md', 'docs/roadmap.md']);
+
+		expect(plan.changeScope).toBe('head-docs-only');
+		expect(plan.totalFiles).toBe(0);
+		expect(plan.lanes.schema.count).toBe(0);
+		expect(plan.lanes.db.count).toBe(0);
+		expect(plan.lanes.heavy.count).toBe(0);
+		expect(plan.rules.every((rule) => rule.rule === 'head docs-only change (build/lint only)')).toBe(true);
+	});
+
 	it('QA-05f: affected lane shards pass cleanly when their selected shard is empty', () => {
 		const emptyDbShard = runTestLanes([
 			'affected-lane',
@@ -383,5 +409,37 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		} finally {
 			rmSync(storageRoot, { recursive: true, force: true });
 		}
+	});
+
+	it('QA-07: test runner defaults fresh checkouts to the shipped example config', () => {
+		const env = { ...process.env };
+		delete env.MULDER_CONFIG;
+		const result = spawnSync(
+			'node',
+			[
+				'scripts/test-runner.mjs',
+				'run',
+				'qa59-config',
+				'--',
+				'node',
+				'--input-type=module',
+				'-e',
+				[
+					'const config = process.env.MULDER_CONFIG;',
+					"if (!config || !config.endsWith('mulder.config.example.yaml')) throw new Error('unexpected config ' + config);",
+				].join(' '),
+			],
+			{
+				cwd: ROOT,
+				encoding: 'utf-8',
+				timeout: 60_000,
+				stdio: ['pipe', 'pipe', 'pipe'],
+				env,
+			},
+		);
+
+		expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+		expect(result.stdout).toContain('test-runner: config=');
+		expect(result.stdout).toContain('mulder.config.example.yaml');
 	});
 });

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -61,10 +61,15 @@ function runTestLanes(args: string[]): { stdout: string; stderr: string; exitCod
 	};
 }
 
-function affectedPlanFor(changedFile: string): AffectedPlan {
-	const result = runTestLanes(['affected-plan', '--changed-file', changedFile, '--json']);
+function affectedPlanForFiles(changedFiles: string[]): AffectedPlan {
+	const changedFileArgs = changedFiles.flatMap((changedFile) => ['--changed-file', changedFile]);
+	const result = runTestLanes(['affected-plan', ...changedFileArgs, '--json']);
 	expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
 	return JSON.parse(result.stdout) as AffectedPlan;
+}
+
+function affectedPlanFor(changedFile: string): AffectedPlan {
+	return affectedPlanForFiles([changedFile]);
 }
 
 function resetSchemaToMissing(): void {
@@ -268,6 +273,41 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 			]),
 		);
 		expect(taxonomyPlan.totalFiles).toBeLessThan(10);
+	});
+
+	it('QA-05e4: access-role migrations stay scoped to schema and RBAC specs', () => {
+		const plan = affectedPlanFor('packages/core/src/database/migrations/041_access_roles.sql');
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(files).toEqual(
+			expect.arrayContaining([
+				'tests/specs/08_core_schema_migrations.test.ts',
+				'tests/specs/111_rbac_implementation.test.ts',
+			]),
+		);
+		expect(plan.totalFiles).toBe(2);
+		expect(plan.lanes.heavy.count).toBe(0);
+	});
+
+	it('QA-05e5: RBAC API/config surfaces do not fan out to the full DB lane', () => {
+		const plan = affectedPlanForFiles([
+			'mulder.config.example.yaml',
+			'packages/core/src/shared/access-control.ts',
+			'apps/api/src/lib/documents.ts',
+			'apps/api/src/lib/entities.ts',
+		]);
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(files).toEqual(
+			expect.arrayContaining([
+				'tests/specs/03_config_loader.test.ts',
+				'tests/specs/74_entity_api_routes.test.ts',
+				'tests/specs/76_document_retrieval_routes.test.ts',
+				'tests/specs/111_rbac_implementation.test.ts',
+			]),
+		);
+		expect(plan.totalFiles).toBe(4);
+		expect(plan.lanes.heavy.count).toBe(0);
 	});
 
 	it('QA-05f: affected lane shards pass cleanly when their selected shard is empty', () => {


### PR DESCRIPTION
## Summary
- add RBAC access-control policy helpers, default roles, config schema/defaults, and example config roles
- add access_roles migration/repository and sensitivity-aware repository/API filtering for documents, entities, stories, conflicts, reviews, and translations
- narrow affected-test planning for RBAC migrations/config/API surfaces so docs/config changes do not fan out into unrelated DB/heavy suites

Closes #293

## Verification
- git diff --check
- npx biome check on changed implementation/planner/test files
- pnpm --filter @mulder/core build
- pnpm --filter @mulder/api build
- pnpm --filter @mulder/tests typecheck
- pnpm exec vitest run tests/specs/111_rbac_implementation.test.ts --reporter=verbose
- pnpm test:scope run step M11-L5 -- --reporter=verbose
- pnpm test:affected:plan -- origin/milestone/11
- MULDER_TEST_ISOLATED_DB=true pnpm test:affected -- origin/milestone/11 -- --reporter=verbose