### PR TITLE
Fix M11 review warnings

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -315,6 +315,8 @@ Builds the trust infrastructure. Depends on M10 foundations (provenance, asserti
 | 🟢 | L4 | Translation service — two paths, caching | §A7 |
 | 🟢 | L5 | RBAC implementation — roles, permissions, sensitivity-based filtering | §A5.3 |
 
+**Post-review repair:** Spec 112 records the M11 review-warning fixes for credibility trust metadata, review metrics reservation, and assertion-classification review artifact registration. M11 remains complete at `5/5`.
+
 **Also read for all M11 steps:** §A3 (assertion types), §A5 (sensitivity)
 
 **Testable:** Credibility profiles auto-generated on ingest. Contradictions detected and modeled as graph entities. Review queues populated. Documents translatable. Role-based access filtering works.

--- a/docs/specs/109_review_workflow_infrastructure.spec.md
+++ b/docs/specs/109_review_workflow_infrastructure.spec.md
@@ -55,7 +55,7 @@ The review layer is not a parallel fact store. It records the human-review state
 
 - Review API routes, app UI, notifications, export/import of offline review batches, or project-board style reviewer assignment screens.
 - Expertise weighting, gamification, consensus algorithms, or any product choice listed as open in §A13.8.
-- Agent findings, taxonomy mappings, similar-case links, and assertion-classification review integration beyond keeping the artifact type model generic enough for later steps.
+- Agent findings, taxonomy mappings, and similar-case links beyond keeping the artifact type model generic enough for later steps.
 - Changing credibility dimension scores, conflict severity, or assertion classification values automatically based on review metrics.
 - Background schedulers for auto-approval. L3 provides a repository operation that callers can invoke later.
 
@@ -102,7 +102,8 @@ L3 blocks L4/L5 only at the milestone integration level, but it directly enables
    - `artifact_types.taxonomy_mapping` defaults to single-review and auto-approve after 336 hours.
    - `artifact_types.similar_case_link` defaults to single-review and auto-approve after 168 hours.
    - `artifact_types.agent_finding` defaults to single-review and no auto-approval.
-   - `metrics.track_accuracy`, `auto_adjust_depth`, `accuracy_threshold_for_upgrade`, and `accuracy_threshold_for_downgrade` match §A13.
+   - `metrics.track_accuracy`, `accuracy_threshold_for_upgrade`, and `accuracy_threshold_for_downgrade` match §A13.
+   - `metrics.auto_adjust_depth` is explicitly reserved with a default of `false` until a review-depth policy worker is implemented.
 
 4. Integrate existing M11 artifacts:
    - When a source credibility profile is created or updated with `profile_author = llm_auto` or draft-like status, upsert a `credibility_profile` review artifact with a compact current value and source context.
@@ -113,6 +114,7 @@ L3 blocks L4/L5 only at the milestone integration level, but it directly enables
 5. Add metrics-ready behavior without automating policy decisions:
    - Repository list options expose status/action filters sufficient for later accuracy reporting.
    - L3 does not implement automatic review-depth upgrades/downgrades. It stores config and events needed for that later behavior.
+   - The default config therefore keeps `review_workflow.metrics.auto_adjust_depth = false`; setting it to `true` is non-operational until a later worker/spec defines the policy loop.
 
 6. Update roadmap state only after gates:
    - Keep L3 in progress while implementation is open.
@@ -159,6 +161,11 @@ L3 blocks L4/L5 only at the milestone integration level, but it directly enables
    - Given a conflict node and a typed conflict resolution are created
    - When the conflict repository completes
    - Then `conflict_node` and `conflict_resolution` review artifacts exist with participant/resolution context and can be found through the conflict review queue.
+
+9. **QA-09: LLM assertion classifications register review artifacts**
+   - Given a knowledge assertion whose classification provenance is `llm_auto`
+   - When the assertion repository persists it
+   - Then an `assertion_classification` review artifact exists with assertion value, provenance, and sensitivity context.
 
 ## 5b. CLI Test Matrix
 

--- a/docs/specs/112_m11_trust_layer_review_repair.spec.md
+++ b/docs/specs/112_m11_trust_layer_review_repair.spec.md
@@ -1,0 +1,93 @@
+---
+spec: 112
+title: "M11 Trust Layer Review Repair"
+roadmap_step: "M11 post-review"
+functional_spec: "§A3, §A5, §A6, §A8, §A13"
+scope: "repair"
+issue: "https://github.com/mulkatz/mulder/issues/295"
+created: 2026-05-07
+---
+
+# Spec 112: M11 Trust Layer Review Repair
+
+## 1. Objective
+
+Close the M11 milestone review warnings without reopening the completed M11 roadmap steps. The repair makes credibility profiles first-class trust artifacts, removes the misleading implication that review metrics already auto-adjust review depth, and connects LLM-generated assertion classifications to the generic review workflow.
+
+## 2. Boundaries
+
+**Roadmap step:** M11 post-review repair. M11 remains `5/5`; this spec does not add a sixth roadmap task.
+
+**Base branch:** `milestone/11`.
+
+**Target branch:** `fix/m11-review-warnings`.
+
+**In scope:**
+
+- Add provenance and sensitivity fields to `source_credibility_profiles`.
+- Backfill credibility profile trust metadata from the owning source.
+- Add sensitivity-aware list/find options for credibility profiles.
+- Include credibility profile provenance/sensitivity in review artifact context.
+- Set `review_workflow.metrics.auto_adjust_depth` default to `false` and document it as reserved.
+- Register `assertion_classification` review artifacts when `knowledge_assertions.classification_provenance = 'llm_auto'`.
+
+**Out of scope:**
+
+- A review-depth metrics worker or automatic policy loop.
+- External query gate audit behavior for agents/exports.
+- Agent-driven or human-reported conflict detection surfaces.
+- UI/API review routes.
+
+## 3. Blueprint
+
+1. Add migration `042_source_credibility_trust_metadata.sql`:
+   - Add `provenance JSONB`, `sensitivity_level TEXT`, and `sensitivity_metadata JSONB` to `source_credibility_profiles`.
+   - Backfill profile provenance to include the owning source ID.
+   - Backfill sensitivity from `sources.sensitivity_level` and `sources.sensitivity_metadata`.
+   - Add shape checks and indexes for provenance source IDs and sensitivity level.
+
+2. Update credibility repository APIs:
+   - Extend `SourceCredibilityProfile` with provenance and sensitivity metadata.
+   - Extend upsert input with optional provenance/sensitivity overrides.
+   - Extend list/find options with `maxSensitivityLevel`.
+   - Filter by both stored profile sensitivity and current owning source sensitivity.
+
+3. Update review workflow integration:
+   - Credibility profile review artifacts include `provenance`, `sensitivity_level`, and `sensitivity_metadata` in context.
+   - LLM-generated assertion classifications create idempotent `assertion_classification` review artifacts.
+   - Human-reviewed assertion classifications do not create new automatic review work.
+
+4. Reserve review metrics auto-adjustment:
+   - Change defaults/schema/example config to `auto_adjust_depth: false`.
+   - Keep accuracy thresholds available for later reporting and worker implementation.
+
+## 4. QA Contract
+
+1. **Credibility trust metadata**
+   - Given a migrated database
+   - Then credibility profile schema exposes provenance and sensitivity constraints/indexes.
+
+2. **Credibility access filtering**
+   - Given a restricted source with a credibility profile
+   - Then an internal-only profile list/find does not return it, while a restricted reader can access it.
+
+3. **Review artifact context**
+   - Given an LLM-generated credibility profile
+   - Then its review artifact context carries source ID, provenance, sensitivity level, and sensitivity metadata.
+
+4. **Metrics reservation**
+   - Given a minimal config with `review_workflow` omitted
+   - Then `review_workflow.metrics.auto_adjust_depth` defaults to `false`.
+
+5. **Assertion classification review**
+   - Given an LLM-auto knowledge assertion classification
+   - Then an `assertion_classification` review artifact is created with current value and trust context.
+   - Given a human-reviewed classification
+   - Then no new automatic review artifact is created.
+
+## 5. Follow-Up Tracking
+
+Create follow-up GitHub issues instead of implementing these in M11 repair:
+
+- External query gating/access audit for later agent/export safety specs: https://github.com/mulkatz/mulder/issues/296
+- Agent-driven and human-reported conflict detection surfaces for later API/UI/agent specs: https://github.com/mulkatz/mulder/issues/297

--- a/mulder.config.example.yaml
+++ b/mulder.config.example.yaml
@@ -202,6 +202,15 @@ access_control:
   external_query_gate:
     enabled: false
 
+# --- Review Workflow ---
+review_workflow:
+  enabled: true
+  metrics:
+    track_accuracy: true
+    auto_adjust_depth: false           # Reserved until a review-depth policy worker exists
+    accuracy_threshold_for_upgrade: 0.7
+    accuracy_threshold_for_downgrade: 0.95
+
 # --- Enrichment ---
 enrichment:
   model: "gemini-2.5-flash"

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -220,7 +220,7 @@ export const CONFIG_DEFAULTS = {
 		},
 		metrics: {
 			track_accuracy: true,
-			auto_adjust_depth: true,
+			auto_adjust_depth: false,
 			accuracy_threshold_for_upgrade: 0.7,
 			accuracy_threshold_for_downgrade: 0.95,
 		},

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -413,7 +413,7 @@ const reviewWorkflowArtifactTypeSchema = z.object({
 
 const reviewWorkflowMetricsSchema = z.object({
 	track_accuracy: z.boolean().default(true),
-	auto_adjust_depth: z.boolean().default(true),
+	auto_adjust_depth: z.boolean().default(false),
 	accuracy_threshold_for_upgrade: z.number().min(0).max(1).default(0.7),
 	accuracy_threshold_for_downgrade: z.number().min(0).max(1).default(0.95),
 });

--- a/packages/core/src/database/migrations/042_source_credibility_trust_metadata.sql
+++ b/packages/core/src/database/migrations/042_source_credibility_trust_metadata.sql
@@ -1,0 +1,101 @@
+ALTER TABLE source_credibility_profiles
+  ADD COLUMN IF NOT EXISTS provenance JSONB NOT NULL DEFAULT jsonb_build_object(
+    'source_document_ids', '[]'::jsonb,
+    'extraction_pipeline_run', 'null'::jsonb,
+    'created_at', to_jsonb(now())
+  ),
+  ADD COLUMN IF NOT EXISTS sensitivity_level TEXT NOT NULL DEFAULT 'internal',
+  ADD COLUMN IF NOT EXISTS sensitivity_metadata JSONB NOT NULL DEFAULT jsonb_build_object(
+    'level', 'internal',
+    'reason', 'default_policy',
+    'assigned_by', 'policy_rule',
+    'assigned_at', to_jsonb(now()),
+    'pii_types', '[]'::jsonb,
+    'declassify_date', 'null'::jsonb
+  );
+
+UPDATE source_credibility_profiles p
+SET
+  provenance = jsonb_build_object(
+    'source_document_ids', jsonb_build_array(p.source_id::text),
+    'extraction_pipeline_run', 'null'::jsonb,
+    'created_at', to_jsonb(COALESCE(p.created_at, now()))
+  ),
+  sensitivity_level = COALESCE(s.sensitivity_level, p.sensitivity_level, 'internal'),
+  sensitivity_metadata = jsonb_build_object(
+    'level', COALESCE(s.sensitivity_level, p.sensitivity_level, 'internal'),
+    'reason', COALESCE(NULLIF(s.sensitivity_metadata->>'reason', ''), 'source_policy'),
+    'assigned_by', COALESCE(NULLIF(s.sensitivity_metadata->>'assigned_by', ''), 'policy_rule'),
+    'assigned_at', COALESCE(NULLIF(s.sensitivity_metadata->>'assigned_at', ''), now()::text),
+    'pii_types', CASE
+      WHEN jsonb_typeof(s.sensitivity_metadata->'pii_types') = 'array'
+        THEN s.sensitivity_metadata->'pii_types'
+      ELSE '[]'::jsonb
+    END,
+    'declassify_date', COALESCE(s.sensitivity_metadata->'declassify_date', 'null'::jsonb)
+  )
+FROM sources s
+WHERE s.id = p.source_id;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'source_credibility_profiles_provenance_object_check'
+  ) THEN
+    ALTER TABLE source_credibility_profiles
+      ADD CONSTRAINT source_credibility_profiles_provenance_object_check CHECK (
+        jsonb_typeof(provenance) = 'object'
+        AND provenance ? 'source_document_ids'
+        AND provenance ? 'extraction_pipeline_run'
+        AND provenance ? 'created_at'
+        AND jsonb_typeof(provenance->'source_document_ids') = 'array'
+        AND (
+          provenance->'extraction_pipeline_run' = 'null'::jsonb
+          OR jsonb_typeof(provenance->'extraction_pipeline_run') = 'string'
+        )
+        AND jsonb_typeof(provenance->'created_at') = 'string'
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'source_credibility_profiles_sensitivity_level_check'
+  ) THEN
+    ALTER TABLE source_credibility_profiles
+      ADD CONSTRAINT source_credibility_profiles_sensitivity_level_check CHECK (
+        sensitivity_level IN ('public', 'internal', 'restricted', 'confidential')
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'source_credibility_profiles_sensitivity_metadata_shape_check'
+  ) THEN
+    ALTER TABLE source_credibility_profiles
+      ADD CONSTRAINT source_credibility_profiles_sensitivity_metadata_shape_check CHECK (
+        jsonb_typeof(sensitivity_metadata) = 'object'
+        AND sensitivity_metadata ? 'level'
+        AND sensitivity_metadata ? 'reason'
+        AND sensitivity_metadata ? 'assigned_by'
+        AND sensitivity_metadata ? 'assigned_at'
+        AND sensitivity_metadata ? 'pii_types'
+        AND sensitivity_metadata ? 'declassify_date'
+        AND sensitivity_metadata->>'level' = sensitivity_level
+        AND sensitivity_metadata->>'level' IN ('public', 'internal', 'restricted', 'confidential')
+        AND sensitivity_metadata->>'assigned_by' IN ('llm_auto', 'human', 'policy_rule')
+        AND jsonb_typeof(sensitivity_metadata->'pii_types') = 'array'
+        AND (
+          sensitivity_metadata->'declassify_date' = 'null'::jsonb
+          OR jsonb_typeof(sensitivity_metadata->'declassify_date') = 'string'
+        )
+      );
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_source_credibility_profiles_provenance_source_ids
+  ON source_credibility_profiles USING GIN ((provenance -> 'source_document_ids'));
+
+CREATE INDEX IF NOT EXISTS idx_source_credibility_profiles_sensitivity_level
+  ON source_credibility_profiles(sensitivity_level);

--- a/packages/core/src/database/repositories/knowledge-assertion.repository.ts
+++ b/packages/core/src/database/repositories/knowledge-assertion.repository.ts
@@ -14,6 +14,7 @@ import type {
 	ListKnowledgeAssertionsInput,
 	UpsertKnowledgeAssertionInput,
 } from './knowledge-assertion.types.js';
+import { upsertReviewableArtifact } from './review-workflow.repository.js';
 
 type Queryable = pg.Pool | pg.PoolClient;
 
@@ -138,6 +139,10 @@ function mapKnowledgeAssertionRow(row: KnowledgeAssertionRow): KnowledgeAssertio
 	};
 }
 
+function parseJsonValue(value: string): unknown {
+	return JSON.parse(value);
+}
+
 function listSuffix(
 	options: ListKnowledgeAssertionsInput | undefined,
 	startIndex: number,
@@ -216,7 +221,35 @@ export async function upsertKnowledgeAssertion(
 			sensitivityLevel,
 			stringifySensitivityMetadata(input.sensitivityMetadata, sensitivityLevel),
 		]);
-		return mapKnowledgeAssertionRow(result.rows[0]);
+		const assertion = mapKnowledgeAssertionRow(result.rows[0]);
+		if (assertion.classificationProvenance === 'llm_auto') {
+			await upsertReviewableArtifact(pool, {
+				artifactType: 'assertion_classification',
+				subjectId: assertion.id,
+				subjectTable: 'knowledge_assertions',
+				createdBy: 'llm_auto',
+				reviewStatus: 'pending',
+				currentValue: {
+					assertion_type: assertion.assertionType,
+					content: assertion.content,
+					confidence_metadata: mapConfidenceMetadataToDb(assertion.confidenceMetadata),
+					classification_provenance: assertion.classificationProvenance,
+					extracted_entity_ids: assertion.extractedEntityIds,
+					quality_metadata: assertion.qualityMetadata,
+				},
+				context: {
+					source_id: assertion.sourceId,
+					story_id: assertion.storyId,
+					provenance: parseJsonValue(stringifyArtifactProvenance(assertion.provenance)),
+					sensitivity_level: assertion.sensitivityLevel,
+					sensitivity_metadata: parseJsonValue(
+						stringifySensitivityMetadata(assertion.sensitivityMetadata, assertion.sensitivityLevel),
+					),
+				},
+				sourceId: assertion.sourceId,
+			});
+		}
+		return assertion;
 	} catch (error: unknown) {
 		if (error instanceof DatabaseError) {
 			throw error;

--- a/packages/core/src/database/repositories/source-credibility.repository.ts
+++ b/packages/core/src/database/repositories/source-credibility.repository.ts
@@ -1,5 +1,12 @@
 import type pg from 'pg';
+import { allowedSensitivityLevelsForMax } from '../../shared/access-control.js';
 import { DATABASE_ERROR_CODES, DatabaseError } from '../../shared/errors.js';
+import { normalizeSensitivityMetadata, stringifySensitivityMetadata } from '../../shared/sensitivity.js';
+import {
+	mapArtifactProvenanceFromDb,
+	normalizeArtifactProvenance,
+	stringifyArtifactProvenance,
+} from './artifact-provenance.js';
 import { upsertReviewableArtifact } from './review-workflow.repository.js';
 import type {
 	CredibilityProfileAuthor,
@@ -32,6 +39,9 @@ interface JoinedRow {
 	profile_author: CredibilityProfileAuthor;
 	last_reviewed: Date | null;
 	review_status: CredibilityReviewStatus;
+	provenance: unknown;
+	sensitivity_level: SourceCredibilityProfile['sensitivityLevel'];
+	sensitivity_metadata: unknown;
 	profile_created_at: Date;
 	profile_updated_at: Date;
 	dim_row_id: string | null;
@@ -43,6 +53,13 @@ interface JoinedRow {
 	known_factors: string[] | null;
 	dim_created_at: Date | null;
 	dim_updated_at: Date | null;
+}
+
+interface SourceTrustRow {
+	id: string;
+	sensitivity_level: SourceCredibilityProfile['sensitivityLevel'];
+	sensitivity_metadata: unknown;
+	created_at: Date;
 }
 
 function isPool(value: Queryable): value is pg.Pool {
@@ -65,6 +82,26 @@ function required(value: string, field: string): string {
 
 function normalizeTextArray(value: readonly string[] | undefined): string[] {
 	return [...new Set((value ?? []).map((item) => item.trim()).filter(Boolean))].sort((a, b) => a.localeCompare(b));
+}
+
+function parseJsonValue(value: string): unknown {
+	return JSON.parse(value);
+}
+
+function profileProvenanceForSource(
+	sourceId: string,
+	input: UpsertSourceCredibilityProfileInput['provenance'],
+	sourceCreatedAt: Date,
+) {
+	const provenance = normalizeArtifactProvenance(
+		input ?? { sourceDocumentIds: [sourceId], createdAt: sourceCreatedAt },
+	);
+	return {
+		...provenance,
+		sourceDocumentIds: [...new Set([...provenance.sourceDocumentIds, sourceId])].sort((left, right) =>
+			left.localeCompare(right),
+		),
+	};
 }
 
 function validate(input: UpsertSourceCredibilityProfileInput): void {
@@ -101,6 +138,12 @@ function collectProfiles(rows: JoinedRow[]): SourceCredibilityProfile[] {
 				profileAuthor: row.profile_author,
 				lastReviewed: row.last_reviewed,
 				reviewStatus: row.review_status,
+				provenance: mapArtifactProvenanceFromDb(row.provenance),
+				sensitivityLevel: row.sensitivity_level ?? 'internal',
+				sensitivityMetadata: normalizeSensitivityMetadata(
+					row.sensitivity_metadata,
+					row.sensitivity_level ?? 'internal',
+				),
 				dimensions: [],
 				createdAt: row.profile_created_at,
 				updatedAt: row.profile_updated_at,
@@ -133,10 +176,12 @@ async function readProfiles(pool: Queryable, whereSql: string, params: unknown[]
 		`
 			SELECT
 				p.profile_id, p.source_id, p.source_name, p.source_type, p.profile_author,
-				p.last_reviewed, p.review_status, p.created_at AS profile_created_at, p.updated_at AS profile_updated_at,
+				p.last_reviewed, p.review_status, p.provenance, p.sensitivity_level, p.sensitivity_metadata,
+				p.created_at AS profile_created_at, p.updated_at AS profile_updated_at,
 				d.id AS dim_row_id, d.dimension_id, d.label, d.score, d.rationale, d.evidence_refs, d.known_factors,
 				d.created_at AS dim_created_at, d.updated_at AS dim_updated_at
 			FROM source_credibility_profiles p
+			JOIN sources s ON s.id = p.source_id
 			LEFT JOIN credibility_dimensions d ON d.profile_id = p.profile_id
 			${whereSql}
 			ORDER BY p.updated_at DESC, p.source_name ASC, p.profile_id ASC, d.dimension_id ASC
@@ -149,13 +194,21 @@ async function readProfiles(pool: Queryable, whereSql: string, params: unknown[]
 export async function findSourceCredibilityProfileBySourceId(
 	pool: Queryable,
 	sourceId: string,
+	options?: Pick<SourceCredibilityProfileListOptions, 'maxSensitivityLevel'>,
 ): Promise<SourceCredibilityProfile | null> {
+	const params: unknown[] = [sourceId];
+	const filters = ['p.source_id = $1'];
+	if (options?.maxSensitivityLevel) {
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		filters.push(`p.sensitivity_level = ANY($${params.length})`);
+		filters.push(`s.sensitivity_level = ANY($${params.length})`);
+	}
 	try {
-		return (await readProfiles(pool, 'WHERE p.source_id = $1', [sourceId]))[0] ?? null;
+		return (await readProfiles(pool, `WHERE ${filters.join(' AND ')}`, params))[0] ?? null;
 	} catch (cause: unknown) {
 		throw new DatabaseError('Failed to find source credibility profile', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
 			cause,
-			context: { sourceId },
+			context: { sourceId, maxSensitivityLevel: options?.maxSensitivityLevel },
 		});
 	}
 }
@@ -176,6 +229,11 @@ export async function listSourceCredibilityProfiles(
 		params.push(options.reviewStatus);
 		filters.push(`p.review_status = $${params.length}`);
 	}
+	if (options?.maxSensitivityLevel) {
+		params.push(allowedSensitivityLevelsForMax(options.maxSensitivityLevel));
+		filters.push(`p.sensitivity_level = ANY($${params.length})`);
+		filters.push(`s.sensitivity_level = ANY($${params.length})`);
+	}
 	const where = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
 	const limit = options?.limit ?? 100;
 	const offset = options?.offset ?? 0;
@@ -184,25 +242,58 @@ export async function listSourceCredibilityProfiles(
 	} catch (cause: unknown) {
 		throw new DatabaseError('Failed to list source credibility profiles', DATABASE_ERROR_CODES.DB_QUERY_FAILED, {
 			cause,
-			context: { sourceType: options?.sourceType, reviewStatus: options?.reviewStatus, limit, offset },
+			context: {
+				sourceType: options?.sourceType,
+				reviewStatus: options?.reviewStatus,
+				maxSensitivityLevel: options?.maxSensitivityLevel,
+				limit,
+				offset,
+			},
 		});
 	}
+}
+
+async function readSourceTrust(client: Queryable, sourceId: string): Promise<SourceTrustRow> {
+	const result = await client.query<SourceTrustRow>(
+		'SELECT id, sensitivity_level, sensitivity_metadata, created_at FROM sources WHERE id = $1',
+		[sourceId],
+	);
+	const source = result.rows[0];
+	if (!source) fail('Source credibility profile source does not exist', { sourceId });
+	return source;
 }
 
 async function writeProfile(
 	client: Queryable,
 	input: UpsertSourceCredibilityProfileInput,
 ): Promise<SourceCredibilityProfile> {
+	const source = await readSourceTrust(client, input.sourceId);
+	const sensitivityLevel = input.sensitivityLevel ?? source.sensitivity_level ?? 'internal';
+	const sensitivityMetadata = input.sensitivityMetadata ?? source.sensitivity_metadata;
+	const provenance = profileProvenanceForSource(input.sourceId, input.provenance, source.created_at);
 	const profile = await client.query<{ profile_id: string }>(
 		`
-			INSERT INTO source_credibility_profiles (source_id, source_name, source_type, profile_author, last_reviewed, review_status)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO source_credibility_profiles (
+				source_id,
+				source_name,
+				source_type,
+				profile_author,
+				last_reviewed,
+				review_status,
+				provenance,
+				sensitivity_level,
+				sensitivity_metadata
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb)
 			ON CONFLICT (source_id) DO UPDATE SET
 				source_name = EXCLUDED.source_name,
 				source_type = EXCLUDED.source_type,
 				profile_author = EXCLUDED.profile_author,
 				last_reviewed = EXCLUDED.last_reviewed,
 				review_status = EXCLUDED.review_status,
+				provenance = EXCLUDED.provenance,
+				sensitivity_level = EXCLUDED.sensitivity_level,
+				sensitivity_metadata = EXCLUDED.sensitivity_metadata,
 				updated_at = now()
 			RETURNING profile_id
 		`,
@@ -213,6 +304,9 @@ async function writeProfile(
 			input.profileAuthor ?? 'llm_auto',
 			input.lastReviewed ?? null,
 			input.reviewStatus ?? 'draft',
+			stringifyArtifactProvenance(provenance),
+			sensitivityLevel,
+			stringifySensitivityMetadata(sensitivityMetadata, sensitivityLevel),
 		],
 	);
 	const profileId = profile.rows[0].profile_id;
@@ -272,6 +366,11 @@ async function writeProfile(
 				source_id: written.sourceId,
 				last_reviewed: written.lastReviewed?.toISOString() ?? null,
 				dimension_count: written.dimensions.length,
+				provenance: parseJsonValue(stringifyArtifactProvenance(written.provenance)),
+				sensitivity_level: written.sensitivityLevel,
+				sensitivity_metadata: parseJsonValue(
+					stringifySensitivityMetadata(written.sensitivityMetadata, written.sensitivityLevel),
+				),
 			},
 			sourceId: written.sourceId,
 		});

--- a/packages/core/src/database/repositories/source-credibility.types.ts
+++ b/packages/core/src/database/repositories/source-credibility.types.ts
@@ -1,3 +1,6 @@
+import type { SensitivityLevel, SensitivityMetadata } from '../../shared/sensitivity.js';
+import type { ArtifactProvenance, ArtifactProvenanceInput } from './artifact-provenance.js';
+
 export type CredibilitySourceType =
 	| 'government'
 	| 'academic'
@@ -32,6 +35,9 @@ export interface SourceCredibilityProfile {
 	profileAuthor: CredibilityProfileAuthor;
 	lastReviewed: Date | null;
 	reviewStatus: CredibilityReviewStatus;
+	provenance: ArtifactProvenance;
+	sensitivityLevel: SensitivityLevel;
+	sensitivityMetadata: SensitivityMetadata;
 	dimensions: CredibilityDimension[];
 	createdAt: Date;
 	updatedAt: Date;
@@ -53,12 +59,16 @@ export interface UpsertSourceCredibilityProfileInput {
 	profileAuthor?: CredibilityProfileAuthor;
 	lastReviewed?: Date | string | null;
 	reviewStatus?: CredibilityReviewStatus;
+	provenance?: ArtifactProvenanceInput;
+	sensitivityLevel?: SensitivityLevel;
+	sensitivityMetadata?: unknown;
 	dimensions: readonly UpsertCredibilityDimensionInput[];
 }
 
 export interface SourceCredibilityProfileListOptions {
 	sourceType?: CredibilitySourceType;
 	reviewStatus?: CredibilityReviewStatus;
+	maxSensitivityLevel?: SensitivityLevel;
 	limit?: number;
 	offset?: number;
 }

--- a/scripts/test-lanes.mjs
+++ b/scripts/test-lanes.mjs
@@ -19,6 +19,14 @@ const HEAD_CHANGED_FILES_OVERRIDE_ENV = 'MULDER_TEST_AFFECTED_HEAD_CHANGED_FILES
 const HEAD_REF_ENV = 'MULDER_TEST_AFFECTED_HEAD_REF';
 const SPEC_DOC_TEST_OVERRIDES = new Map([
 	['77_document_observability_aggregation', ['tests/specs/77_document_observability_route.test.ts']],
+	[
+		'112_m11_trust_layer_review_repair',
+		[
+			'tests/specs/107_credibility_profile_drafts.test.ts',
+			'tests/specs/109_review_workflow_infrastructure.test.ts',
+			'tests/specs/111_rbac_implementation.test.ts',
+		],
+	],
 ]);
 
 function usage() {
@@ -708,6 +716,19 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 		return { rule: 'rbac access-role migration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
 	}
 
+	if (file === 'packages/core/src/database/migrations/042_source_credibility_trust_metadata.sql') {
+		selectExact([
+			'tests/specs/08_core_schema_migrations.test.ts',
+			'tests/specs/107_credibility_profile_drafts.test.ts',
+			'tests/specs/109_review_workflow_infrastructure.test.ts',
+			'tests/specs/111_rbac_implementation.test.ts',
+		]);
+		return {
+			rule: 'source credibility trust metadata migration',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
 	if (file.startsWith('packages/core/src/database/migrations/')) {
 		selectLanes(['schema', 'db', 'heavy']);
 		return { rule: 'unknown migration', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
@@ -716,6 +737,30 @@ function resolveAffectedRule(file, discoveredByPath, lanes) {
 	if (file.startsWith('packages/core/src/database/repositories/access-role')) {
 		selectExact(['tests/specs/111_rbac_implementation.test.ts']);
 		return { rule: 'rbac access-role repository', selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)) };
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/source-credibility.')) {
+		selectExact([
+			'tests/specs/107_credibility_profile_drafts.test.ts',
+			'tests/specs/109_review_workflow_infrastructure.test.ts',
+			'tests/specs/111_rbac_implementation.test.ts',
+		]);
+		return {
+			rule: 'source credibility repository',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
+	}
+
+	if (file.startsWith('packages/core/src/database/repositories/knowledge-assertion.')) {
+		selectExact([
+			'tests/specs/101_assertion_classification_enrich.test.ts',
+			'tests/specs/109_review_workflow_infrastructure.test.ts',
+			'tests/specs/111_rbac_implementation.test.ts',
+		]);
+		return {
+			rule: 'knowledge assertion repository',
+			selectedFiles: [...selected].sort((a, b) => a.localeCompare(b)),
+		};
 	}
 
 	if (file.startsWith('packages/core/src/database/repositories/source.')) {

--- a/tests/specs/107_credibility_profile_drafts.test.ts
+++ b/tests/specs/107_credibility_profile_drafts.test.ts
@@ -138,7 +138,21 @@ function cleanTables(): void {
 	truncateExistingTables(['credibility_dimensions', 'source_credibility_profiles', ...MULDER_TEST_TABLES]);
 }
 
-async function createTextSource(label = 'spec107') {
+function sensitivityMetadata(level: import('@mulder/core').SensitivityLevel) {
+	return {
+		level,
+		reason: 'spec107_fixture',
+		assignedBy: 'policy_rule' as const,
+		assignedAt: '2026-05-07T00:00:00.000Z',
+		piiTypes: [],
+		declassifyDate: null,
+	};
+}
+
+async function createTextSource(
+	label = 'spec107',
+	sensitivityLevel: import('@mulder/core').SensitivityLevel = 'internal',
+) {
 	const source = await coreModule.createSource(pool, {
 		filename: `${label}-${randomUUID()}.md`,
 		storagePath: `raw/${label}-${randomUUID()}.md`,
@@ -148,6 +162,8 @@ async function createTextSource(label = 'spec107') {
 		pageCount: 1,
 		hasNativeText: true,
 		nativeTextRatio: 1,
+		sensitivityLevel,
+		sensitivityMetadata: sensitivityMetadata(sensitivityLevel),
 	});
 	return source;
 }
@@ -409,6 +425,8 @@ describe('Spec 107: credibility profile drafts', () => {
 		for (const value of ['llm_auto', 'human', 'hybrid', 'draft', 'reviewed', 'contested']) {
 			expect(profileChecks).toContain(value);
 		}
+		expect(profileChecks).toContain('jsonb_typeof(provenance)');
+		expect(profileChecks).toContain('sensitivity_level');
 
 		const dimensionChecks = db.runSql(
 			[
@@ -426,11 +444,13 @@ describe('Spec 107: credibility profile drafts', () => {
 				'SELECT indexname',
 				'FROM pg_indexes',
 				"WHERE schemaname = 'public'",
-				"  AND indexname IN ('idx_source_credibility_profiles_review_status', 'idx_credibility_dimensions_dimension_id', 'idx_credibility_dimensions_low_score_review')",
+				"  AND indexname IN ('idx_source_credibility_profiles_review_status', 'idx_source_credibility_profiles_provenance_source_ids', 'idx_source_credibility_profiles_sensitivity_level', 'idx_credibility_dimensions_dimension_id', 'idx_credibility_dimensions_low_score_review')",
 				'ORDER BY indexname;',
 			].join('\n'),
 		);
 		expect(indexes).toContain('idx_source_credibility_profiles_review_status');
+		expect(indexes).toContain('idx_source_credibility_profiles_provenance_source_ids');
+		expect(indexes).toContain('idx_source_credibility_profiles_sensitivity_level');
 		expect(indexes).toContain('idx_credibility_dimensions_dimension_id');
 		expect(indexes).toContain('idx_credibility_dimensions_low_score_review');
 	});
@@ -475,11 +495,41 @@ describe('Spec 107: credibility profile drafts', () => {
 		expect(second.profileId).toBe(first.profileId);
 		expect(second.dimensions).toHaveLength(config.credibility.dimensions.length);
 		expect(second.dimensions[0].score).toBeGreaterThan(first.dimensions[0].score);
+		expect(second.provenance.sourceDocumentIds).toEqual([source.id]);
+		expect(second.sensitivityLevel).toBe('internal');
+		expect(second.sensitivityMetadata.level).toBe('internal');
 		expect(
 			Number(
 				db.runSql(`SELECT COUNT(*) FROM credibility_dimensions WHERE profile_id = ${sqlLiteral(second.profileId)};`),
 			),
 		).toBe(config.credibility.dimensions.length);
+	});
+
+	it.skipIf(!pgAvailable)('QA-03b: repository carries sensitivity/provenance and filters by access level', async () => {
+		const source = await createTextSource('spec107-qa03b', 'restricted');
+		const profile = await coreModule.upsertSourceCredibilityProfile(pool, {
+			sourceId: source.id,
+			sourceName: source.filename,
+			sourceType: 'witness',
+			profileAuthor: 'llm_auto',
+			reviewStatus: 'draft',
+			dimensions: dimensionInputs(0.5),
+		});
+		const artifact = await coreModule.findReviewableArtifactBySubject(pool, 'credibility_profile', profile.profileId);
+
+		expect(profile.provenance.sourceDocumentIds).toEqual([source.id]);
+		expect(profile.sensitivityLevel).toBe('restricted');
+		expect(profile.sensitivityMetadata.level).toBe('restricted');
+		expect(artifact?.context.source_id).toBe(source.id);
+		expect(artifact?.context.sensitivity_level).toBe('restricted');
+		expect(artifact?.context.provenance).toMatchObject({ source_document_ids: [source.id] });
+		await expect(
+			coreModule.findSourceCredibilityProfileBySourceId(pool, source.id, {
+				maxSensitivityLevel: 'internal',
+			}),
+		).resolves.toBeNull();
+		expect(await coreModule.listSourceCredibilityProfiles(pool, { maxSensitivityLevel: 'internal' })).toEqual([]);
+		expect(await coreModule.listSourceCredibilityProfiles(pool, { maxSensitivityLevel: 'restricted' })).toHaveLength(1);
 	});
 
 	it.skipIf(!pgAvailable)('QA-04: draft generation creates reviewable profiles', async () => {

--- a/tests/specs/109_review_workflow_infrastructure.test.ts
+++ b/tests/specs/109_review_workflow_infrastructure.test.ts
@@ -255,7 +255,7 @@ describe('Spec 109: review workflow infrastructure', () => {
 		expect(config.review_workflow.artifact_types.agent_finding.auto_approve_after_hours).toBeNull();
 		expect(config.review_workflow.metrics).toEqual({
 			track_accuracy: true,
-			auto_adjust_depth: true,
+			auto_adjust_depth: false,
 			accuracy_threshold_for_upgrade: 0.7,
 			accuracy_threshold_for_downgrade: 0.95,
 		});
@@ -495,6 +495,64 @@ describe('Spec 109: review workflow infrastructure', () => {
 		expect(artifact?.sourceId).toBe(source.id);
 		expect(artifact?.currentValue.source_name).toBe('Spec 109 Source');
 		expect(artifact?.context.source_id).toBe(source.id);
+		expect(artifact?.context.sensitivity_level).toBe('internal');
+		expect(artifact?.context.provenance).toMatchObject({ source_document_ids: [source.id] });
+	});
+
+	it.skipIf(!pgAvailable)('QA-07b: LLM assertion classifications register review artifacts', async () => {
+		const { source, story } = await createStory('qa07b');
+		const assertion = await coreModule.upsertKnowledgeAssertion(pool, {
+			sourceId: source.id,
+			storyId: story.id,
+			assertionType: 'hypothesis',
+			content: 'The observed pattern may indicate coordinated activity.',
+			confidenceMetadata: confidenceMetadata(),
+			classificationProvenance: 'llm_auto',
+			extractedEntityIds: [],
+			provenance: { sourceDocumentIds: [source.id] },
+			qualityMetadata: { classifier: 'fixture' },
+			sensitivityLevel: 'restricted',
+			sensitivityMetadata: {
+				level: 'restricted',
+				reason: 'fixture',
+				assignedBy: 'llm_auto',
+				assignedAt: '2026-05-06T00:00:00.000Z',
+				piiTypes: [],
+				declassifyDate: null,
+			},
+		});
+		const artifact = await coreModule.findReviewableArtifactBySubject(pool, 'assertion_classification', assertion.id);
+		const reviewed = await coreModule.upsertKnowledgeAssertion(pool, {
+			sourceId: source.id,
+			storyId: story.id,
+			assertionType: 'observation',
+			content: 'A reviewer explicitly classified this sentence.',
+			confidenceMetadata: confidenceMetadata(),
+			classificationProvenance: 'human_reviewed',
+			extractedEntityIds: [],
+			provenance: { sourceDocumentIds: [source.id] },
+			sensitivityLevel: 'internal',
+			sensitivityMetadata: {
+				level: 'internal',
+				reason: 'fixture',
+				assignedBy: 'human',
+				assignedAt: '2026-05-06T00:00:00.000Z',
+				piiTypes: [],
+				declassifyDate: null,
+			},
+		});
+
+		expect(artifact?.reviewStatus).toBe('pending');
+		expect(artifact?.sourceId).toBe(source.id);
+		expect(artifact?.currentValue.assertion_type).toBe('hypothesis');
+		expect(artifact?.currentValue.classification_provenance).toBe('llm_auto');
+		expect(artifact?.currentValue.quality_metadata).toMatchObject({ classifier: 'fixture' });
+		expect(artifact?.context.story_id).toBe(story.id);
+		expect(artifact?.context.sensitivity_level).toBe('restricted');
+		expect(artifact?.context.provenance).toMatchObject({ source_document_ids: [source.id] });
+		await expect(
+			coreModule.findReviewableArtifactBySubject(pool, 'assertion_classification', reviewed.id),
+		).resolves.toBeNull();
 	});
 
 	it.skipIf(!pgAvailable)('QA-08: conflict nodes and resolutions register review artifacts', async () => {

--- a/tests/specs/111_rbac_implementation.test.ts
+++ b/tests/specs/111_rbac_implementation.test.ts
@@ -410,6 +410,46 @@ describe('Spec 111: RBAC implementation', () => {
 				await coreModule.findStoriesByEntityId(pool, internalFixture.entity.id, { maxSensitivityLevel: 'internal' })
 			).map((story) => story.id),
 		).not.toContain(restrictedStoryForInternalEntity.id);
+		const internalProfile = await coreModule.upsertSourceCredibilityProfile(pool, {
+			sourceId: internalFixture.source.id,
+			sourceName: 'Internal credibility source',
+			sourceType: 'other',
+			profileAuthor: 'llm_auto',
+			reviewStatus: 'draft',
+			dimensions: [
+				{
+					dimensionId: 'transparency',
+					label: 'Transparency',
+					score: 0.72,
+					rationale: 'Fixture internal profile',
+				},
+			],
+		});
+		const restrictedProfile = await coreModule.upsertSourceCredibilityProfile(pool, {
+			sourceId: restrictedFixture.source.id,
+			sourceName: 'Restricted credibility source',
+			sourceType: 'other',
+			profileAuthor: 'llm_auto',
+			reviewStatus: 'draft',
+			dimensions: [
+				{
+					dimensionId: 'transparency',
+					label: 'Transparency',
+					score: 0.64,
+					rationale: 'Fixture restricted profile',
+				},
+			],
+		});
+		expect(
+			(await coreModule.listSourceCredibilityProfiles(pool, { maxSensitivityLevel: 'internal' })).map(
+				(profile) => profile.profileId,
+			),
+		).toEqual([internalProfile.profileId]);
+		expect(
+			(await coreModule.listSourceCredibilityProfiles(pool, { maxSensitivityLevel: 'confidential' })).map(
+				(profile) => profile.profileId,
+			),
+		).toEqual(expect.arrayContaining([internalProfile.profileId, restrictedProfile.profileId]));
 		expect(await coreModule.findAllSources(pool, { maxSensitivityLevel: 'confidential' })).toHaveLength(4);
 	});
 

--- a/tests/specs/59_hermetic_test_infrastructure.test.ts
+++ b/tests/specs/59_hermetic_test_infrastructure.test.ts
@@ -325,6 +325,28 @@ describe('Spec 59 — Hermetic Test Infrastructure', () => {
 		expect(plan.lanes.heavy.count).toBe(0);
 	});
 
+	it('QA-05e5b: M11 review-repair surfaces stay scoped to trust-layer specs', () => {
+		const plan = affectedPlanForFiles([
+			'packages/core/src/database/migrations/042_source_credibility_trust_metadata.sql',
+			'packages/core/src/database/repositories/source-credibility.repository.ts',
+			'packages/core/src/database/repositories/knowledge-assertion.repository.ts',
+			'docs/specs/112_m11_trust_layer_review_repair.spec.md',
+		]);
+		const files = plan.files.map((file) => file.relativePath);
+
+		expect(files).toEqual(
+			expect.arrayContaining([
+				'tests/specs/08_core_schema_migrations.test.ts',
+				'tests/specs/101_assertion_classification_enrich.test.ts',
+				'tests/specs/107_credibility_profile_drafts.test.ts',
+				'tests/specs/109_review_workflow_infrastructure.test.ts',
+				'tests/specs/111_rbac_implementation.test.ts',
+			]),
+		);
+		expect(plan.totalFiles).toBe(5);
+		expect(plan.lanes.heavy.count).toBe(0);
+	});
+
 	it('QA-05e6: docs-only PR head commits do not select DB or schema lanes', () => {
 		const plan = affectedHeadPlanForFiles(['docs/specs/111_rbac_implementation.spec.md', 'docs/roadmap.md']);
 


### PR DESCRIPTION
## Summary
- closes #295 by making credibility profiles provenance/sensitivity-bearing trust artifacts with RBAC-aware filters
- reserves review_workflow.metrics.auto_adjust_depth by defaulting it to false until a policy worker exists
- registers LLM-auto assertion classifications as reviewable artifacts
- scopes affected test mapping for the new M11 repair migration/repositories so it does not fan out to the whole DB suite

## Follow-ups
- external query gate/access audit: #296
- agent and human-reported conflict detection surfaces: #297

## Verification
- pnpm --filter @mulder/core build
- pnpm --filter @mulder/pipeline build
- pnpm test:scope run step M11-L1 -- --reporter=verbose
- pnpm test:scope run step M11-L3 -- --reporter=verbose
- pnpm test:scope run step M11-L5 -- --reporter=verbose
- pnpm test:scope run milestone M11 -- --reporter=verbose
- pnpm vitest run tests/specs/59_hermetic_test_infrastructure.test.ts --reporter=verbose
- pnpm test:affected:plan origin/milestone/11
- MULDER_TEST_ISOLATED_DB=true pnpm test:affected origin/milestone/11 -- --reporter=verbose